### PR TITLE
Make it configurable wether to allow the feedback popup

### DIFF
--- a/app/config.default.coffee
+++ b/app/config.default.coffee
@@ -49,6 +49,9 @@ module.exports =
     showInquiry: true
     showLoginCreateAccount: true
     showOffCanvasList: true
+  feedback:
+    # Whether to allow the feedback popup
+    enable: true
   itinerary:
     # How long vehicle should be late in order to mark it delayed. Measured in seconds.
     delayThreshold: 180

--- a/app/config.hsl.coffee
+++ b/app/config.hsl.coffee
@@ -54,6 +54,9 @@ module.exports =
     showInquiry: true
     showLoginCreateAccount: true
     showOffCanvasList: true
+  feedback:
+    # Whether to allow the feedback popup
+    enable: true
   itinerary:
     # How long vehicle should be late in order to mark it delayed. Measured in seconds.
     delayThreshold: 180

--- a/app/config.joensuu.coffee
+++ b/app/config.joensuu.coffee
@@ -53,6 +53,9 @@ module.exports =
     showInquiry: true
     showLoginCreateAccount: true
     showOffCanvasList: true
+  feedback:
+    # Whether to allow the feedback popup
+    enable: true
   itinerary:
     # How long vehicle should be late in order to mark it delayed. Measured in seconds.
     delayThreshold: 180

--- a/app/util/feedback.coffee
+++ b/app/util/feedback.coffee
@@ -1,9 +1,9 @@
 reactCookie   = if window? then require 'react-cookie' else null
-
+config = require '../config'
 #call when "user returns to frontpage"
 # time (currentTime) in ms
 shouldDisplayPopup = (time) ->
-  if window?
+  if window? and config.feedback.enable
     visitCount = reactCookie.load('vc')
     if visitCount > 1
       feedbackInteractionDate = reactCookie.load('fid')


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all changed components

  * [ ] have examples
  * [ ] have unit tests
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

