### PR TITLE
Fix stop popup additional patterns

### DIFF
--- a/app/component/map/tile-layer/SelectStopRow.js
+++ b/app/component/map/tile-layer/SelectStopRow.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { FormattedMessage } from 'react-intl';
 import uniqBy from 'lodash/uniqBy';
+import filter from 'lodash/filter';
 
 import RouteDestination from '../../departure/route-destination';
 import routeCompare from '../../../util/route-compare';
@@ -38,12 +39,16 @@ function SelectStopRow(props) {
   );
 
   if (patternData.length > 1) {
-    patterns.push(
-      <div key="second" className="route-detail-text">
-        <FormattedMessage id="in-addition" defaultMessage="In addition" />
-        {uniqBy(patternData.slice(1), pattern => pattern.shortName).map(getName)}
-      </div>
-    );
+    const otherPatterns = filter(
+      patternData.slice(1),
+      pattern => pattern.shortName !== patternData[0].shortName);
+    if (otherPatterns.length > 0) {
+      patterns.push(
+        <div key="second" className="route-detail-text">
+          <FormattedMessage id="in-addition" defaultMessage="In addition" />
+          {uniqBy(otherPatterns, pattern => pattern.shortName).map(getName)}
+        </div>);
+    }
   }
 
   return (

--- a/app/component/map/tile-layer/SelectStopRow.js
+++ b/app/component/map/tile-layer/SelectStopRow.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { FormattedMessage } from 'react-intl';
 import uniqBy from 'lodash/uniqBy';
-import filter from 'lodash/filter';
+import reject from 'lodash/reject';
 
 import RouteDestination from '../../departure/route-destination';
 import routeCompare from '../../../util/route-compare';
@@ -39,9 +39,7 @@ function SelectStopRow(props) {
   );
 
   if (patternData.length > 1) {
-    const otherPatterns = filter(
-      patternData.slice(1),
-      pattern => pattern.shortName !== patternData[0].shortName);
+    const otherPatterns = reject(patternData, ['shortName', patternData[0].shortName]);
     if (otherPatterns.length > 0) {
       patterns.push(
         <div key="second" className="route-detail-text">


### PR DESCRIPTION
Performing the following steps...

1. Click a stop cluster on the map
2. A popup appears allowing you to select a stop
3. The selectable stop row contains the first route number and additional route numbers departing from that stop

...this PR solves the following bug:
The list of additional route numbers contains the first route number as well (e.g. "7B, in addition: 7B")