### PR TITLE
Fix layout bug if no route found

### DIFF
--- a/app/component/summary.scss
+++ b/app/component/summary.scss
@@ -7,7 +7,7 @@
 }
 
 .summary-no-route-found {
-    margin: 1em;
+    padding: 1em;
 }
 
 .time-selectors {


### PR DESCRIPTION
If no route was found the “no route  found” message caused the page to be scrollable sideways on mobile.