### PR TITLE
Attempt to not kill parent process when pressing CTRL-C

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "predev-win-national": "npm run win-static",
     "prestart": "npm run static",
     "prewin-start": "npm run win-static",
-    "dev": "PID=$$; PGID=$(ps -o pgid=$PID | grep -o [0-9]*); trap 'kill -QUIT %1 $PGID > /dev/null' EXIT; NODE_ENV=development nodemon -e js,jsx,cjsx,css,scss,html,coffee --watch ./app/ server/server.js & NODE_ENV=development forever -f start server/hotLoadServer.js",
+    "dev": "PID=$$; trap 'pkill -QUIT -P $PID > /dev/null' EXIT; NODE_ENV=development nodemon -e js,jsx,cjsx,css,scss,html,coffee --watch ./app/ server/server.js & NODE_ENV=development forever -f start server/hotLoadServer.js",
     "dev-win-hsl": "cd win-launch-scripts&& hsl-win-launch-script.bat",
     "dev-win-national": "cd win-launch-scripts&& set CONFIG=&& national-win-launch-script.bat",
     "dev-nowatch": "NODE_ENV=development node server/server.js & NODE_ENV=development node server/hotLoadServer.js",


### PR DESCRIPTION
When running digitransit-ui in dev mode like this `npm run dev` and pressing `CTRL-C` to stop it, the terminal window / shell is killed as well. (At least, this happens with terminator and zsh)

This PR tries to fix that, by only killing child processes and not the parent process, using `pkill`