### PR TITLE
changes icon based on mode instead of hardcoded bus stop icon

### DIFF
--- a/app/component/OriginSelector.js
+++ b/app/component/OriginSelector.js
@@ -42,7 +42,7 @@ const OriginSelector = ({ favourites, oldSearches }) => {
       />)
       .concat(oldSearches.map(s => <OriginSelectorRow
         key={`o-${s.properties.label}`}
-        icon={getIcon(s.properties.layer)}
+        icon={getIcon(s.properties.layer, s.properties.mode)}
         label={s.properties.label}
         lat={s.geometry.coordinates[1]}
         lon={s.geometry.coordinates[0]}

--- a/app/component/SuggestionItem.js
+++ b/app/component/SuggestionItem.js
@@ -19,7 +19,7 @@ const SuggestionItem = pure((props) => {
   } else {
     icon = (
       <Icon
-        img={getIcon(props.item.properties.layer)}
+        img={getIcon(props.item.properties.layer, props.item.properties.mode)}
         className={props.item.iconClass || ''}
       />
     );

--- a/app/util/suggestionUtils.js
+++ b/app/util/suggestionUtils.js
@@ -62,14 +62,14 @@ export function uniqByLabel(features) {
   );
 }
 
-export function getIcon(layer) {
+export function getIcon(layer, mode = 'bus-stop') {
   const layerIcon = new Map([
     ['favouritePlace', 'icon-icon_star'],
     ['favouriteRoute', 'icon-icon_star'],
     ['favouriteStop', 'icon-icon_star'],
     ['favourite', 'icon-icon_star'],
     ['address', 'icon-icon_place'],
-    ['stop', 'icon-icon_bus-stop'],
+    ['stop', `icon-icon_${mode.toLowerCase()}`],
     ['locality', 'icon-icon_city'],
     ['station', 'icon-icon_station'],
     ['localadmin', 'icon-icon_city'],


### PR DESCRIPTION
Icon in splash screen should show correct icon based on mode. If mode is undefined, then use hardcoded valude 'icon-icon_bus-stop'.
