### PR TITLE
Improve time editing

### DIFF
--- a/app/component/TimeInput.js
+++ b/app/component/TimeInput.js
@@ -48,11 +48,12 @@ class TimeInput extends Component {
         className="text-time-selector"
         defaultValue={this.props.value}
         onChange={this.onChange}
-        onClick={() => { this.refs.time.select(); }}
+        onFocus={() => { this.refs.time.select(); }}
         maxLength="5"
         size="5"
         style={{
           display: 'inline-block',
+          cursor: 'text',
         }}
       />
     );


### PR DESCRIPTION
Currently, it is impossible to see the cursor by using mouse because every click selects all the text and prevents the cursor to be visible. This modification changes the behavior so that when the field is clicked for the first time, all the text is selected but another click will make the cursor visible because the field already have focus. Also, the cursor suggest that this is a field which is edited in place. These are the most urgent fixes if #1335 is not moving forward.