### PR TITLE
Display destination name together with alight text. Hide alight text if airplane

### DIFF
--- a/app/component/itinerary/transit-leg.cjsx
+++ b/app/component/itinerary/transit-leg.cjsx
@@ -80,11 +80,15 @@ class TransitLeg extends React.Component
               =1 {one minute}
               other {# minutes}})' />
         </div>
-        <div><FormattedMessage
-          id='alight'
-          defaultMessage='Alight at stop'/>
-        </div>
-        <div>{@props.leg.to.name}</div>
+        <div>
+          {if @props.leg.mode != 'AIRPLANE'
+            <FormattedMessage
+              id='alight'
+              values={{
+                toName: <b>{@props.leg.to.name}</b>
+                }}
+              defaultMessage='Alight at stop {toName}'/>}
+         </div>
       </div>
     </div>
 

--- a/app/translations.coffee
+++ b/app/translations.coffee
@@ -42,7 +42,7 @@ translations =
                             } ({minutes, plural,
                                =1 {yksi minuutti}
                                other {# minuutia}})'
-    'alight': 'Nouse kyydistä pysäkillä'
+    'alight': 'Nouse kyydistä pysäkillä ({toName})'
     'start-journey-place': 'Aloita matka paikasta'
     'walk-to-destination': 'Kävele määränpäähän'
     'walk-to-stop': 'Kävele pysäkille'
@@ -162,7 +162,7 @@ translations =
                             } ({minutes, plural,
                                =1 {en minut}
                                other {# minuter}})'
-    'alight': 'Stig av vid hållplatsen'
+    'alight': 'Stig av vid hållplatsen {toName}'
     'start-journey-place': 'Utgå från'
     'walk-to-destination': 'Gå till destination'
     'walk-to-stop': 'Gå till hållplatsen'


### PR DESCRIPTION
* Show the destination name together with the alight text, not on the next line.
* If transit mode is AIRPLANE, do not show the alight text