### PR TITLE
Use configured font from theme in leaflet-container

### DIFF
--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -83,6 +83,8 @@ div.leaflet-container {
   position: absolute;
   width: 100%;
   background: rgb(230, 229, 217);
+  font-family: $font-family;
+  font-weight: $font-weight-map-container;
 }
 
 div.current-location-marker > span > svg.icon {

--- a/sass/themes/default/_theme.scss
+++ b/sass/themes/default/_theme.scss
@@ -50,6 +50,7 @@ $font-family: Lato, Arial, Georgia, Serif;
 $font-weight-book: 300;
 $font-weight-medium: 400;
 $font-weight-bold: 700;
+$font-weight-map-container: $font-weight-book;
 $letter-spacing: 0;
 
 $font-family-narrow: 'PT Sans Narrow', 'Arial Condensed', Arial, Georgia, Serif;

--- a/sass/themes/hsl/_theme.scss
+++ b/sass/themes/hsl/_theme.scss
@@ -43,6 +43,7 @@ $font-family: "Gotham Rounded SSm A","Gotham Rounded SSm B", Arial, Georgia, Ser
 $font-weight-book: 400;
 $font-weight-medium: 500;
 $font-weight-bold: 700;
+$font-weight-map-container: $font-weight-book;
 $letter-spacing: -0.025em;
 
 $font-family-narrow: "Gotham XNarrow SSm A","Gotham XNarrow SSm B", Arial, Georgia, Serif;


### PR DESCRIPTION
Make it possible to configure the font and weight for leaflet markers.