### PR TITLE
Make head tags configurable

### DIFF
--- a/app/config.default.coffee
+++ b/app/config.default.coffee
@@ -116,12 +116,12 @@ module.exports =
     showInfoButton: true
   socialMedia:
     title: "Uusi Matka.fi"
-    description: "#{APP_DESCRIPTION}"
+    description: APP_DESCRIPTION
     locale: "fi_FI"
     twitter:
       site: '@hsldevcom'
   meta:
-    description: "#{APP_DESCRIPTION}"
+    description: APP_DESCRIPTION
     keywords: "reitti,reitit,opas,reittiopas,joukkoliikenne"
 
   # Ticket information feature toggle

--- a/app/config.default.coffee
+++ b/app/config.default.coffee
@@ -6,6 +6,7 @@ PIWIK_ADDRESS = process.env.PIWIK_ADDRESS or ''
 PIWIK_ID = process.env.PIWIK_ID or ''
 SENTRY_DSN = process.env.SENTRY_DSN or ''
 PORT = process.env.PORT or 8080
+APP_DESCRIPTION = "Liikenneviraston Matka.fi uudistuu. Apuasi kaivataan kehitystyössä. Tule palvelun testaajaksi tai tee siitä saman tien parempi."
 
 module.exports =
   PIWIK_ADDRESS: "#{PIWIK_ADDRESS}"
@@ -115,7 +116,14 @@ module.exports =
     showInfoButton: true
   socialMedia:
     title: "Uusi Matka.fi"
-    description: "Liikenneviraston Matka.fi uudistuu. Apuasi kaivataan kehitystyössä. Tule palvelun testaajaksi tai tee siitä saman tien parempi."
+    description: "#{APP_DESCRIPTION}"
+    locale: "fi_FI"
+    twitter:
+      site: '@hsldevcom'
+  meta:
+    description: "#{APP_DESCRIPTION}"
+    keywords: "reitti,reitit,opas,reittiopas,joukkoliikenne"
+
   # Ticket information feature toggle
   showTicketInformation: false
   showRouteInformation: false

--- a/app/config.hsl.coffee
+++ b/app/config.hsl.coffee
@@ -6,6 +6,7 @@ PIWIK_ADDRESS = process.env.PIWIK_ADDRESS or ''
 PIWIK_ID = process.env.PIWIK_ID or ''
 SENTRY_DSN = process.env.SENTRY_DSN or ''
 PORT = process.env.PORT or 8080
+APP_DESCRIPTION = "HSL:n Reittiopas.fi uudistuu. Apuasi kaivataan kehitystyössä. Tule palvelun testaajaksi tai tee siitä saman tien parempi."
 
 module.exports =
   PIWIK_ADDRESS: "#{PIWIK_ADDRESS}"
@@ -119,7 +120,13 @@ module.exports =
     showInfoButton: true
   socialMedia:
     title: "Uusi Reittiopas"
-    description: "HSL:n Reittiopas.fi uudistuu. Apuasi kaivataan kehitystyössä. Tule palvelun testaajaksi tai tee siitä saman tien parempi."
+    description: "#{APP_DESCRIPTION}"
+    locale: "fi_FI"
+    twitter:
+      site: '@hsldevcom'
+  meta:
+    description: "#{APP_DESCRIPTION}"
+    keywords: "reitti,reitit,opas,reittiopas,joukkoliikenne"
   # Ticket information feature toggle
   showTicketInformation: true
   showRouteInformation: false

--- a/app/config.hsl.coffee
+++ b/app/config.hsl.coffee
@@ -120,12 +120,12 @@ module.exports =
     showInfoButton: true
   socialMedia:
     title: "Uusi Reittiopas"
-    description: "#{APP_DESCRIPTION}"
+    description: APP_DESCRIPTION
     locale: "fi_FI"
     twitter:
       site: '@hsldevcom'
   meta:
-    description: "#{APP_DESCRIPTION}"
+    description: APP_DESCRIPTION
     keywords: "reitti,reitit,opas,reittiopas,joukkoliikenne"
   # Ticket information feature toggle
   showTicketInformation: true

--- a/app/config.joensuu.coffee
+++ b/app/config.joensuu.coffee
@@ -6,6 +6,7 @@ PIWIK_ADDRESS = process.env.PIWIK_ADDRESS or ''
 PIWIK_ID = process.env.PIWIK_ID or ''
 SENTRY_DSN = process.env.SENTRY_DSN or ''
 PORT = process.env.PORT or 8080
+APP_DESCRIPTION = "Reittiopas uudistuu. Tule mukaan! Ota uuden uuden sukupolven matkaopas käyttöösi."
 
 module.exports =
   PIWIK_ADDRESS: "#{PIWIK_ADDRESS}"
@@ -118,7 +119,13 @@ module.exports =
     showInfoButton: true
   socialMedia:
     title: "Uusi Reittiopas - Joensuu"
-    description: "Reittiopas uudistuu. Tule mukaan! Ota uuden uuden sukupolven matkaopas käyttöösi."
+    description: "#{APP_DESCRIPTION}"
+    locale: "fi_FI"
+    twitter:
+      site: '@hsldevcom'
+    meta:
+      description: "#{APP_DESCRIPTION}"
+      keywords: "reitti,reitit,opas,reittiopas,joukkoliikenne"
   # Ticket information feature toggle
   showTicketInformation: false
   showRouteInformation: false

--- a/app/meta.js
+++ b/app/meta.js
@@ -24,10 +24,10 @@ export default function getMetadata(lang) {
       content: 'utf-8',
     }, {
       name: 'description',
-      content: 'Löydä joukkoliikennetarjonta lähelle ja kauas.',
+      content: config.meta.description,
     }, {
       name: 'keywords',
-      content: 'reitti,reitit,opas,reittiopas,joukkoliikenne',
+      content: config.meta.keywords,
     }, {
       name: 'viewport',
       content: 'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1 user-scalable=no, minimal-ui', // eslint-disable-line max-len
@@ -69,13 +69,13 @@ export default function getMetadata(lang) {
       content: `${root}/img/${configPath}-icons/social-share.png`,
     }, {
       property: 'og:locale',
-      content: 'fi_FI',
+      content: config.socialMedia.locale,
     }, {
       name: 'twitter:card',
       content: 'summary_large_image',
     }, {
       name: 'twitter:site',
-      content: '@hsldevcom',
+      content: config.socialMedia.twitter.site,
     }, {
       name: 'twitter:title',
       content: config.socialMedia.title,


### PR DESCRIPTION
Make values in head tags configurable.

The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all changed components

  * [ ] have examples
  * [ ] have unit tests
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.
