### PR TITLE
Don't cancel user's search interaction by a geolocation change

### DIFF
--- a/app/action/EndpointActions.js
+++ b/app/action/EndpointActions.js
@@ -44,7 +44,7 @@ export function setEndpoint(actionContext, payload) {
 }
 
 export function setUseCurrent(actionContext, payload) {
-  actionContext.dispatch('useCurrentPosition', payload.target);
+  actionContext.dispatch('useCurrentPosition', payload);
   return actionContext.executeAction(route, payload);
 }
 

--- a/app/component/GeopositionSelector.js
+++ b/app/component/GeopositionSelector.js
@@ -23,6 +23,7 @@ const GeopositionSelector = ({ origin, status, searchModalIsOpen }, context) => 
     && !searchModalIsOpen && !origin.userSetPosition && !origin.useCurrentPosition) {
     context.executeAction(setUseCurrent, {
       target: 'origin',
+      keepSelectedLocation: true, // don't overwrite if user has already set a location
       router: context.router,
       location: context.location,
     });

--- a/app/component/SplashOrChildren.js
+++ b/app/component/SplashOrChildren.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import connectToStores from 'fluxible-addons-react/connectToStores';
+import { locationShape } from 'react-router';
 import Splash from './Splash';
 
 import { getIntroShown, setIntroShown } from '../store/localStorage';
@@ -13,6 +14,7 @@ class SplashOrComponent extends React.Component {
 
   static contextTypes = {
     config: React.PropTypes.object.isRequired,
+    location: locationShape.isRequired,
   };
 
   constructor(props, { config }) {
@@ -29,7 +31,10 @@ class SplashOrComponent extends React.Component {
   }
 
   render() {
-    if (!this.props.displaySplash && !this.state.shouldShowIntro) {
+    const location = this.context.location;
+    const searchOpen = location && location.state && location.state.oneTabSearchModalOpen;
+
+    if (!this.props.displaySplash && !searchOpen && !this.state.shouldShowIntro) {
       return this.props.children;
     }
     return (

--- a/app/store/EndpointStore.js
+++ b/app/store/EndpointStore.js
@@ -138,10 +138,12 @@ class EndpointStore extends Store {
     }
   }
 
-  useCurrentPosition(target) {
-    if (target === 'destination') {
-      this.setDestinationToCurrent();
-    } else {
+  useCurrentPosition(payload) {
+    if (payload.target === 'destination') {
+      if (!this.destination.userSetPosition || !payload.keepSelectedLocation) {
+        this.setDestinationToCurrent();
+      }
+    } else if (!this.origin.userSetPosition || !payload.keepSelectedLocation) {
       this.setOriginToCurrent();
       this.emitChange('origin-use-current');
     }


### PR DESCRIPTION
Delayed response for setting user's initial geolocation no longer closes the splash screen, if user has already started defining a location using the search modal.
- If user enters an address, it will be used as the start point
- If user closes the search modal without entering an address, geolocation will be used immediately after closing the modal.