### PR TITLE
Allow accessing dev-mode-app with ip other than localhost

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -176,6 +176,10 @@ function setUpRoutes() {
             );
           };
 
+
+          var host = req.headers["host"]||"localhost";
+          var hostname = host.split(":")[0];
+
           var html = ReactDOM.renderToStaticMarkup(
             React.createElement(
               applicationHtml,
@@ -185,7 +189,7 @@ function setUpRoutes() {
                 content: content,
                 polyfill: polyfills,
                 state: 'window.state=' + serialize(application.dehydrate(context)) + ';',
-                livereload: process.env.NODE_ENV === "development" ? '//localhost:9000/' : config.ROOT_PATH + "/",
+                livereload: process.env.NODE_ENV === "development" ? "//" + hostname + ":9000/" : config.ROOT_PATH + "/",
                 locale: 'window.locale="' + locale + '"',
                 fonts: fonts
               }


### PR DESCRIPTION
Live reload still does not work but atleast you can access (and manually refresh) the app from ip other than 127.0.0.1