### PR TITLE
Fix tab stats

### DIFF
--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -31,6 +31,7 @@ class IndexPage extends React.Component {
     executeAction: React.PropTypes.func.isRequired,
     location: locationShape.isRequired,
     router: routerShape.isRequired,
+    piwik: React.PropTypes.object,
   };
 
   static propTypes = {
@@ -93,8 +94,8 @@ class IndexPage extends React.Component {
   }
 
   trackEvent = (...args) => {
-    if (typeof this.context.piwik === 'function') {
-      this.context.piwik(...args);
+    if (typeof this.context.piwik === 'object') {
+      this.context.piwik.trackEvent(...args);
     }
   }
 

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -108,10 +108,10 @@ class IndexPage extends React.Component {
       } else {
         this.openNearby(selected === 2);
       }
-      this.trackEvent('Front page tabs', `Nearby ${selected === 1 ? 'close' : 'open'}`);
+      this.trackEvent('Front page tabs', 'Nearby', selected === 1 ? 'close' : 'open');
     } else {
       this.openNearby(true);
-      this.trackEvent('Front page tabs', 'Nearby open (desktop)');
+      this.trackEvent('Front page tabs', 'Nearby', 'click');
     }
   };
 
@@ -124,10 +124,10 @@ class IndexPage extends React.Component {
       } else {
         this.openFavourites(selected === 1);
       }
-      this.trackEvent('Front page tabs', `Favourites ${selected === 2 ? 'close' : 'open'}`);
+      this.trackEvent('Front page tabs', 'Favourites', selected === 2 ? 'close' : 'open');
     } else {
       this.openFavourites(true);
-      this.trackEvent('Front page tabs', 'Favourites open (desktop)');
+      this.trackEvent('Front page tabs', 'Favourites', 'click');
     }
   };
 

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -108,10 +108,10 @@ class IndexPage extends React.Component {
       } else {
         this.openNearby(selected === 2);
       }
-      this.trackEvent('Front page tabs', 'Nearby', selected === 1 ? 'close' : 'open');
+      this.trackEvent('Front page tabs', `Nearby ${selected === 1 ? 'close' : 'open'}`);
     } else {
       this.openNearby(true);
-      this.trackEvent('Front page tabs', 'Nearby', 'open');
+      this.trackEvent('Front page tabs', 'Nearby open (desktop)');
     }
   };
 
@@ -124,10 +124,10 @@ class IndexPage extends React.Component {
       } else {
         this.openFavourites(selected === 1);
       }
-      this.trackEvent('Front page tabs', 'Favourites', selected === 2 ? 'close' : 'open');
+      this.trackEvent('Front page tabs', `Favourites ${selected === 2 ? 'close' : 'open'}`);
     } else {
       this.openFavourites(true);
-      this.trackEvent('Front page tabs', 'Nearby', 'open');
+      this.trackEvent('Front page tabs', 'Favourites open (desktop)');
     }
   };
 

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -111,7 +111,7 @@ class IndexPage extends React.Component {
       this.trackEvent('Front page tabs', 'Nearby', selected === 1 ? 'close' : 'open');
     } else {
       this.openNearby(true);
-      this.trackEvent('Front page tabs', 'Nearby', 'click');
+      this.trackEvent('Front page tabs', 'Nearby', 'open');
     }
   };
 
@@ -127,7 +127,7 @@ class IndexPage extends React.Component {
       this.trackEvent('Front page tabs', 'Favourites', selected === 2 ? 'close' : 'open');
     } else {
       this.openFavourites(true);
-      this.trackEvent('Front page tabs', 'Favourites', 'click');
+      this.trackEvent('Front page tabs', 'Favourites', 'open');
     }
   };
 


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.
