### PR TITLE
Replace swedish translation of 'to-stop' message

### DIFF
--- a/app/translations.js
+++ b/app/translations.js
@@ -1202,7 +1202,7 @@ const translations = {
     'tickets': 'Biljetter',
     'time': 'Tid',
     'timetable': 'Tidtabell',
-    'to-stop': 'Till hållplats',
+    'to-stop': 'Avstånd',
     'today': 'I dag',
     'tomorrow': 'I morgon',
     'train-with-route-number': 'Tåg {routeNumber} {headSign}',


### PR DESCRIPTION
“Till hållplats” is too long to fit where it is used, replace with “Avstånd”