### PR TITLE
(Map-controls) Make scale and zoom position for map configurable

### DIFF
--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -65,11 +65,12 @@ class Map extends React.Component {
     }).addTo(this.refs.map.leafletElement);
 
     if (this.props.showScaleBar) {
-      L.control.scale({ imperial: false, position: 'bottomright' }).addTo(this.refs.map.leafletElement);
+      L.control.scale({ imperial: false, position: config.map.controls.scale.position })
+        .addTo(this.refs.map.leafletElement);
     }
 
     if (!this.props.disableZoom || L.Browser.touch) {
-      L.control.zoom({ position: 'topleft' })
+      L.control.zoom({ position: config.map.controls.zoom.position })
         .addTo(this.refs.map.leafletElement);
     }
 

--- a/app/config.default.js
+++ b/app/config.default.js
@@ -103,7 +103,15 @@ export default {
     tileSize: 512,
     zoomOffset: -1,
     useVectorTiles: true,
-
+    controls: {
+      zoom: {
+        // available controls positions: 'topleft', 'topright', 'bottomleft, 'bottomright'
+        position: 'topright',
+      },
+      scale: {
+        position: 'bottomright',
+      },
+    },
     genericMarker: {
       // Do not render name markers at zoom levels below this value
       nameMarkerMinZoom: 18,


### PR DESCRIPTION
Today scale (referenced as scaleBar) and zoom control for Map have hard-coded positions.
This PR includes flexibility to configure these positions. Naturally, positions are defaulted to hard-coded values.

- [x] follows the style and naming rules (passes `npm run lint`)
- [x] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)

