### PR TITLE
changes to About page to make it more configurable

### DIFF
--- a/app/component/AboutPage.js
+++ b/app/component/AboutPage.js
@@ -12,7 +12,7 @@ const AboutPage = ({ currentLanguage }, context) => {
         {about.map((section, i) => (
           <div key={`about-section-${i}`}>
             <h1 className="about-header">{section.header}</h1>
-            {section.paragraphs && section.paragraphs.map(p => (<p key={`about-section-p-${i}`}>{p}</p>))}
+            {section.paragraphs && section.paragraphs.map((p, j) => (<p key={`about-section-${i}-p-${j}`}>{p}</p>))}
             {section.link && <Link to={section.link}>{section.link}</Link>}
           </div>
         ))}

--- a/app/component/AboutPage.js
+++ b/app/component/AboutPage.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 import React from 'react';
 import { Link } from 'react-router';
 import { FormattedMessage } from 'react-intl';
@@ -8,27 +9,13 @@ const AboutPage = ({ currentLanguage }, context) => {
   return (
     <div className="about-page fullscreen">
       <div className="page-frame fullscreen momentum-scroll">
-        <h1 id="about-header">
-          <FormattedMessage
-            id="about-this-service" defaultMessage="About this service"
-          />
-        </h1>
-        <p>{about.about}</p>
-
-        <h1>
-          <FormattedMessage
-            id="digitransit-platform" defaultMessage="Digitransit platform"
-          />
-        </h1>
-        <p>{about.digitransit}</p>
-
-        <h1>
-          <FormattedMessage
-            id="datasources" defaultMessage="Datasources"
-          />
-        </h1>
-        <p>{about.datasources}</p>
-
+        {about.map((section, i) => (
+          <div key={`about-section-${i}`}>
+            <h1 className="about-header">{section.header}</h1>
+            {section.paragraphs && section.paragraphs.map(p => (<p key={`about-section-p-${i}`}>{p}</p>))}
+            {section.link && <Link to={section.link}>{section.link}</Link>}
+          </div>
+        ))}
         <Link to="/">
           <div className="call-to-action-button">
             <FormattedMessage

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -409,23 +409,52 @@ export default {
   ],
 
   aboutThisService: {
-    fi: {
-      about: 'Palvelu kattaa joukkoliikenteen, kävelyn, pyöräilyn ja yksityisautoilun rajatuilta osin. Palvelu perustuu Digitransit palvelualustaan.',
-      digitransit: 'Digitransit palvelualusta on HSL:n ja Liikenneviraston kehittämä avoimen lähdekoodin ratkaisu, jonka taustalla toimii mm. OpenTripPlanner. Lähdekoodi tarjotaan EUPL v1.2 ja AGPLv3 lisensseillä.',
-      datasources: 'Kartat, kadut, rakennukset, pysäkkisijainnit ym. tiedot tarjoaa © OpenStreetMap contributors ja ne ladataan Geofabrik palvelusta. Osoitetiedot tuodaan VRK:n rakennustietorekisteristä ja ne ladataan OpenAddresses-palvelusta. Joukkoliikenteen reitit ja aikataulut ladataan mm. Liikenneviraston valtakunnallisesta joukkoliikenteen tietokannasta.',
-    },
+    fi: [
+      {
+        header: 'Tietoja palvelusta',
+        paragraphs: ['Palvelu kattaa joukkoliikenteen, kävelyn, pyöräilyn ja yksityisautoilun rajatuilta osin. Palvelu perustuu Digitransit palvelualustaan.'],
+      },
+      {
+        header: 'Digitransit palvelualusta',
+        paragraphs: ['Digitransit palvelualusta on HSL:n ja Liikenneviraston kehittämä avoimen lähdekoodin ratkaisu, jonka taustalla toimii mm. OpenTripPlanner. Lähdekoodi tarjotaan EUPL v1.2 ja AGPLv3 lisensseillä.'],
+      },
+      {
+        header: 'Tietolähteet',
+        paragraphs: ['Kartat, kadut, rakennukset, pysäkkisijainnit ym. tiedot tarjoaa © OpenStreetMap contributors ja ne ladataan Geofabrik palvelusta. Osoitetiedot tuodaan VRK:n rakennustietorekisteristä ja ne ladataan OpenAddresses-palvelust' +
+        'a. Joukkoliikenteen reitit ja aikataulut ladataan mm. Liikenneviraston valtakunnallisesta joukkoliikenteen tietokannasta.'],
+      },
+    ],
 
-    sv: {
-      about: 'Reseplaneraren täcker med vissa begränsningar kollektivtrafik, promenad, cykling samt privatbilism. Tjänsten baserar sig på Digitransit-plattformen.',
-      digitransit: 'Digitransit-plattformen är en öppen programvara utvecklad av HRT och Trafikverket, som bl.a. stödjer sig på OpenTripPlanner. Källkoden distribueras under EUPL v1.2 och AGPLv3 licenserna.',
-      datasources: 'Kartor, gator, byggnader, hållplatser och dylik information erbjuds av © OpenStreetMap contributors och laddas ned från Geofabrik-tjänsten. Addressinformation hämtas från BRC:s byggnadsinformationsregister och laddas ned från OpenAddresses-tjänsten. Kollektivtrafikens rutter och tidtabeller hämtas bl.a. från Trafikverkets landsomfattande kollektivtrafiksdatabas.',
-    },
+    sv: [
+      {
+        header: 'Om tjänsten',
+        paragraphs: ['Reseplaneraren täcker med vissa begränsningar kollektivtrafik, promenad, cykling samt privatbilism. Tjänsten baserar sig på Digitransit-plattformen.'],
+      },
+      {
+        header: 'Digitransit-plattformen',
+        paragraphs: ['Digitransit-plattformen är en öppen programvara utvecklad av HRT och Trafikverket, som bl.a. stödjer sig på OpenTripPlanner. Källkoden distribueras under EUPL v1.2 och AGPLv3 licenserna.'],
+      },
+      {
+        header: 'Datakällor',
+        paragraphs: ['Kartor, gator, byggnader, hållplatser och dylik information erbjuds av © OpenStreetMap contributors och laddas ned från Geofabrik-tjänsten. Addressinformation hämtas från BRC:s byggnadsinformationsregister och laddas ned fr' +
+        'ån OpenAddresses-tjänsten. Kollektivtrafikens rutter och tidtabeller hämtas bl.a. från Trafikverkets landsomfattande kollektivtrafiksdatabas.'],
+      },
+    ],
 
-    en: {
-      about: 'The service covers public transport, walking, cycling, and some private car use. Service is built on Digitransit platform.',
-      digitransit: 'Digitransit service platform is created by HSL and Finnish Transport Agency, built on top of e.g. OpenTripPlanner. The source code of the platform is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.',
-      datasources: "Maps, streets, buildings, stop locations etc. from © OpenStreetMap contributors downloaded from Geofabrik. Additional address data from Finland's Population Register Centre downloaded from OpenAddresses Public transport routes and timetables from Finnish Transport Agency's national public transit database.",
-    },
+    en: [
+      {
+        header: 'About this service',
+        paragraphs: ['The service covers public transport, walking, cycling, and some private car use. Service is built on Digitransit platform.'],
+      },
+      {
+        header: 'Digitransit platform',
+        paragraphs: ['Digitransit service platform is created by HSL and Finnish Transport Agency, built on top of e.g. OpenTripPlanner. The source code of the platform is dual-licensed under the EUPL v1.2 and AGPLv3 licenses.'],
+      },
+      {
+        header: 'Datasources',
+        paragraphs: ['Maps, streets, buildings, stop locations etc. from © OpenStreetMap contributors downloaded from Geofabrik. Additional address data from Finland\'s Population Register Centre downloaded from OpenAddresses Public transport routes and timetables from Finnish Transport Agency\'s national public transit database.'],
+      },
+    ],
 
     nb: {},
     fr: {},

--- a/test/flow/page_object/about.js
+++ b/test/flow/page_object/about.js
@@ -8,6 +8,6 @@ module.exports = {
     verifyPage,
   }],
   elements: {
-    aboutHeader: '#about-header',
+    aboutHeader: '.about-header:nth-of-type(1)',
   },
 };


### PR DESCRIPTION
Changes to AboutPage to make it more configurable. Each project is independent and adding translations to translations.js for hardcoded values make less sense. This change makes it possible to have several headers and more paragraphs beneath that. Added a configurable link as well. I have only changed config.default.js to demonstrate setup.