### PR TITLE
Fix visual test syntax

### DIFF
--- a/test/visual/components.js
+++ b/test/visual/components.js
@@ -127,7 +127,8 @@ gemini.suite('components', (parent) => {
       suite.setCaptureElements('#Favourite .component-example:nth-of-type(2) .component')
       .capture('normal');
     });
-    
+  });
+
   gemini.suite('IconWithTail', (component) => {
     component.setCaptureElements(
       '#IconWithTail .component-example:nth-of-type(1) .component')


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

