### PR TITLE
Make route number component a bit wider

### DIFF
--- a/app/component/departure.scss
+++ b/app/component/departure.scss
@@ -118,7 +118,7 @@
 
 // route-number component
 .route-number {
-  width: 3.5em;
+  width: 4.5em;
   vertical-align: top;
   position: relative;
   display: inline-block;


### PR DESCRIPTION
In Disruption info the current width is not enough to show line numbers such as 206A.

![route-number](https://cloud.githubusercontent.com/assets/2797729/21745913/24290340-d53e-11e6-8547-fb27ff5d4a1d.png)

This wider version should work also in cases such as 123AB.