### PR TITLE
Hide generic marker text at certain zoom levels

### DIFF
--- a/app/component/map/generic-marker.cjsx
+++ b/app/component/map/generic-marker.cjsx
@@ -79,8 +79,9 @@ class GenericMarker extends React.Component
     </Marker>
 
   getNameMarker: ->
-    unless @props.renderName
+    unless @props.renderName and @props.map.getZoom() >= config.genericMarker.nameMarkerMinZoom
       return false
+
     <Marker map={@props.map}
             layerContainer={@props.layerContainer}
             key={@props.name + "_text"}

--- a/app/config.default.coffee
+++ b/app/config.default.coffee
@@ -65,6 +65,8 @@ module.exports =
     zoomOffset: -1
     useVectorTiles: true
     genericMarker:
+      # Do not render name markers at zoom levels below this value
+      nameMarkerMinZoom: 18
       popup:
         offset: [106, 3]
         maxWidth: 250

--- a/app/config.hsl.coffee
+++ b/app/config.hsl.coffee
@@ -70,6 +70,8 @@ module.exports =
     zoomOffset: -1
     useVectorTiles: true
     genericMarker:
+      # Do not render name markers at zoom levels below this value
+      nameMarkerMinZoom: 18
       popup:
         offset: [106, 3]
         maxWidth: 250

--- a/app/config.joensuu.coffee
+++ b/app/config.joensuu.coffee
@@ -69,6 +69,8 @@ module.exports =
     zoomOffset: -1
     useVectorTiles: false
     genericMarker:
+      # Do not render name markers at zoom levels below this value
+      nameMarkerMinZoom: 18
       popup:
         offset: [106, 3]
         maxWidth: 250


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all changed components

  * [ ] have examples
  * [ ] have unit tests
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

… the zoom level. Only for non-tile map.