### PR TITLE
Do not cache index page in ServiceWorker for now

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -189,13 +189,10 @@ function getPluginsConfig(env) {
         additional: [
           ':externals:',
           'js/+([a-z0-9]).js',
-          // TODO: move the ones below back to optional after caching has been fixed.
-          'css/*.css',
-          '*.svg',
         ],
-        optional: ['js/*_theme.*.js', 'js/*_sprite.*.js', '*.png'],
+        optional: ['js/*_theme.*.js', 'js/*_sprite.*.js', '*.png', 'css/*.css', '*.svg'],
       },
-      externals: ['/'],
+      externals: [/* '/' Can be re-added later when we want to cache index page */],
       safeToUseOptionalCaches: true,
       ServiceWorker: {
         entry: './app/util/font-sw.js',


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.
