### PR TITLE
Use color variable name that is visible also in non hsl version

### DIFF
--- a/app/component/util/not-implemented.scss
+++ b/app/component/util/not-implemented.scss
@@ -1,14 +1,14 @@
 .not-implemented-icon {
   width: 5em;
   height: 5em;
-  fill: $primary-color;
+  fill: $action-color;
 }
 
 .not-implemented-color {
- color: $primary-color;
+ color: $action-color;
 }
 
 .not-implemented a {
   text-decoration: none;
-  color: $primary-color;
+  color: $action-color;
 }


### PR DESCRIPTION
Makes the "not implemented" popup display title,icon, links also in non hsl version