### PR TITLE
Add pointer cursor to dropdown

### DIFF
--- a/app/component/summary.scss
+++ b/app/component/summary.scss
@@ -35,6 +35,7 @@
     border-radius: 0;
     appearance: none;
     @include font-book;
+    cursor: pointer;
 
     &:hover {
       background-color: $primary-color;


### PR DESCRIPTION
Partially fixes the usability problem in #1224 that the caret is not clickable and the text does not indicate that user can click it.
