### PR TITLE
Restrict parallel tests for gemini

### DIFF
--- a/.gemini.conf.json
+++ b/.gemini.conf.json
@@ -6,7 +6,8 @@
   "retry": 3,
   "suitesPerSession": 10,
   "system": {
-    "plugins": { "browserstack": {} }
+    "plugins": { "browserstack": {} },
+    "parallelLimit": 3
   },
   "browsers": {
     "ie11": {


### PR DESCRIPTION
The PR is done - it:

- [ ] follows the style and naming rules (passes `npm run lint`)
- [ ] doesn't break anything (passes `npm run test-local` and `npm run test-browserstack`)
- [ ] design is as expected. NOTE! visuals are compared using HSL theme (`CONFIG=hsl npm run dev`).
-- If no design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual` passes
-- If design changes: `BS_USERNAME=user BS_ACCESS_KEY=key npm run test-visual-update` to generate new images
- [ ] any changed files are transformed to ES6
- [ ] all new strings visible to users are

  * [ ] added to translations file
  * [ ] are translated to English, Finnish and Swedish (if not, add translations-needed label to PR)
  
- [ ] all changed components

  * [ ] have examples
  * [ ] are included in the style guide
  * [ ] are included in the visual tests (added to gemini tests)

If this PR fixes a bug, it includes a new test that catches the bug to prevent regressions.
