### PR TITLE
DT-1014 Fallback to default endpoint to avoid undefined center in map

### DIFF
--- a/app/component/map/map.cjsx
+++ b/app/component/map/map.cjsx
@@ -118,6 +118,8 @@ class Map extends React.Component
       center =
         if not @props.fitBounds and @props.lat and @props.lon
           [@props.lat, @props.lon]
+        else
+          [config.defaultEndpoint.lat, config.defaultEndpoint.lon]
 
       zoom = @props.zoom
       bounds = boundWithMinimumArea @props.from, @props.to


### PR DESCRIPTION
When running with `map.useVectorTiles = false`, using digitransit with `?mock` in the URL fails because the leaflet center is not defined.
