### PR TITLE
Make it possible to configure the thickness of itinerary line

### DIFF
--- a/app/component/map/line.cjsx
+++ b/app/component/map/line.cjsx
@@ -2,7 +2,7 @@ isBrowser          = window?
 React              = require 'react'
 Polyline           = if isBrowser then require('react-leaflet/lib/Polyline').default else null
 cx                 = require 'classnames'
-
+config             = require '../../config'
 
 class Line extends React.Component
   componentDidMount: () =>
@@ -28,13 +28,16 @@ class Line extends React.Component
     # updating className does not work currently :(
 
     objs = []
+    haloWeight = if @props.thin then config.map.line.halo.thinWeight else config.map.line.halo.weight
+    legWeight = if @props.thin then config.map.line.leg.thinWeight else config.map.line.leg.weight
+
     objs.push <Polyline map={@props.map}
                         layerContainer={@props.layerContainer}
                         key="halo"
                         ref="halo"
                         positions={@props.geometry}
                         className={"leg-halo #{className}"}
-                        weight={if @props.thin then 4 else 5}
+                        weight={haloWeight}
                         interactive={false} />
     objs.push <Polyline map={@props.map}
                         layerContainer={@props.layerContainer}
@@ -43,7 +46,7 @@ class Line extends React.Component
                         positions={@props.geometry}
                         className="leg #{className}"
                         color={if @props.passive then "#c2c2c2" else "currentColor"}
-                        weight={if @props.thin then 2 else 3}
+                        weight={legWeight}
                         interactive={false} />
 
     <div style={{display: "none"}}>{objs}</div>

--- a/app/config.default.coffee
+++ b/app/config.default.coffee
@@ -67,6 +67,13 @@ module.exports =
         offset: [106, 3]
         maxWidth: 250
         minWidth: 250
+  line:
+    halo:
+      weight: 5
+      thinWeight: 4
+    leg:
+      weight: 3
+      thinWeight: 2
   stopCard:
     header:
       showDescription: true

--- a/app/config.hsl.coffee
+++ b/app/config.hsl.coffee
@@ -72,6 +72,13 @@ module.exports =
         offset: [106, 3]
         maxWidth: 250
         minWidth: 250
+    line:
+      halo:
+        weight: 5
+        thinWeight: 4
+      leg:
+        weight: 3
+        thinWeight: 2
   stopCard:
     header:
       showDescription: true


### PR DESCRIPTION
Make thickness of itinerary lines in map configurable without breaking existing possibility to set `thin` true or false.

Styles for markers will be a separate pull request.