### PR TITLE
Drop support for supportsHistory

### DIFF
--- a/app/action/ItinerarySearchActions.js
+++ b/app/action/ItinerarySearchActions.js
@@ -1,4 +1,3 @@
-import { supportsHistory } from 'history/lib/DOMUtils';
 import { locationToOTP } from '../util/otpStrings';
 import { getRoutePath } from '../util/path';
 import history from '../history';
@@ -30,11 +29,9 @@ export function route(actionContext, payload, done) {
       to = locationToOTP(destination);
     }
 
-    if (supportsHistory()) {
-      history.push({
-        pathname: getRoutePath(from, to),
-      });
-    }
+    history.push({
+      pathname: getRoutePath(from, to),
+    });
   }
 
   return done();

--- a/app/component/navigation/MainMenuContainer.js
+++ b/app/component/navigation/MainMenuContainer.js
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes } from 'react';
 import Drawer from 'material-ui/Drawer';
-import { supportsHistory } from 'history/lib/DOMUtils';
 
 import config from '../../config';
 import Icon from '../icon/Icon';
@@ -15,43 +14,33 @@ class MainMenuContainer extends Component {
     router: PropTypes.object.isRequired,
   };
 
-  state = { offcanvasVisible: false };
-
   onRequestChange = (newState) => this.internalSetOffcanvas(newState);
 
   getOffcanvasState = () => {
-    if (typeof window !== 'undefined' && supportsHistory()) {
-      if (this.context.location.state != null &&
-          this.context.location.state.offcanvasVisible != null) {
-        return this.context.location.state.offcanvasVisible;
-      }
-      // If the state is missing or doesn't have offcanvasVisible, it's not set
-      return false;
+    if (this.context.location.state != null &&
+        this.context.location.state.offcanvasVisible != null) {
+      return this.context.location.state.offcanvasVisible;
     }
-    // Use state only if we can't use the state in history API
-    return this.state.offcanvasVisible;
+    // If the state is missing or doesn't have offcanvasVisible, it's not set
+    return false;
   }
 
   toggleOffcanvas = () => this.internalSetOffcanvas(!this.getOffcanvasState());
 
   internalSetOffcanvas = (newState) => {
-    this.setState({ offcanvasVisible: newState });
-
     if (this.context.piwik != null) {
       this.context.piwik.trackEvent('Offcanvas', 'Index', newState ? 'open' : 'close');
     }
 
-    if (supportsHistory()) {
-      if (newState) {
-        this.context.router.push({
-          state: { offcanvasVisible: newState },
-          pathname: this.context.location.pathname + (
-            (this.context.location.search && this.context.location.search.indexOf('mock') > -1) ?
-              '?mock' : ''),
-        });
-      } else {
-        this.context.router.goBack();
-      }
+    if (newState) {
+      this.context.router.push({
+        state: { offcanvasVisible: newState },
+        pathname: this.context.location.pathname + (
+          (this.context.location.search && this.context.location.search.indexOf('mock') > -1) ?
+            '?mock' : ''),
+      });
+    } else {
+      this.context.router.goBack();
     }
   }
 

--- a/app/component/navigation/SummaryNavigation.js
+++ b/app/component/navigation/SummaryNavigation.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Drawer from 'material-ui/Drawer';
-import { supportsHistory } from 'history/lib/DOMUtils';
 import cx from 'classnames';
 
 import CustomizeSearch from '../summary/CustomizeSearch';
@@ -48,8 +47,7 @@ class SummaryNavigation extends React.Component {
   }
 
   getOffcanvasState = () =>
-    (typeof window !== 'undefined' && supportsHistory() && this.context.location.state &&
-      this.context.location.state.customizeSearchOffcanvas) || false;
+    this.context.location.state && this.context.location.state.customizeSearchOffcanvas;
 
   internalSetOffcanvas = (newState) => {
     if (this.context.piwik != null) {
@@ -60,18 +58,16 @@ class SummaryNavigation extends React.Component {
       );
     }
 
-    if (supportsHistory()) {
-      if (newState) {
-        this.context.router.push({
-          ...this.context.location,
-          state: {
-            ...this.context.location.state,
-            customizeSearchOffcanvas: newState,
-          },
-        });
-      } else {
-        this.context.router.goBack();
-      }
+    if (newState) {
+      this.context.router.push({
+        ...this.context.location,
+        state: {
+          ...this.context.location.state,
+          customizeSearchOffcanvas: newState,
+        },
+      });
+    } else {
+      this.context.router.goBack();
     }
   }
 


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

As it is only used in a few palaces