### PR TITLE
Make intro views more accessible for screen reader users

### DIFF
--- a/app/component/Intro.js
+++ b/app/component/Intro.js
@@ -43,8 +43,9 @@ export default class Intro extends React.Component {
       key={i}
       tabIndex={0}
       onClick={this.onNextClick}
+      role="main"
     >
-      <img alt="" aria-hidden="true" src={content.image} role="presentation" />
+      <img alt="" aria-hidden="true" src={content.image} />
       <h3>{content.header[this.context.intl.locale]}</h3>
       <span>{content.text[this.context.intl.locale]}</span>
     </button>

--- a/app/component/Intro.js
+++ b/app/component/Intro.js
@@ -51,10 +51,12 @@ export default class Intro extends React.Component {
 
 
   renderDot = (text, i) =>
-    <span key={i} className={cx('dot', { active: i === this.state.slideIndex })}>•</span>
+    <span key={i} className={cx('dot', { active: i === this.state.slideIndex })} aria-hidden="true">•</span>
 
   render() {
     const themeSlides = slides[this.context.config.CONFIG] || [];
+    const screenreaderInfoStyle = { position: 'absolute', left: -10000, top: 'auto', height: '1px', width: '1px', overflow: 'hidden' };
+
     return (
       <div className="flex-vertical intro-slides">
         <BindKeyboardSwipeableViews
@@ -73,6 +75,7 @@ export default class Intro extends React.Component {
         </BindKeyboardSwipeableViews>
         <div className={cx('bottom', { hidden: this.state.slideIndex === themeSlides.length })} >
           {[...themeSlides, this.props.finalSlide].map(this.renderDot)}
+          <span style={screenreaderInfoStyle} role="paragraph"> {this.state.slideIndex + 1}/{themeSlides.length} </span>
           <button tabIndex={(this.state.slideIndex)}className="next noborder" onClick={this.onNextClick}>
             <FormattedMessage id="next" defaultMessage="next" />
           </button>


### PR DESCRIPTION
With a little fizes the intro views are more accessible for screen reader users. 


I add "a breadcrumb" (now a span element like x/y) which is hidden for sighted users by CSS but screen readers see it. It tells to blind screen reader users information of their location on intro views. Dots, which get the same information for sighted users, don't work for the blind and that's why I also hidden the dots for screen readers using aria-hidden attribute.

The content of intro views (title and text) are inside a button element. Screen readers read them just one element, a button, and don't find any headings from the page. I add the main role (role="main") for the button element: that's way screen readers find both, heading and text right. 
