### PR TITLE
Only apply overflow-fade on search-header__button's contents

### DIFF
--- a/app/component/search.scss
+++ b/app/component/search.scss
@@ -512,12 +512,10 @@ div.origin-destination-bar {
     font-size: $font-size-small !important;
     font-weight: $font-weight-bold !important;
 
-    &:first-child {
-      @extend .overflow-fade;
-    }
-
-    // Uh-oh, override material-ui style for not overflowing the beginning of the word
     > div > div {
+      @extend .overflow-fade;
+
+      // Uh-oh, override material-ui style for not overflowing the beginning of the word
       align-items: stretch !important;
       height: 3.5em !important;
     }


### PR DESCRIPTION
This fixes the right edge of the ORIGIN button click animation appearing
as a fading out gradient.

Additionally, this fixes overflowing text on the SEARCH button on very
narrow screens since `@extend: .overflow-fade;` is applied to all
children.

### Before
![before](https://i.imgur.com/yU0rxoE.png)

### After
![after](http://i.imgur.com/O0aC950.png)