### PR TITLE
Increase tolerance for non-deterministic visual tests

### DIFF
--- a/test/visual/components.js
+++ b/test/visual/components.js
@@ -76,8 +76,8 @@ gemini.suite('components', (parent) => {
   gemini.suite('TimeNavigationButtons', (component) => {
     component.setCaptureElements(
       '#TimeNavigationButtons .component-example:nth-of-type(1) .component')
-    .capture('normal')
-    .capture('hovered', (actions) => {
+    .capture('normal', { tolerance: 5 }, () => {})
+    .capture('hovered', { tolerance: 5 }, (actions) => {
       actions.mouseMove(
         '#TimeNavigationButtons .component-example:nth-of-type(1) .component button:first-of-type'
       );


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all changed components

  * [ ] have examples
  * [ ] have unit tests
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

