### PR TITLE
NRP-836 Make search suggestion types configurable

### DIFF
--- a/app/component/SearchInputContainer.js
+++ b/app/component/SearchInputContainer.js
@@ -63,11 +63,7 @@ export default class SearchInputContainer extends Component {
   }
 
   getItems() {
-    if (this.props.type === 'all') {
-      const suggestions = find(this.state.suggestions, ['name', this.state.type]);
-      return (suggestions && suggestions.items) || [];
-    }
-    return this.state.suggestions;
+    return this.state.suggestions || [];
   }
 
   focusItem(i) {  // eslint-disable-line class-methods-use-this

--- a/app/config.default.js
+++ b/app/config.default.js
@@ -45,6 +45,7 @@ export default {
   search: {
     suggestions: {
       useTransportIcons: false,
+      types: ['endpoint'],
     },
   },
 

--- a/app/util/searchUtils.js
+++ b/app/util/searchUtils.js
@@ -310,11 +310,21 @@ export function executeSearchImmediate(getStore, { input, type }, callback) {
   }
 
   Promise.all([endpoitSearches, searchSearches])
-    .then(([endpoints, search]) => callback([
-      { name: 'endpoint', items: endpoints },
-      { name: 'search', items: search },
-    ]))
-    .catch(err => console.error(err)); // eslint-disable-line no-console
+    .then(([endpoints, search]) => {
+      const suggestionTypes = config.search.suggestions.types;
+      let searchItems = [];
+
+      if (suggestionTypes) {
+        suggestionTypes.forEach((suggestionType) => {
+          if (suggestionType === 'endpoint') {
+            searchItems = searchItems.concat(endpoints);
+          } else if (suggestionType === 'search') {
+            searchItems = searchItems.concat(search);
+          }
+        });
+      }
+      return callback(searchItems);
+    }).catch(err => console.error(err)); // eslint-disable-line no-console
 }
 
 const debouncedSearch = debounce(executeSearchImmediate, 300);


### PR DESCRIPTION
As of current, stop place suggestions retrieved from OTP are not rendered in the SearchInputContainer. This PR provides configuration of toggling this on and off.  

- [x] follows the style and naming rules (passes `npm run lint`)
- [x] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [x] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
- [x] any changed files are transformed to ES6
