### PR TITLE
Fix splash styles on firefox

### DIFF
--- a/app/component/OriginSelector.js
+++ b/app/component/OriginSelector.js
@@ -9,8 +9,10 @@ import { getIcon } from '../util/suggestionUtils';
 const OriginSelectorRow = ({ icon, label, lat, lon }, { executeAction }) => (
   <li>
     <button
-      className="noborder" onClick={() => executeAction(setEndpoint,
-    { target: 'origin', endpoint: { lat, lon, address: label } })}
+      className="noborder"
+      style={{ display: 'block' }}
+      onClick={() => executeAction(setEndpoint,
+        { target: 'origin', endpoint: { lat, lon, address: label } })}
     >
       <Icon className={`splash-icon ${icon}`} img={icon} />
       { label }

--- a/app/component/Splash.js
+++ b/app/component/Splash.js
@@ -44,9 +44,11 @@ class Splash extends React.Component {
           <FormattedMessage id="splash-you-can-also" defaultMessage="You can also" />
         </div>
         <div id="splash-search-field-container" className="flex-vertical">
-          <span id="splash-searchfield" ><button className="noborder" onClick={this.openModal}>
-            <FormattedMessage id="give-origin" defaultMessage="Type in your origin" />
-            <Icon className="icon-edit" img="icon-icon_edit" /></button>
+          <span id="splash-searchfield" >
+            <button className="noborder" onClick={this.openModal} style={{ display: 'block' }}>
+              <FormattedMessage id="give-origin" defaultMessage="Type in your origin" />
+              <Icon className="icon-edit" img="icon-icon_edit" />
+            </button>
           </span>
         </div>
         <div className="splash-separator">

--- a/app/component/splash.scss
+++ b/app/component/splash.scss
@@ -132,7 +132,7 @@
       padding-bottom: 7px;
       cursor: pointer;
       border-bottom: 1px solid $light-gray;
-      span {
+      > span {
         display: flex;
         align-items: center;
       }


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.

