### PR TITLE
feat: only include modal when it should be open

### DIFF
--- a/app/component/disruption/disruption-info.cjsx
+++ b/app/component/disruption/disruption-info.cjsx
@@ -14,7 +14,7 @@ class DisruptionInfo extends React.Component
     toggleDisruptionInfo: React.PropTypes.func
 
   render: ->
-    if typeof window != 'undefined'
+    if typeof window != 'undefined' and @props.open
       <Modal open={@props.open} title={<FormattedMessage id="disruption-info" defaultMessage="Disruption Info"/>} toggleVisibility={@props.toggleDisruptionInfo}>
         <Relay.RootContainer
           Component={DisruptionListContainer}


### PR DESCRIPTION
Reduces the number of queries done while initially loading the front
page from two to one. When opening the modal, another query is done to
fetch full alert information as required by the modal contents.

See [DT-450](https://digitransit.atlassian.net/browse/DT-450).