### PR TITLE
Dt 490 show disruption info in routing results

### DIFF
--- a/app/component/departure/departure-list-container.cjsx
+++ b/app/component/departure/departure-list-container.cjsx
@@ -34,7 +34,7 @@ class DepartureListContainer extends React.Component
       pattern.stoptimes.map (stoptime) ->
         stop: stoptime.stop
         canceled: stoptime.realtimeState == 'CANCELED' or (window.mock && stoptime.realtimeDeparture % 40 == 0)
-        stoptime: stoptime.serviceDay + stoptime.realtimeDeparture
+        stoptime: stoptime.serviceDay + (if stoptime.realtimeState == 'CANCELED' then stoptime.scheduledDeparture else stoptime.realtimeDeparture)
         realtime: stoptime.realtime
         pattern: pattern.pattern
         trip: stoptime.trip

--- a/app/component/departure/departure-list-container.cjsx
+++ b/app/component/departure/departure-list-container.cjsx
@@ -33,6 +33,7 @@ class DepartureListContainer extends React.Component
     stoptimes.map (pattern) ->
       pattern.stoptimes.map (stoptime) ->
         stop: stoptime.stop
+        canceled: stoptime.realtimeState == 'CANCELED' or (window.mock && stoptime.realtimeDeparture % 40 == 0)
         stoptime: stoptime.serviceDay + stoptime.realtimeDeparture
         realtime: stoptime.realtime
         pattern: pattern.pattern
@@ -67,16 +68,17 @@ class DepartureListContainer extends React.Component
 
       classes =
         disruption: (filter departure.pattern.alerts, validAt).length > 0
+        canceled: departure.canceled
 
       if rowClasses
         classes[rowClasses] = true
 
       if @props.routeLinks
         departureObjs.push <Link to="/linjat/#{departure.pattern.code}" key={id}>
-          <Departure departure={departure} showStop={@props.showStops} currentTime={currentTime} className={cx classes}/>
+          <Departure departure={departure} showStop={@props.showStops} currentTime={currentTime} className={cx classes} canceled={departure.canceled} />
         </Link>
       else
-        departureObjs.push <Departure key={id} departure={departure} showStop={@props.showStops} currentTime={currentTime} className={cx classes} />
+        departureObjs.push <Departure key={id} departure={departure} showStop={@props.showStops} currentTime={currentTime} className={cx classes} canceled={departure.canceled} />
 
     departureObjs
 

--- a/app/component/departure/departure-time.cjsx
+++ b/app/component/departure/departure-time.cjsx
@@ -1,11 +1,14 @@
 React       = require 'react'
 timeUtils   = require '../../util/time-utils'
 cx          = require 'classnames'
+Icon        = require '../icon/icon'
 ComponentUsageExample = require '../documentation/component-usage-example'
 Example = require '../documentation/example-data'
 
 DepartureTime = (props) ->
+  canceled = <Icon img={'icon-icon_caution'} className={'icon cancelation-info'} /> if props.canceled
   <span style={props.style} className={cx "time", "realtime": props.realtime}>
+    {canceled}
     {timeUtils.renderDepartureStoptime props.departureTime, props.realtime, props.currentTime}
   </span>
 

--- a/app/component/departure/departure.cjsx
+++ b/app/component/departure/departure.cjsx
@@ -20,7 +20,8 @@ Departure = (props) ->
     <DepartureTime
       departureTime={props.departure.stoptime}
       realtime={props.departure.realtime}
-      currentTime={props.currentTime} />
+      currentTime={props.currentTime}
+      canceled={props.canceled} />
     <RouteNumber
       mode={mode}
       realtime={props.departure.realtime}

--- a/app/component/departure/departure.scss
+++ b/app/component/departure/departure.scss
@@ -33,8 +33,9 @@
 
 .time {
   font-weight: $font-weight-bold;
-  width: 3em;
-  margin-right: 1em;
+  width: 4.2em;
+  margin-right: 0.5em;
+  padding-right: 0.5em;
   text-align: right;
 }
 .vehicle-number {
@@ -66,4 +67,38 @@
 
 .leaflet-map-pane .departure svg {
     z-index: 0;
+}
+
+.cancelation-info {
+    width: 12px;
+    height: 12px;
+    stroke: $white;
+    color: $cancelation-red;
+    margin: 0 0.5em;
+}
+
+.canceled {
+    .time {
+        position: relative;
+        display: inline-block;
+        color: $cancelation-black;
+        background-color: $cancelation-background;
+        border-radius: $border-radius;
+        &::before,
+        &::after {
+            content: '';
+            width: 2em;
+            position: absolute;
+            left: 1.75em;
+            top: 50%;
+            opacity: 0.5;
+            border-bottom: 1px solid $cancelation-red;
+        }
+        &::before {
+            transform: skewY(-30deg);
+        }
+        &::after {
+            transform: skewY(30deg);
+        }
+    }
 }

--- a/app/queries.js
+++ b/app/queries.js
@@ -452,6 +452,7 @@ var DepartureListFragments = {
         headsign
       }
       stoptimes {
+        realtimeState
         realtimeDeparture
         realtime
         serviceDay

--- a/app/queries.js
+++ b/app/queries.js
@@ -454,6 +454,7 @@ var DepartureListFragments = {
       stoptimes {
         realtimeState
         realtimeDeparture
+        scheduledDeparture
         realtime
         serviceDay
         stop {

--- a/build/schema.json
+++ b/build/schema.json
@@ -2421,6 +2421,18 @@
                         "deprecationReason": null
                     },
                     {
+                        "name": "realtimeState",
+                        "description": null,
+                        "args": [],
+                        "type": {
+                            "kind": "ENUM",
+                            "name": "RealtimeState",
+                            "ofType": null
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
                         "name": "serviceDay",
                         "description": null,
                         "args": [],
@@ -2489,6 +2501,47 @@
                     {
                         "name": "COORDINATE_WITH_DRIVER",
                         "description": "Must coordinate with driver to arrange pickup / drop off.",
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "possibleTypes": null
+            },
+            {
+                "kind": "ENUM",
+                "name": "RealtimeState",
+                "description": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "enumValues": [
+                    {
+                        "name": "SCHEDULED",
+                        "description": "The trip information comes from the GTFS feed, i.e. no real-time update has been applied.",
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "UPDATED",
+                        "description": "The trip information has been updated, but the trip pattern stayed the same as the trip pattern of the scheduled trip.",
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "CANCELED",
+                        "description": "The trip has been canceled by a real-time update.",
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "ADDED",
+                        "description": "The trip has been added using a real-time update, i.e. the trip was not present in the GTFS feed.",
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "MODIFIED",
+                        "description": "The trip information has been updated and resulted in a different trip pattern compared to the trip pattern of the scheduled trip.",
                         "isDeprecated": false,
                         "deprecationReason": null
                     }

--- a/sass/themes/default/_theme.scss
+++ b/sass/themes/default/_theme.scss
@@ -38,6 +38,7 @@ $hilight-color: $livi-logo-blue;
 $action-color: $livi-logo-blue;
 $disruption-color: $hsl-disruption;
 $disruption-passive-color: $livi-logo-blue;
+$cancelation-color: #ecc;
 
 /* Markers */
 $viewpoint-marker-color: $title-color;

--- a/sass/themes/default/_theme.scss
+++ b/sass/themes/default/_theme.scss
@@ -38,7 +38,9 @@ $hilight-color: $livi-logo-blue;
 $action-color: $livi-logo-blue;
 $disruption-color: $hsl-disruption;
 $disruption-passive-color: $livi-logo-blue;
-$cancelation-color: #ecc;
+$cancelation-red: #dc0451;
+$cancelation-black: #666;
+$cancelation-background: #fbe0ea;
 
 /* Markers */
 $viewpoint-marker-color: $title-color;

--- a/sass/themes/hsl/_theme.scss
+++ b/sass/themes/hsl/_theme.scss
@@ -31,6 +31,7 @@ $hilight-color: $hsl-pink;
 $action-color: $hsl-blue;
 $disruption-color: $hsl-disruption;
 $disruption-passive-color: rgb(77, 162, 217);
+$cancelation-color: #ecc;
 
 /* Markers */
 $viewpoint-marker-color: $hsl-blue;

--- a/sass/themes/hsl/_theme.scss
+++ b/sass/themes/hsl/_theme.scss
@@ -31,7 +31,9 @@ $hilight-color: $hsl-pink;
 $action-color: $hsl-blue;
 $disruption-color: $hsl-disruption;
 $disruption-passive-color: rgb(77, 162, 217);
-$cancelation-color: #ecc;
+$cancelation-red: #dc0451;
+$cancelation-black: #666;
+$cancelation-background: #fbe0ea;
 
 /* Markers */
 $viewpoint-marker-color: $hsl-blue;


### PR DESCRIPTION
[DT-490](https://digitransit.atlassian.net/browse/DT-490)

- Styles may be improved still a bit, however they also need to be changed quite much when the new two tabs design is implemented.
- There is a mode for mocking in the demo.
- Deployment of new GraphQL cancelation info is required for this branch to work.