### PR TITLE
DT-645: Add pointer-events: none for stops

### DIFF
--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -235,7 +235,6 @@ div.stop-name-marker {
   stroke-opacity: $stop-thin-opacity;
   fill: #fff;
   fill-opacity: 1;
-  pointer-events: none;
 }
 
 .map .stop {
@@ -243,7 +242,21 @@ div.stop-name-marker {
   stroke-opacity: 1;
   fill: #fff;
   fill-opacity: 1;
-  pointer-events: none;
+}
+
+/* BEWARE! This is an ugly hack.
+ * It so happens that firefox will not allow SVG clicks to bubble to DOM if pointer-events: none is not set.
+ * If we set pointer-events: none for all browsers, then we lose "pointer cursor" for all browsers.
+ * This css selector targets only firefox: https://css-tricks.com/snippets/css/css-hacks-targeting-firefox/
+ */
+@-moz-document url-prefix() {
+  .map .stop {
+    pointer-events: none;
+  }
+
+  .map .stop-halo {
+    pointer-events: none;
+  }
 }
 
 .map .thin .stop, .map .thin .stop-small {

--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -235,6 +235,7 @@ div.stop-name-marker {
   stroke-opacity: $stop-thin-opacity;
   fill: #fff;
   fill-opacity: 1;
+  pointer-events: none;
 }
 
 .map .stop {
@@ -242,6 +243,7 @@ div.stop-name-marker {
   stroke-opacity: 1;
   fill: #fff;
   fill-opacity: 1;
+  pointer-events: none;
 }
 
 .map .thin .stop, .map .thin .stop-small {


### PR DESCRIPTION
This currently disables the “cursor: pointer” rule for some reason, but
is the only way to get clicks bubbling trough on Firefox.