### PR TITLE
feat: improve sorting by passing row objects

### DIFF
--- a/app/component/departure/next-departures-list.cjsx
+++ b/app/component/departure/next-departures-list.cjsx
@@ -24,42 +24,41 @@ NextDeparturesList = (props) ->
         (distance - distance % 100) / 1000
     departure.roundedDistance = roundedDistance
 
-    firstTime = departure.stoptimes[0]?.stoptimes[0]
-    departure.stoptime = firstTime?.serviceDay +
+    firstTime = departure.stoptime?.stoptimes[0]
+    departure.sorttime = firstTime?.serviceDay +
       if firstTime?.realtime
         firstTime.realtimeDeparture
       else
         firstTime?.scheduledDeparture
 
-  sortedDepartures = sortBy props.departures, ['roundedDistance', 'stoptime']
+  sortedDepartures = sortBy props.departures, ['roundedDistance', 'sorttime']
 
   for departure in sortedDepartures
-    for stoptime in departure.stoptimes
-      departureTimes = []
-      for departureTime in stoptime.stoptimes
-        canceled =  departureTime.realtimeState == 'CANCELED' or (window.mock && departureTime.realtimeDeparture % 40 == 0)
-        key = stoptime.pattern.route.gtfsId + ":" + stoptime.pattern.headsign + ":" + departureTime.realtimeDeparture
-        departureTimes.push <DepartureTime
-          key={key}
-          departureTime={departureTime.serviceDay + departureTime.realtimeDeparture}
-          realtime={departureTime.realtime}
-          currentTime={props.currentTime}
-          canceled={canceled} />
+    stoptime = departure.stoptime
+    departureTimes = []
+    for departureTime in stoptime.stoptimes
+      canceled =  departureTime.realtimeState == 'CANCELED' or (window.mock && departureTime.realtimeDeparture % 40 == 0)
+      key = stoptime.pattern.route.gtfsId + ":" + stoptime.pattern.headsign + ":" + departureTime.realtimeDeparture
+      departureTimes.push <DepartureTime
+        key={key}
+        departureTime={departureTime.serviceDay + departureTime.realtimeDeparture}
+        realtime={departureTime.realtime}
+        currentTime={props.currentTime}
+        canceled={canceled} />
 
-      departureObjs.push <Link to="/linjat/#{stoptime.pattern.code}" key={stoptime.pattern.code}>
-        <div className="next-departure-row padding-vertical-normal border-bottom">
-          <Distance distance={departure.distance}/>
-          <RouteNumber
-            mode={stoptime.pattern.route.type}
-            realtime={false}
-            text={stoptime.pattern.route.shortName} />
-          <RouteDestination
-            mode={stoptime.pattern.route.type}
-            destination={stoptime.pattern.headsign or stoptime.pattern.route.longName} />
-          {departureTimes}
-        </div>
-      </Link>
-
+    departureObjs.push <Link to="/linjat/#{stoptime.pattern.code}" key={stoptime.pattern.code}>
+      <div className="next-departure-row padding-vertical-normal border-bottom">
+        <Distance distance={departure.distance}/>
+        <RouteNumber
+          mode={stoptime.pattern.route.type}
+          realtime={false}
+          text={stoptime.pattern.route.shortName} />
+        <RouteDestination
+          mode={stoptime.pattern.route.type}
+          destination={stoptime.pattern.headsign or stoptime.pattern.route.longName} />
+        {departureTimes}
+      </div>
+    </Link>
   <div>
     {departureObjs}
   </div>

--- a/app/component/favourites/favourite-route-list-container.cjsx
+++ b/app/component/favourites/favourite-route-list-container.cjsx
@@ -41,9 +41,10 @@ class FavouriteRouteListContainer extends React.Component
             keepStoptimes.push stoptime
             seenDepartures[seenKey] = true
 
-        nextDepartures.push
-          distance: closest.distance
-          stoptimes: keepStoptimes
+        for stoptime in keepStoptimes
+          nextDepartures.push
+            distance: closest.distance
+            stoptime: stoptime
 
     nextDepartures
 

--- a/app/component/route/nearby-route-list-container.cjsx
+++ b/app/component/route/nearby-route-list-container.cjsx
@@ -61,9 +61,11 @@ class NearbyRouteListContainer extends React.Component
         if !isSeen and isModeIncluded and isPickup and isCloseInTime
           keepStoptimes.push stoptime
           seenDepartures[seenKey] = true
-      nextDepartures.push
-        distance: stopAtDistance.distance
-        stoptimes: keepStoptimes
+
+      for stoptime in keepStoptimes
+        nextDepartures.push
+          distance: stopAtDistance.distance
+          stoptime: stoptime
 
     nextDepartures
 


### PR DESCRIPTION
Improve sorting of departures in nearby and favourites tabs. Sometimes the sort was off in the times.

Previously the object passed to NextDeparturesList was not the row object so sorting was tricky. Now container components, favourite and nearby containers, pass full row objects.