### PR TITLE
Use auto width on time selectors

### DIFF
--- a/app/component/departure/departure.scss
+++ b/app/component/departure/departure.scss
@@ -42,7 +42,7 @@
 
 .time {
   @include font-narrow-medium;
-  width: 4em;
+  width: auto;
   margin-right: 0.5em;
   padding-right: 0.5em;
   text-align: right;

--- a/app/component/navigation/index-navigation.scss
+++ b/app/component/navigation/index-navigation.scss
@@ -287,7 +287,7 @@ ul.offcanvas-list {
     margin-right: 5px;
 
     &.time {
-      width: 1.9em;
+      width: auto;
 
       &.hour {
         border-top-left-radius: $border-radius;


### PR DESCRIPTION
Only one of the digits was displayed in time selectors on two digit hours and minutes.