### PR TITLE
DT-556 Disruption info icons are not displayed correctly in popup

### DIFF
--- a/app/component/departure/departure.scss
+++ b/app/component/departure/departure.scss
@@ -63,3 +63,7 @@
   height: 0.5em;
   width: 0.5em;
 }
+
+.leaflet-map-pane .departure svg {
+    z-index: 0;
+}


### PR DESCRIPTION
Overwrite leaflet svg z-index for vehicle icon. Otherwise disruption icon drops below vehicle icon.

[DT-556](https://digitransit.atlassian.net/browse/DT-556)