### PR TITLE
Fix agency links without protocol

### DIFF
--- a/app/component/AgencyInfo.js
+++ b/app/component/AgencyInfo.js
@@ -4,11 +4,13 @@ import ExternalLink from './ExternalLink';
 
 function AgencyInfo({ agencyName, url }) {
   if (agencyName && url) {
+    const link = (url.indexOf('://') === -1) ? `//${url}` : url;
+
     return (
       <div className="agency-link-container">
         <ExternalLink
           className="agency-link"
-          href={url}
+          href={link}
         ><div className={agencyName.length > 30 ? 'overflow-fade' : ''}>{agencyName}</div></ExternalLink>
       </div>);
   }


### PR DESCRIPTION
The root cause is a data issue, but it doesn’t hurt to have some degree of sanity on our side. If we have an external link component it should never direct you to a relative path.