### PR TITLE
makes max and min zoom configurable

### DIFF
--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -184,7 +184,8 @@ class Map extends React.Component {
           ref="map"
           center={center}
           zoom={zoom}
-          minZoom={1}
+          minZoom={this.context.config.map.minZoom}
+          maxZoom={this.context.config.map.maxZoom}
           zoomControl={false}
           attributionControl={false}
           bounds={(this.props.fitBounds && boundWithMinimumArea(this.props.bounds)) || undefined}
@@ -199,6 +200,8 @@ class Map extends React.Component {
             zoomOffset={config.map.zoomOffset || 0}
             updateWhenIdle={false}
             size={(config.map.useRetinaTiles && L.Browser.retina) ? '@2x' : ''}
+            minZoom={this.context.config.map.minZoom}
+            maxZoom={this.context.config.map.maxZoom}
           />
           <AttributionControl
             position="bottomleft"

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -101,6 +101,8 @@ export default {
     useRetinaTiles: true,
     tileSize: 512,
     zoomOffset: -1,
+    minZoom: 1,
+    maxZoom: 18,
     useVectorTiles: true,
 
     genericMarker: {


### PR DESCRIPTION
Makes it possible to configure maxZoom (and minZoom) on map. React-leaflet has an error, so zoom has to be configured on <TileLayer as well. 