### PR TITLE
style: tune default theme button hover color

### DIFF
--- a/sass/themes/default/_theme.scss
+++ b/sass/themes/default/_theme.scss
@@ -41,7 +41,7 @@ $cancelation-background: #fbe0ea;
 $disruption-color: $cancelation-red;
 
 $standalone-btn-color: $primary-color;
-$standalone-btn-hover-color: $secondary-color;
+$standalone-btn-hover-color: $gray-blue-light;
 
 /* Markers */
 $viewpoint-marker-color: $title-color;


### PR DESCRIPTION
Fixes issue https://digitransit.atlassian.net/browse/DT-1106

Seems to already work for HSL theme. Changing the default theme button hover background color for now. It should be further improved when improving "matka.fi" colors next week.

