### PR TITLE
Configuration support for test and dev environments DT-242

### DIFF
--- a/app/config.default.coffee
+++ b/app/config.default.coffee
@@ -1,15 +1,16 @@
+SERVER_ROOT = process.env.SERVER_ROOT
 module.exports =
   URL:
-    OTP: 'http://digitransit.fi/otp/routers/finland/'
-    GEOCODER: 'http://digitransit.fi/geocoder/'
-    MAP: 'http://digitransit.fi/hsl-map/'
-    MQTT: 'ws://213.138.147.225:1883'
-    ALERTS: 'http://matka.hsl.fi/hsl-alert/'
-    FONT: 'http://fonts.googleapis.com/css?family=Lato:300,400,900%7CPT+Sans+Narrow:400,700'
-    REALTIME: 'http://digitransit.fi/navigator-server'
-    PELIAS: 'http://digitransit.fi/pelias/v1/autocomplete'
+    OTP: "#{SERVER_ROOT}/otp/routers/finland/"
+    GEOCODER: "#{SERVER_ROOT}/geocoder/"
+    MAP: "#{SERVER_ROOT}/hsl-map/"
+    MQTT: "ws://213.138.147.225:1883"
+    ALERTS: "#{SERVER_ROOT}/hsl-alert/"
+    FONT: "http://fonts.googleapis.com/css?family=Lato:300,400,900%7CPT+Sans+Narrow:400,700"
+    REALTIME: "#{SERVER_ROOT}/navigator-server"
+    PELIAS: "#{SERVER_ROOT}/pelias/v1/autocomplete"
+  title: "Digitransit"
   cities: []
-  title: 'Digitransit'
   searchParams: {}
   nearbyRoutes:
     radius: 10000

--- a/app/config.hsl.coffee
+++ b/app/config.hsl.coffee
@@ -1,17 +1,18 @@
+SERVER_ROOT = process.env.SERVER_ROOT
 module.exports =
   URL:
-    OTP: 'http://matka.hsl.fi/otp/routers/finland/'
-    GEOCODER: 'http://matka.hsl.fi/geocoder/'
-    MAP: 'http://matka.hsl.fi/hsl-map/'
-    MQTT: 'ws://213.138.147.225:1883'
-    ALERTS: 'http://matka.hsl.fi/hsl-alert/'
-    FONT: 'http://fonts.googleapis.com/css?family=Nunito:300,400,700%7COpen+Sans+Condensed:300,700'
-    REALTIME: 'http://matka.hsl.fi/navigator-server'
-    PELIAS: 'http://matka.hsl.fi/pelias/v1/search'
-  title: 'Digitransit (HSL)'
-  icon: 'hsl-icon.png'
-  preferredAgency: 'HSL'
+    OTP: "#{SERVER_ROOT}/otp/routers/finland/"
+    GEOCODER: "#{SERVER_ROOT}/geocoder/"
+    MAP: "#{SERVER_ROOT}/hsl-map/"
+    MQTT: "ws://213.138.147.225:1883"
+    ALERTS: "#{SERVER_ROOT}/hsl-alert/"
+    FONT: "http://fonts.googleapis.com/css?family=Nunito:300,400,700%7COpen+Sans+Condensed:300,700"
+    REALTIME: "#{SERVER_ROOT}/navigator-server"
+    PELIAS: "#{SERVER_ROOT}/pelias/v1/search"
+  title: "Digitransit (HSL)"
   cities: ["helsinki", "vantaa", "espoo", "kauniainen", "kerava", "kirkkonummi", "sipoo"]
+  icon: "hsl-icon.png"
+  preferredAgency: "HSL"
   searchParams:
     "boundary.rect.min_lat": 59.9
     "boundary.rect.max_lat": 60.45

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -38,6 +38,12 @@
 ## Browse to application
 - http://localhost:8080/
 
+## Changing url for OpenTripPlanner and Geocoding
+In package.json there is a configuration variable "SERVER_ROOT". It controls where user interface connects in order to do e.g. routing.
+By default it uses http://matka.hsl.fi but you can override SERVER_ROOT like so:
+
+- npm run dev --digitransit-ui:SERVER_ROOT=http://dev.digitransit.fi
+
 ## Build release version and start production server
-- npm run build
+- npm run build --digitransit-ui:SERVER_ROOT={This depends on environment}
 - npm run start

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -10,7 +10,7 @@
   (you will get warnings, ignore those for now)
 
 ## :warning: What if 'npm install' fails?
-- Ensure you have npm3 installed: 'sudo npm install -f npm@3'
+- Ensure you have npm3 installed: 'sudo npm install -g npm@3'
 - Clear npm cache: 'npm cache clean'
 - remove node_modules: 'rm -rf node_modules'
 - Try again: 'npm install'

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -42,8 +42,7 @@
 In package.json there is a configuration variable "SERVER_ROOT". It controls where user interface connects in order to do e.g. routing.
 By default it uses http://matka.hsl.fi but you can override SERVER_ROOT like so:
 
-- npm run dev --digitransit-ui:SERVER_ROOT=http://dev.digitransit.fi
-
+- SERVER_ROOT=http://dev.digitransit.fi npm run dev
 ## Build release version and start production server
-- npm run build --digitransit-ui:SERVER_ROOT={This depends on environment}
+- SERVER_ROOT=YOUR_API_SERVER npm run build
 - npm run start

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "dev": "NODE_ENV=development nodemon -e js,jsx,cjsx,css,scss,html,coffee --watch ./app/ server/server.js & NODE_ENV=development node server/hotLoadServer.js",
     "dev-win-hsl": "cd win-launch-scripts&& hsl-win-launch-script.bat",
     "dev-win-national": "cd win-launch-scripts&& set CONFIG=&& national-win-launch-script.bat",
-    "dev-nowatch": "NODE_ENV=development node server/server.js & NODE_ENV=development node server/hotLoadServer.js",
     "test": "./run-ui-tests.sh local",
     "build": "NODE_ENV=production webpack -p --progress --colors",
     "start": "NODE_ENV=production nodemon server/server"
+  },
+  "config": {
+    "SERVER_ROOT": "http://matka.hsl.fi"
   },
   "main": "server.js",
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ function getPluginsConfig(env) {
       new webpack.ContextReplacementPlugin(/moment(\/|\\)locale$/, /fi|sv|en\-gb/),
       new webpack.DefinePlugin({
         'process.env': {
+          SERVER_ROOT: JSON.stringify(process.env.npm_package_config_SERVER_ROOT),
           NODE_ENV: JSON.stringify("development"),
           ROOT_PATH: JSON.stringify(process.env.ROOT_PATH ? process.env.ROOT_PATH : '/'),
           CONFIG: JSON.stringify(process.env.CONFIG ? process.env.CONFIG : 'default')
@@ -59,6 +60,7 @@ function getPluginsConfig(env) {
       new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /fi|sv|en\-gb/),
       new webpack.DefinePlugin({
         'process.env': {
+          SERVER_ROOT: JSON.stringify(process.env.npm_package_config_SERVER_ROOT),
           NODE_ENV: JSON.stringify("production"),
           ROOT_PATH: JSON.stringify(process.env.ROOT_PATH ? process.env.ROOT_PATH : '/'),
           CONFIG: JSON.stringify(process.env.CONFIG ? process.env.CONFIG : 'default')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,7 @@ function getPluginsConfig(env) {
       new webpack.ContextReplacementPlugin(/moment(\/|\\)locale$/, /fi|sv|en\-gb/),
       new webpack.DefinePlugin({
         'process.env': {
-          SERVER_ROOT: JSON.stringify(process.env.npm_package_config_SERVER_ROOT),
+          SERVER_ROOT: JSON.stringify(process.env.SERVER_ROOT),
           NODE_ENV: JSON.stringify("development"),
           ROOT_PATH: JSON.stringify(process.env.ROOT_PATH ? process.env.ROOT_PATH : '/'),
           CONFIG: JSON.stringify(process.env.CONFIG ? process.env.CONFIG : 'default')
@@ -60,7 +60,7 @@ function getPluginsConfig(env) {
       new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /fi|sv|en\-gb/),
       new webpack.DefinePlugin({
         'process.env': {
-          SERVER_ROOT: JSON.stringify(process.env.npm_package_config_SERVER_ROOT),
+          SERVER_ROOT: JSON.stringify(process.env.SERVER_ROOT),
           NODE_ENV: JSON.stringify("production"),
           ROOT_PATH: JSON.stringify(process.env.ROOT_PATH ? process.env.ROOT_PATH : '/'),
           CONFIG: JSON.stringify(process.env.CONFIG ? process.env.CONFIG : 'default')


### PR DESCRIPTION
Relates closely to: https://github.com/HSLdevcom/digitransit-deploy/pull/48

1) Read Installation.md 
2) Try to e.g. "npm run dev --digitransit-ui:SERVER_ROOT=http://testing.digitransit.fi"
3) Check with chrome developer tools that requests go to "testing"

We still need to improve deployment script so that correct backends are used