### PR TITLE
Only use M for subway if shortName not available

### DIFF
--- a/app/util/leg-text-util.js
+++ b/app/util/leg-text-util.js
@@ -4,7 +4,7 @@
 const MAX_ROUTE_LENGTH = 6;
 
 function getLegText(leg) {
-  if (leg.transitLeg && leg.mode.toLowerCase() === 'subway') {
+  if (leg.transitLeg && leg.mode.toLowerCase() === 'subway' && !leg.route.shortName) {
     // TODO: Translate these characters.
     return 'M';
   } else if (leg.transitLeg && leg.route.shortName &&


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all changed components

  * [ ] have examples
  * [ ] have unit tests
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

