### PR TITLE
Make it configurable to use the DesktopWrapper

### DIFF
--- a/app/component/util/DesktopWrapper.js
+++ b/app/component/util/DesktopWrapper.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import dimensions from 'react-dimensions';
+import config from '../../config';
 
 function DesktopWrapper({ children, containerWidth }) {
-  if (containerWidth < 980 ||
-    (typeof window !== 'undefined' && window.location.pathname === '/styleguide')
+  if (containerWidth < 980
+    || !config.enableDesktopWrapper
+    || (typeof window !== 'undefined' && window.location.pathname === '/styleguide')
   ) {
     return children;
   }

--- a/app/config.default.coffee
+++ b/app/config.default.coffee
@@ -40,6 +40,7 @@ module.exports =
   availableLanguages: ['fi', 'sv', 'en', 'fr', 'nb']
   defaultLanguage: 'en'
   timezone: 'Europe/Helsinki'
+  enableDesktopWrapper: true
   mainMenu:
     # Whether to show the left menu toggle button at all
     show: true

--- a/app/config.hsl.coffee
+++ b/app/config.hsl.coffee
@@ -45,6 +45,7 @@ module.exports =
   availableLanguages: ['fi', 'sv', 'en']
   defaultLanguage: 'en'
   timezone: 'Europe/Helsinki'
+  enableDesktopWrapper: true
   mainMenu:
     # Whether to show the left menu toggle button at all
     show: true


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all changed components

  * [ ] have examples
  * [ ] have unit tests
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

