### PR TITLE
Improve timepicker appearance when editing

### DIFF
--- a/app/component/TimeInput.js
+++ b/app/component/TimeInput.js
@@ -48,7 +48,6 @@ class TimeInput extends Component {
         className="text-time-selector"
         defaultValue={this.props.value}
         onChange={this.onChange}
-        onClick={() => { this.refs.time.select(); }}
         maxLength="5"
         style={{
           display: 'inline-block',

--- a/app/component/summary.scss
+++ b/app/component/summary.scss
@@ -142,6 +142,11 @@
     }
   }
 
+  input[type="time"]:focus, input[type="text"]:focus {
+    background-color: $white;
+    color: $black;
+  }
+
   .right-offcanvas-toggle {
       span {
         color: $primary-font-color;


### PR DESCRIPTION
The current way of editing time in desktop browser is bad because it does not clearly indicate that user should directly edit the field as the previous timepicker component is no longer in use. This PR improves the current situation as follows:

1) Disable selecting all the text in the field to make it act as a typical input field (cursor blinks)
2) Use white background and black text when the field is active

The result in Firefox (`type="text"`):
![timepicker-ff](https://cloud.githubusercontent.com/assets/2797729/22857376/b554d9c8-f0ac-11e6-839b-4bdc46c1076d.png)
There is a little glitch as the input component does not fully take the space because of the padding of the parent container.

The result in Chrome (`type="time"`)
![timepicker-chrome](https://cloud.githubusercontent.com/assets/2797729/22857377/b9092632-f0ac-11e6-87bd-a0e2ba90d01e.png)
White background also hides the incorrect caret symbol.

Unfortunately the timepicker component in Chrome is unintuitive to use and not as good as in mobile browsers.
