### PR TITLE
NRP-1155: remove favourite duplicates in splash/origin selector  

### DIFF
--- a/app/component/OriginSelector.js
+++ b/app/component/OriginSelector.js
@@ -38,6 +38,11 @@ OriginSelectorRow.contextTypes = {
 };
 
 const OriginSelector = ({ favourites, oldSearches }, { config }) => {
+  const notInFavourites = item => favourites.filter(favourite =>
+  favourite.address === item.properties.address &&
+  favourite.lat === item.properties.lat &&
+  favourite.lon === item.properties.lon).length === 0;
+
   const names = favourites.map(
       f => <OriginSelectorRow
         key={`f-${f.locationName}`}
@@ -46,7 +51,7 @@ const OriginSelector = ({ favourites, oldSearches }, { config }) => {
         lat={f.lat}
         lon={f.lon}
       />)
-      .concat(oldSearches.map(s => <OriginSelectorRow
+      .concat(oldSearches.filter(notInFavourites).map(s => <OriginSelectorRow
         key={`o-${s.properties.label}`}
         icon={getIcon(s.properties.layer)}
         label={s.properties.label}


### PR DESCRIPTION
Favourites are also in the oldSearches list. This fix filters oldSearches before being added to the OriginSelector.

![screen shot 2017-03-13 at 10 17 48](https://cloud.githubusercontent.com/assets/15194982/23848880/6a33125e-07d9-11e7-9cfa-be510d41ce82.png)

Console.log of - favourites and oldSearches in `app/component/OriginSelector.js`
![screen shot 2017-03-13 at 08 17 20](https://cloud.githubusercontent.com/assets/15194982/23848881/6a3410dc-07d9-11e7-8211-85885a6be93a.png)

