### PR TITLE
Expect only defined name, not full label

### DIFF
--- a/test/flow/tests/itinerary-search/itinerary-search.js
+++ b/test/flow/tests/itinerary-search/itinerary-search.js
@@ -15,8 +15,8 @@ module.exports = {
 
     const itineraryInstructions = browser.page.itineraryInstructions();
     itineraryInstructions.waitForFirstItineraryInstructionColumn();
-    itineraryInstructions.verifyOrigin('Helsingin rautatieasema, Helsinki');
-    itineraryInstructions.verifyDestination('Narinkkatori, Helsinki');
+    itineraryInstructions.verifyOrigin('Helsingin rautatieasema');
+    itineraryInstructions.verifyDestination('Narinkkatori');
     browser.end();
   },
 


### PR DESCRIPTION
Because labeling conventions tend to change. Helsingin rautatieasema
is uniquely defined without the city name at the end.