### PR TITLE
Fix route schedule timezone.

### DIFF
--- a/app/component/route/RouteScheduleContainer.js
+++ b/app/component/route/RouteScheduleContainer.js
@@ -62,8 +62,10 @@ class RouteScheduleContainer extends Component {
         </div>);
     }
     return trips.map((trip) => {
-      const departureTime = this.formatTime(trip.stoptimes[stops[from].id].scheduledDeparture);
-      const arrivalTime = this.formatTime(trip.stoptimes[stops[to].id].scheduledArrival);
+      const fromSt = trip.stoptimes[stops[from].id];
+      const toSt = trip.stoptimes[stops[to].id];
+      const departureTime = this.formatTime(fromSt.serviceDay + fromSt.scheduledDeparture);
+      const arrivalTime = this.formatTime(toSt.serviceDay + toSt.scheduledArrival);
 
       return (
         <RouteScheduleTripRow
@@ -151,6 +153,7 @@ export const relayFragment = {
         stoptimes {
           scheduledArrival
           scheduledDeparture
+          serviceDay
           stop {
             id
           }

--- a/app/component/route/RouteScheduleContainer.js
+++ b/app/component/route/RouteScheduleContainer.js
@@ -100,7 +100,7 @@ class RouteScheduleContainer extends Component {
     return transformedTrips;
   }
 
-  formatTime = (timestamp) => moment(timestamp * 1000).format('HH:mm');
+  formatTime = (timestamp) => moment.utc(timestamp * 1000).format('HH:mm');
 
   changeDate = ({ target }) => {
     // TODO: add setState and a callback that resets the laoding state in oreder to get a spinner.


### PR DESCRIPTION
The timetable showed the times in the current locale
instead of UTC, which caused the times to be wrong
depending on the offset between the browser timezone
and UTC.

Cf. difference between HSL timetables and the view in
E.g.
http://aikataulut.reittiopas.fi/linjat/fi/h72_72n.html
https://dev.reittiopas.fi/linjat/HSL:1072:1:02