### PR TITLE
Minor improvements to the ui test script

### DIFF
--- a/test/flow/script/run-ui-tests.sh
+++ b/test/flow/script/run-ui-tests.sh
@@ -16,15 +16,23 @@ if [ -z "$BROWSERSTACK_BUILD" ]; then
 fi
 
 PLATFORM=`uname`
-ARCHITECTURE=`arch`
-if [ $PLATFORM == 'Darwin' ]; then
-  SELENIUM_URL=http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar
+
+if command -v arch > /dev/null 2>&1
+then
+  ARCHITECTURE=`arch`
+  echo "Detected architecture $ARCHITECTURE"
+else
+  echo "Command 'arch' does not exist. Setting empty value."
+  ARCHITECTURE=''
+fi
+
+SELENIUM_URL="https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar"
+
+if [[ $PLATFORM == 'Darwin' ]]; then
   BROWSERSTACK_LOCAL_URL="https://www.browserstack.com/browserstack-local/BrowserStackLocal-darwin-x64.zip"
-elif [ $ARCHITECTURE == 'i686' ]; then
-  SELENIUM_URL=https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar
+elif [[ $ARCHITECTURE == 'i686' ]]; then
   BROWSERSTACK_LOCAL_URL="https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-ia32.zip"
 else
-  SELENIUM_URL=https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar
   BROWSERSTACK_LOCAL_URL="https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip"
 fi
 
@@ -34,6 +42,7 @@ SELENIUM_BINARY="./test/flow/binaries/selenium-server-standalone-2.53.0.jar"
 
 # checks for dependencies and downloads them if needed
 function checkDependencies {
+  echo "Checking dependencies"
   mkdir -p ./test/flow/binaries
   if [ ! -f $SELENIUM_BINARY ]; then
     echo "Downloading Selenium..."
@@ -61,15 +70,17 @@ killtree() {
 checkDependencies
 
 if [ "$1" == "local" ]; then
+  echo "Staring digitransit-ui server"
   CONFIG=hsl PORT=8000 npm run dev-nowatch &
   NODE_PID=$!
-  # Wait for the server to start
+  echo "Wait for the server to start"
   sleep 10
-  # Then run tests
+
+  echo "Run tests"
   $NIGHTWATCH_BINARY -c ./test/flow/config/nightwatch.json
   TESTSTATUS=$?
 
-  # Kill Node
+  echo "Kill node with pid: $NODE_PID"
   killtree $NODE_PID
   exit $TESTSTATUS
 elif [ "$1" == "browserstack" ]; then


### PR DESCRIPTION
The real issue I had running the local tests was caused by this: https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/3280
(even though running selenium alone worked fine)

Still, some improvements to the script should be made to avoid misleading messages like `unary operator expected`

The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all changed components

  * [ ] have examples
  * [ ] have unit tests
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

…oid unary operator expected message. More verbose output.