### PR TITLE
Initialize routing parameter sliders properly

### DIFF
--- a/app/component/CustomizeSearch.js
+++ b/app/component/CustomizeSearch.js
@@ -13,6 +13,21 @@ import Select from './Select';
 import config from '../config';
 import { route } from '../action/ItinerarySearchActions';
 
+// find the array slot closest to a value
+function mapToSlider(value, arr) {
+  let best = 0;
+  let minDiff = Math.abs(value - arr[0]);
+
+  for (let i = 1; i < arr.length; i++) {
+    const diff = Math.abs(value - arr[i]);
+    if (diff < minDiff) {
+      minDiff = diff;
+      best = i;
+    }
+  }
+  return best;
+}
+
 class CustomizeSearch extends React.Component {
 
   static contextTypes = {
@@ -47,7 +62,6 @@ class CustomizeSearch extends React.Component {
     return sliderSteps;
   }
 
-
   static getDefaultModes() {
     return [
       ...Object.keys(config.transportModes)
@@ -78,9 +92,11 @@ class CustomizeSearch extends React.Component {
   }
 
   getWalkReluctanceSlider = () => {
-    // TODO: connect to this.context.getStore('ItinerarySearchStore').getWalkReluctance()
-
-    const walkReluctanceSliderValues = CustomizeSearch.getSliderStepsArray(0.8, 10, 2).reverse();
+    const walkReluctanceSliderValues =
+          CustomizeSearch.getSliderStepsArray(0.8, 10, 2).reverse();
+    const initVal = this.context.location.query.walkReluctance ?
+          mapToSlider(this.context.location.query.walkReluctance, walkReluctanceSliderValues) :
+          10;
 
     return (<section className="offcanvas-section">
       <Slider
@@ -88,13 +104,13 @@ class CustomizeSearch extends React.Component {
           id: 'walking',
           defaultMessage: 'Walking',
         })}
-        defaultValue={10}
         onSliderChange={e => this.updateSettings(
           'walkReluctance',
           walkReluctanceSliderValues[e.target.value],
         )}
         min={0}
         max={20}
+        defaultValue={initVal}
         step={1}
         minText={this.context.intl.formatMessage({
           id: 'avoid-walking',
@@ -109,10 +125,11 @@ class CustomizeSearch extends React.Component {
   }
 
   getWalkBoardCostSlider = () => {
-    // TODO: connect to this.context.getStore('ItinerarySearchStore').getWalkBoardCost()
-
     const walkBoardCostSliderValues =
       CustomizeSearch.getSliderStepsArray(1, 1800, 600).reverse().map(num => Math.round(num));
+    const initVal = this.context.location.query.walkBoardCost ?
+          mapToSlider(this.context.location.query.walkBoardCost, walkBoardCostSliderValues) :
+          10;
 
     return (
       <section className="offcanvas-section">
@@ -121,13 +138,13 @@ class CustomizeSearch extends React.Component {
             id: 'transfers',
             defaultMessage: 'Transfers',
           })}
-          defaultValue={10}
           onSliderChange={e => this.updateSettings(
             'walkBoardCost',
             walkBoardCostSliderValues[e.target.value],
           )}
           min={0}
           max={20}
+          defaultValue={initVal}
           step={1}
           minText={this.context.intl.formatMessage({
             id: 'avoid-transfers',
@@ -142,10 +159,11 @@ class CustomizeSearch extends React.Component {
   }
 
   getTransferMarginSlider = () => {
-    // TODO: connect to this.context.getStore('ItinerarySearchStore').getMinTransferTime()
-
-    const transferMarginSliderValues = CustomizeSearch.getSliderStepsArray(60, 660, 180).map(
-      num => Math.round(num));
+    const transferMarginSliderValues =
+          CustomizeSearch.getSliderStepsArray(60, 660, 180).map(num => Math.round(num));
+    const initVal = this.context.location.query.minTransferTime ?
+          mapToSlider(this.context.location.query.minTransferTime, transferMarginSliderValues) :
+          10;
 
     return (
       <section className="offcanvas-section">
@@ -154,13 +172,13 @@ class CustomizeSearch extends React.Component {
             id: 'transfers-margin',
             defaultMessage: 'Transfer margin',
           })}
-          defaultValue={10}
           onSliderChange={e => this.updateSettings(
             'minTransferTime',
             transferMarginSliderValues[e.target.value],
           )}
           min={0}
           max={20}
+          defaultValue={initVal}
           step={1}
           minText={this.context.intl.formatMessage({
             id: 'no-transfers-margin',
@@ -175,9 +193,10 @@ class CustomizeSearch extends React.Component {
   }
 
   getWalkSpeedSlider = () => {
-    // TODO: connect to this.context.getStore('ItinerarySearchStore').getWalkSpeed()
-
     const walkingSpeedSliderValues = CustomizeSearch.getSliderStepsArray(0.5, 3, 1.2);
+    const initVal = this.context.location.query.walkSpeed ?
+          mapToSlider(this.context.location.query.walkSpeed, walkingSpeedSliderValues) :
+          10;
 
     return (
       <section className="offcanvas-section">
@@ -186,13 +205,13 @@ class CustomizeSearch extends React.Component {
             id: 'walking-speed',
             defaultMessage: 'Walking speed',
           })}
-          defaultValue={10}
           onSliderChange={e => this.updateSettings(
             'walkSpeed',
             walkingSpeedSliderValues[e.target.value],
           )}
           min={0}
           max={20}
+          defaultValue={initVal}
           step={1}
           minText={this.context.intl.formatMessage({
             id: 'slow',


### PR DESCRIPTION
Set the default value of each slider to the respective
query parameter values if available

The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.
