### PR TITLE
Search stops only from Pelias, not from OTP

### DIFF
--- a/app/action/SearchActions.js
+++ b/app/action/SearchActions.js
@@ -277,13 +277,7 @@ function executeSearchInternal(actionContext, { input, type }) {
       addOldSearches(oldSearches, input),
     ];
 
-    if (config.search.showStopsFirst) {
-      searches.push(searchStops(input));
-      searches.push(getGeocodingResult(input, position, language));
-    } else {
-      searches.push(getGeocodingResult(input, position, language));
-      searches.push(searchStops(input));
-    }
+    searches.push(getGeocodingResult(input, position, language));
 
     return Promise.all(searches)
     .then(flatten)


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

