### PR TITLE
feat: always show disruption info button

### DIFF
--- a/app/component/DisruptionInfoButtonContainer.js
+++ b/app/component/DisruptionInfoButtonContainer.js
@@ -23,11 +23,11 @@ function DisruptionInfoButtonContainer(props, { router, location }) {
         forceFetch
         queryConfig={new ViewerRoute()}
         environment={Relay.Store}
-        render={({ done, renderProps }) => (done ? (
+        render={({ renderProps }) => (
           <DisruptionInfoButton
             {...renderProps}
             toggleDisruptionInfo={openDisruptionInfo}
-          />) : undefined
+          />
         )}
       />);
   }

--- a/app/component/MainMenu.js
+++ b/app/component/MainMenu.js
@@ -28,13 +28,13 @@ function MainMenu(props, context) {
         {config.mainMenu.showInquiry && inquiry}
       </header>
       <div className="offcanvas-section">
-        {config.mainMenu.showDisruptions && props.showDisruptionInfo &&
-          <DisruptionInfoButtonContainer />}
-      </div>
-      <div className="offcanvas-section">
         <Link id="frontpage" to="/">
           <FormattedMessage id="frontpage" defaultMessage="Frontpage" />
         </Link>
+      </div>
+      <div className="offcanvas-section">
+        {config.mainMenu.showDisruptions && props.showDisruptionInfo &&
+          <DisruptionInfoButtonContainer />}
       </div>
       <MainMenuLinks
         content={([config.appBarLink].concat(config.footer && config.footer.content) || [])


### PR DESCRIPTION
Disruption info button renders without the icon when there are no alerts (i.e. also when loading).