### PR TITLE
Use mixin and include for font style in map container

### DIFF
--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -83,8 +83,7 @@ div.leaflet-container {
   position: absolute;
   width: 100%;
   background: rgb(230, 229, 217);
-  font-family: $font-family;
-  font-weight: $font-weight-map-container;
+  @include font-map-container;
 }
 
 div.current-location-marker > span > svg.icon {

--- a/sass/base/_helper-mixins.scss
+++ b/sass/base/_helper-mixins.scss
@@ -19,6 +19,12 @@
   letter-spacing: $letter-spacing;
 }
 
+@mixin font-map-container {
+  font-family: $font-family;
+  font-weight: $font-weight-map-container;
+  letter-spacing: $letter-spacing;
+}
+
 @mixin font-narrow-book {
   font-family: $font-family-narrow;
   font-weight: $font-narrow-weight-book;


### PR DESCRIPTION
See #600 
Not using mixin @font-book as we meed to set font weight differently in the map in our theme.