### PR TITLE
Set default language to finnish for hsl, joensuu and turku configs

### DIFF
--- a/app/config.hsl.js
+++ b/app/config.hsl.js
@@ -39,6 +39,7 @@ export default {
 
   maxWalkDistance: 2500,
   availableLanguages: ['fi', 'sv', 'en'],
+  defaultLanguage: 'fi',
 
   parkAndRide: {
     showParkAndRide: true,

--- a/app/config.joensuu.js
+++ b/app/config.joensuu.js
@@ -27,6 +27,7 @@ export default {
   },
 
   availableLanguages: ['fi', 'sv', 'en'],
+  defaultLanguage: 'fi',
 
   initialLocation: {
     lat: 62.6024263,

--- a/app/config.turku.js
+++ b/app/config.turku.js
@@ -27,6 +27,7 @@ export default {
   },
 
   availableLanguages: ['fi', 'sv', 'en'],
+  defaultLanguage: 'fi',
 
   initialLocation: {
     lat: 60.451159,


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

