### PR TITLE
Tune docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,38 +4,38 @@ MAINTAINER Reittiopas version: 0.1
 EXPOSE 8080
 LABEL io.openshift.expose-services 8080:http
 
-# Where the app is built and run inside the docker fs
-ENV WORK=/opt/digitransit-ui
-
-# Used indirectly for saving npm logs etc.
-ENV HOME=/opt/digitransit-ui
-
-# App specific settings to override when the image is run
-ENV SENTRY_DSN=''
-ENV SENTRY_SECRET_DSN=''
-ENV PORT=8080
-ENV API_URL=''
-ENV APP_PATH=''
-ENV CONFIG=''
-ENV PIWIK_ADDRESS=''
-ENV PIWIK_ID=''
-ENV NODE_ENV=''
+ENV \
+  # Where the app is built and run inside the docker fs \
+  WORK=/opt/digitransit-ui \
+  # Used indirectly for saving npm logs etc. \
+  HOME=/opt/digitransit-ui \
+  # App specific settings to override when the image is run \
+  SENTRY_DSN='' \
+  SENTRY_SECRET_DSN='' \
+  PORT=8080 \
+  API_URL='' \
+  APP_PATH='' \
+  CONFIG='' \
+  PIWIK_ADDRESS='' \
+  PIWIK_ID='' \
+  NODE_ENV=''
 
 WORKDIR ${WORK}
 ADD . ${WORK}
 
 # Build and set permissions for arbitary non-root users in OpenShift
 # (https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-specific-guidelines)
-RUN npm install && \
+RUN \
+  npm install && \
   npm run static && \
   npm rebuild node-sass && \
   npm run build && \
   npm cache clean && \
-  chmod -R a+rwX .
+  chmod -R a+rwX . && \
+  chown -R 9999:9999 ${WORK}
 
 # Don't run as root, because there's no reason to (https://docs.docker.com/engine/articles/dockerfile_best-practices/#user).
 # This also reveals permission problems on local Docker, before pushing to OpenShift.
-RUN chown -R 9999:9999 ${WORK}
 USER 9999
 
 CMD npm run start

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN \
   npm run static && \
   npm rebuild node-sass && \
   npm run build && \
+  rm -rf static docs test /tmp/* && \
+  npm prune --production && \
   npm cache clean && \
   chmod -R a+rwX . && \
   chown -R 9999:9999 ${WORK}

--- a/app/server.js
+++ b/app/server.js
@@ -41,8 +41,8 @@ function getStringOrArrayElement(arrayOrString, index) {
 // Look up paths for various asset files
 const appRoot = `${process.cwd()}/`;
 
-const svgSprite = fs.readFileSync(`${appRoot}static/svg-sprite.${config.CONFIG}.svg`).toString();
-const geolocationStarter = fs.readFileSync(`${appRoot}static/geolocation.js`).toString();
+const svgSprite = fs.readFileSync(`${appRoot}_static/svg-sprite.${config.CONFIG}.svg`).toString();
+const geolocationStarter = fs.readFileSync(`${appRoot}_static/geolocation.js`).toString();
 
 const networkLayer = new Relay.DefaultNetworkLayer(`${config.URL.OTP}index/graphql`);
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "predev": "npm run static",
     "predev-win-hsl": "npm run win-static",
     "predev-win-national": "npm run win-static",
-    "prestart": "npm run static",
-    "prewin-start": "npm run win-static",
     "dev": "PID=$$; trap 'pkill -QUIT -P $PID > /dev/null' EXIT; NODE_ENV=development nodemon -e js,css,scss,html --watch ./app/ server/server.js -x \"node --harmony\" & NODE_ENV=development forever -f start server/hotLoadServer.js",
     "dev-win-hsl": "cd win-launch-scripts&& hsl-win-launch-script.bat",
     "dev-win-national": "cd win-launch-scripts&& set CONFIG=&& national-win-launch-script.bat",

--- a/static/svg-sprite.hsl.svg
+++ b/static/svg-sprite.hsl.svg
@@ -779,5 +779,3 @@
 </symbol>
 </defs>
 </svg>
-</defs>
-</svg>


### PR DESCRIPTION
The PR is done - it:
Makes the docker build faster and resulting image smaller.
Fixes one svg file.
Fixes the server to really only use files from _static. 

- [x] follows the style and naming rules (passes `npm run lint`)
- [?] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
 - some randomness noticed
- [?] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [x] any changed files are transformed to ES6
- [-] all new strings visible to users are

  * [-] added to translations file
  * [-] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [-] all changed components

  * [-] have examples
  * [-] are included in the style guide
  * [-] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.
