### PR TITLE
do not allow selecting top suggestion if there are no suggestions

### DIFF
--- a/app/component/search/SearchInputContainer.js
+++ b/app/component/search/SearchInputContainer.js
@@ -81,7 +81,7 @@ export default class SearchInputContainer extends Component {
   }
 
   handleOnKeyDown = (event, eventProps) => {
-    if (event.keyCode === 13) {
+    if (event.keyCode === 13 && this.state.suggestions.length > 0) {
       // enter selects current
       this.currentItemSelected();
       this.blur();


### PR DESCRIPTION
DT-465 was an old bug report and probably things have changed many times since then. 
I was not able to reproduce the favourite problem at all.

For the other half I am not sure if the original problem is still there. I however fixed the  SearchInputContainer so that now it is not possible to select entry with Enter key if there are no suggestions present. Before the fix this was a problem with other browsers too.