### PR TITLE
Allow building with a selected theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ More information about [testing](docs/Tests.md).
 * [Z-Index Index](docs/ZIndex.md)
 * [Benchmark results and UX](docs/JSBenchmark.md)
 * [Navigation](docs/Navigation.md)
+* [Themes](docs/Themes.md)

--- a/app/client.js
+++ b/app/client.js
@@ -82,8 +82,12 @@ const callback = () => app.rehydrate(window.state, (err, context) => {
   window.context = context;
 
   if (process.env.NODE_ENV === 'development') {
-  // eslint-disable-next-line global-require, import/no-dynamic-require
-    require(`../sass/themes/${config.CONFIG}/main.scss`);
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    try {
+      require(`../sass/themes/${config.CONFIG}/main.scss`);
+    } catch (error) {
+      require(`../sass/themes/default/main.scss`);
+    }
   }
 
   Relay.injectNetworkLayer(new RelayNetworkLayer([

--- a/app/client.js
+++ b/app/client.js
@@ -82,11 +82,12 @@ const callback = () => app.rehydrate(window.state, (err, context) => {
   window.context = context;
 
   if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line global-require, import/no-dynamic-require
     try {
+      // eslint-disable-next-line global-require, import/no-dynamic-require
       require(`../sass/themes/${config.CONFIG}/main.scss`);
     } catch (error) {
-      require(`../sass/themes/default/main.scss`);
+      // eslint-disable-next-line global-require, import/no-dynamic-require
+      require('../sass/themes/default/main.scss');
     }
   }
 

--- a/app/configurations/config.lahti.js
+++ b/app/configurations/config.lahti.js
@@ -2,7 +2,7 @@ import configMerger from '../util/configMerger';
 
 const CONFIG = 'lahti';
 const APP_TITLE = 'Uusi Reittiopas';
-const APP_DESCRIPTION = 'Uusi Reittiopas - lahti';
+const APP_DESCRIPTION = 'Uusi Reittiopas - Lahti';
 
 const walttiConfig = require('./waltti').default;
 

--- a/docs/Themes.md
+++ b/docs/Themes.md
@@ -1,0 +1,52 @@
+# Custom themes and configurations
+
+Appearance and behavior of digitransit-ui can be customized by:
+- Creating a custom config file to a path `app/configurations/config.<theme>.js`
+- Optionally adding custom style definitions to `sass/themes/<theme>` folder
+- If dynamic theme mapping to the new theme is desired, the new theme must be added to the
+theme map found in `app/configurations/config.default.js`
+
+Check the existing themes such as 'oulu' for details. There is a npm script for initializing all three steps above
+with a single command:
+
+- `npm run add-theme <name> '#RRGGBB' <optional navbar logo>`
+
+After running the command, the created skeleton files can be edited further.
+
+
+## Dynamic theme mapping
+
+The UI can change the theme per request. This happens by defining how host names are mapped to theme names. See config.default.js
+for details.
+
+
+## Themes in development mode
+
+Dynamic theme mapping is not available when the UI server is launched as 'npm run dev'. The desired theme can de selected as:
+- `CONFIG=<theme> npm run dev`
+
+
+## Themes in production mode
+
+Dynamic theme mapping is available by default in production mode i.e. when the app is launched using `npm start` command. A single
+selected theme can be forced by setting the `CONFIG` env. variable:
+- `CONFIG=<theme> npm start`
+
+
+## Building the production version
+
+The build command `npm run build` collects all existing themes found from `app/configurations` folder. To build with a single theme,
+use the command:
+
+- `CONFIG=<theme> npm run build`
+
+To avoid illegal references to nonexistent themes, such a limited build could be run as:
+
+- `CONFIG=<theme> npm start`
+
+
+
+
+
+
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -273,12 +273,6 @@ function getPluginsConfig(env) {
   ]);
 }
 
-function getDirectories(srcDirectory) {
-  return fs.readdirSync(srcDirectory).filter(file =>
-    fs.statSync(path.join(srcDirectory, file)).isDirectory() // eslint-disable-line comma-dangle
-  );
-}
-
 function getDevelopmentEntry() {
   const entry = [
     'webpack-dev-server/client?http://localhost:' + port,
@@ -311,20 +305,11 @@ function getEntry() {
 
     addEntry('default');
     addEntry(process.env.CONFIG, config.sprites);
-    return entry;
+  } else {
+    getAllConfigs().forEach((config) => {
+      addEntry(config.CONFIG, config.sprites);
+    });
   }
-
-  const spriteMap = {};
-  getAllConfigs().forEach((config) => {
-    spriteMap[config.CONFIG] = config.sprites; // assign also undefined/null
-  });
-
-  const directories = getDirectories('./sass/themes');
-  directories.forEach((theme) => {
-    if (theme in spriteMap) {
-      addEntry(theme, spriteMap[theme]);
-    }
-  });
 
   return entry;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,7 +95,7 @@ function getRulesConfig(env) {
 }
 
 function getAllConfigs() {
-  if (process.env.CONFIG !== '') {
+  if (process.env.CONFIG && process.env.CONFIG !== '') {
     return [require('./app/config').getNamedConfiguration(process.env.CONFIG)];
   }
 
@@ -301,12 +301,14 @@ function getEntry() {
     main: './app/client',
   };
 
-  if (process.env.CONFIG !== '') {
+  const addEntry = (theme, sprites) => {
+    entry[theme + '_theme'] = ['./sass/themes/' + theme + '/main.scss'];
+    entry[theme + '_sprite'] = ['./static/' + (sprites || '/svg-sprite.' + theme + '.svg')];
+  };
+
+  if (process.env.CONFIG && process.env.CONFIG !== '') {
     const config = require('./app/config').getNamedConfiguration(process.env.CONFIG);
-    const addEntry = (theme, sprites) => {
-      entry[theme + '_theme'] = ['./sass/themes/' + theme + '/main.scss'];
-      entry[theme + '_sprite'] = ['./static/' + (sprites || '/svg-sprite.' + theme + '.svg')];
-    };
+
     addEntry('default');
     addEntry(process.env.CONFIG, config.sprites);
     return entry;
@@ -320,11 +322,7 @@ function getEntry() {
   const directories = getDirectories('./sass/themes');
   directories.forEach((theme) => {
     if (theme in spriteMap) {
-      const sassEntryPath = './sass/themes/' + theme + '/main.scss';
-      entry[theme + '_theme'] = [sassEntryPath];
-      const svgEntryPath = spriteMap[theme] ? './static/' + spriteMap[theme] :
-          './static/svg-sprite.' + theme + '.svg';
-      entry[theme + '_sprite'] = [svgEntryPath];
+      addEntry(theme, spriteMap[theme]);
     }
   });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -296,7 +296,11 @@ function getEntry() {
   };
 
   const addEntry = (theme, sprites) => {
-    entry[theme + '_theme'] = ['./sass/themes/' + theme + '/main.scss'];
+    let themeCss = './sass/themes/' + theme + '/main.scss';
+    if (!fs.existsSync(themeCss)) {
+      themeCss = './sass/themes/default/main.scss';
+    }
+    entry[theme + '_theme'] = [themeCss];
     entry[theme + '_sprite'] = ['./static/' + (sprites || '/svg-sprite.' + theme + '.svg')];
   };
 


### PR DESCRIPTION
If CONFIG env var is set, npm build collects only the defined theme together with the default theme into the build. 

Custom configurations no longer require a matching scss theme, but  automatically use the default styles in absence of the scss  theme folder.
 
This PR includes https://github.com/HSLdevcom/digitransit-ui/pull/1404
