### PR TITLE
fix: z-index

### DIFF
--- a/app/component/front-page/front-page-panel.scss
+++ b/app/component/front-page/front-page-panel.scss
@@ -9,7 +9,7 @@ $heading-color: #858585;
   position: absolute;
   top: 0;
   height: calc(100% - 48px);
-  z-index: 1000;
+  z-index: 1200;
   width: 100%;
   overflow: hidden;
   background-color: $background-color;
@@ -42,7 +42,7 @@ $heading-color: #858585;
 }
 
 .frontpage-panel-container .tabs-row {
-  z-index: 1001;
+  z-index: 1201;
   width: 100%;
 }
 


### PR DESCRIPTION
The front page tabs should open on top of the menu bar.