### PR TITLE
fix local firefox testing

### DIFF
--- a/test/flow/nightwatch.json
+++ b/test/flow/nightwatch.json
@@ -13,8 +13,7 @@
     "port": 4444,
     "cli_args": {
       "webdriver.chrome.driver": "",
-      "webdriver.ie.driver": "",
-      "webdriver.firefox.bin": "./firefox/firefox-bin"
+      "webdriver.ie.driver": ""
     }
   },
 


### PR DESCRIPTION
when this is integrated the downloaded firefox binary needs to be added to path in snap

`PATH="./firefox:$PATH"`