### PR TITLE
NRP-1270: fix updates set in production the same day

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -257,6 +257,7 @@ function getPluginsConfig(env) {
       AppCache: {
         caches: ['main', 'additional', 'optional'],
       },
+      version: '[hash]',
     }),
     new GzipCompressionPlugin({
       asset: '[path].gz[query]',


### PR DESCRIPTION
Change caching version from 'CurrentDate' to 'hash', which fixes a problem with multiple deployments the same day (hotfixes etc.).