### PR TITLE
Reorder piwik id mapping to avoid accidental matches

### DIFF
--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -475,14 +475,18 @@ export default {
   },
 
   piwikMap: [ // in priority order. 1st match stops
-    { id: '5', expr: 'dev.reittiopas' },
-    { id: '4', expr: 'reittiopas' },
-    { id: '7', expr: 'dev.matka|dev.digitransit' },
-    { id: '6', expr: 'matka|digitransit' },
     { id: '10', expr: 'dev-joensuu' },
     { id: '11', expr: 'joensuu' },
     { id: '12', expr: 'dev-turku' },
     { id: '13', expr: 'turku' },
+    // put generic expressions last so that they do not match waltti cities
+    // e.g. reittiopas.hameenlinna.fi or turku.digitransit.fi
+    { id: '5', expr: 'dev.reittiopas' },
+    { id: '4', expr: 'reittiopas' },
+    { id: '7', expr: 'dev.matka' },
+    { id: '6', expr: 'matka' },
+    { id: '7', expr: 'dev.digitransit' },
+    { id: '6', expr: 'digitransit' },
   ],
 
   minutesToDepartureLimit: 9,


### PR DESCRIPTION
'digitransit' which was ment for matka.fi matched all waltti cities.
Also reittiopas will be present in many domain names.
Reordering the regex array fixes the problem.
