### PR TITLE
DT-1165 Re-enable IE browser tests

### DIFF
--- a/test/flow/page_object/itineraryInstructions.js
+++ b/test/flow/page_object/itineraryInstructions.js
@@ -4,9 +4,8 @@ function waitForFirstItineraryInstructionColumn() {
 }
 
 function verifyOrigin(origin) {
-  return this.waitForElementPresent('@itineraryOrigin',
+  return this.waitForElementVisible('@itineraryOrigin',
                                     this.api.globals.itinerarySearchTimeout)
-    .moveToElement('@itineraryOrigin', 0, 0)
     .assert.containsText('@itineraryOrigin', origin);
 }
 

--- a/test/flow/script/run-ui-tests.sh
+++ b/test/flow/script/run-ui-tests.sh
@@ -114,7 +114,7 @@ elif [ "$1" == "browserstack" ]; then
   # Wait for the server to start
   sleep 10
   # Then run tests
-  env BROWSERSTACK_USER=$2 BROWSERSTACK_KEY=$3 $NIGHTWATCH_BINARY -c ./test/flow/nightwatch.json -e bs-fx,bs-chrome --suiteRetries 3
+  env BROWSERSTACK_USER=$2 BROWSERSTACK_KEY=$3 $NIGHTWATCH_BINARY -c ./test/flow/nightwatch.json -e bs-fx,bs-chrome,bs-ie --suiteRetries 3
   TESTSTATUS=$?
   # Kill Node and Browserstack tunnel
   if [ "$START_SERVER" == "1" ]; then


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.
