### PR TITLE
Show spinner if itinerary rows empty

### DIFF
--- a/app/page/summary.cjsx
+++ b/app/page/summary.cjsx
@@ -136,7 +136,11 @@ class SummaryPage extends React.Component
         {toItinerary}
         {summary}
       </Map>
-      <div>{rows}</div>
+      { if rows.length == 0
+          <div className="spinner-loader"/>
+        else
+          <div>{rows}</div>}
+
     </SummaryNavigation>
 
 module.exports = SummaryPage

--- a/app/page/summary.cjsx
+++ b/app/page/summary.cjsx
@@ -136,10 +136,10 @@ class SummaryPage extends React.Component
         {toItinerary}
         {summary}
       </Map>
-      { if rows.length == 0
-          <div className="spinner-loader"/>
-        else
-          <div>{rows}</div>}
+      {if rows.length == 0
+        <div className="spinner-loader"/>
+      else
+        <div>{rows}</div>}
 
     </SummaryNavigation>
 


### PR DESCRIPTION
Show a spinner while waiting for itinerary search result. To let the user know that the search is ongoing.