### PR TITLE
Fix layout bug where disruption icon is absolute-postioned to wrong container

### DIFF
--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -556,6 +556,7 @@ div.route-tabs {
     border-bottom: 1px solid $light-gray;
     display: flex;
     padding: 0.8em 0.8em 0.8em 0.8em;
+    position: relative;
 
     .icon.caution {
       fill: $cancelation-red;


### PR DESCRIPTION
This only manifests itself when the disruption list for a route is scrollable. ITC the alert triangles remained absolutely positioned with the viewport and did not scroll with the list.