### PR TITLE
DT-836 Measure frame jank in map and nearby routes

### DIFF
--- a/app/component/front-page/front-page-panel.cjsx
+++ b/app/component/front-page/front-page-panel.cjsx
@@ -15,6 +15,7 @@ Feedback              = require '../../util/feedback'
 FeedbackActions       = require '../../action/feedback-action'
 intl = require 'react-intl'
 FormattedMessage = intl.FormattedMessage
+{startMeasuring, stopMeasuring} = require '../../util/jankmeter'
 
 class FrontPagePanel extends React.Component
   @contextTypes:
@@ -74,6 +75,21 @@ class FrontPagePanel extends React.Component
       @setState
         selectedPanel: newSelection
 
+  startMeasuring: ->
+    startMeasuring()
+
+  stopMeasuring: =>
+    results = stopMeasuring()
+    if !results
+      return
+    # Piwik doesn't show event values, if they are too long, so we must round... >_<
+    @context.piwik?.trackEvent('perf', 'nearby-panel-drag', 'min',
+                               Math.round(results.min))
+    @context.piwik?.trackEvent('perf', 'nearby-panel-drag', 'max',
+                               Math.round(results.max))
+    @context.piwik?.trackEvent('perf', 'nearby-panel-drag', 'avg',
+                               Math.round(results.avg))
+
   render: ->
     PositionStore = @context.getStore 'PositionStore'
     location = PositionStore.getLocationState()
@@ -103,7 +119,12 @@ class FrontPagePanel extends React.Component
                     </div>
                   </div>
                   <NextDeparturesListHeader />
-                  <div className="scrollable momentum-scroll scroll-extra-padding-bottom" id="scrollable-routes">
+                  <div
+                    className="scrollable momentum-scroll scroll-extra-padding-bottom"
+                    id="scrollable-routes"
+                    onTouchStart={@startMeasuring}
+                    onTouchEnd={@stopMeasuring}
+                    >
                     {routesPanel}
                   </div>
                 </div>

--- a/app/util/jankmeter.js
+++ b/app/util/jankmeter.js
@@ -1,0 +1,43 @@
+var counter = 0;
+var min, max, total, lastTime;
+var rafID = null;
+
+function measure() {
+    if(rafID) {
+        var newTime = performance.now();
+        var duration = newTime - lastTime;
+        total += duration;
+        lastTime = newTime;
+
+        counter += 1;
+        if(duration < min){
+            min = duration;
+        }
+        if(duration > max){
+            max = duration;
+        }
+        rafID = requestAnimationFrame(measure);
+    }
+}
+
+export function startMeasuring() {
+    if(!performance.now) {
+      return;
+    }
+    if(!rafID) {
+        min = 10000000;
+        max = 0;
+        total = 0;
+        counter = 0;
+        lastTime = performance.now();
+        rafID = requestAnimationFrame(measure);
+    }
+}
+
+export function stopMeasuring() {
+    if(rafID && counter != 0) {
+        cancelAnimationFrame(rafID);
+        rafID = null;
+        return {min: min, max: max, avg: total/counter};
+    }
+}


### PR DESCRIPTION
DT-836

Windows phone support is pretty bad with map tracking; the events just don't seem to fire reliably and even then the requestAnimationFrame seems to fire only once. Debugging this should wait for Win10 dev laptop.