### PR TITLE
Ie11 slider reset fix

### DIFF
--- a/app/component/CustomizeSearch.js
+++ b/app/component/CustomizeSearch.js
@@ -406,7 +406,6 @@ class CustomizeSearch extends React.Component {
   }
 
   resetParameters = () => {
-    console.log('resetParameters');
     resetCustomizedSettings();
     this.setState({
       walkSpeed: mapToSlider(defaultSettings.walkSpeed, this.walkingSpeedSliderValues),

--- a/app/component/CustomizeSearch.js
+++ b/app/component/CustomizeSearch.js
@@ -406,6 +406,7 @@ class CustomizeSearch extends React.Component {
   }
 
   resetParameters = () => {
+    console.log('resetParameters');
     resetCustomizedSettings();
     this.setState({
       walkSpeed: mapToSlider(defaultSettings.walkSpeed, this.walkingSpeedSliderValues),

--- a/app/component/CustomizeSearch.js
+++ b/app/component/CustomizeSearch.js
@@ -83,7 +83,6 @@ class CustomizeSearch extends React.Component {
     this.state = {
       accessibilityOption: 0,
       minTransferTime: 0,
-      modes: [],
       walkBoardCost: 0,
       walkReluctance: 0,
       walkSpeed: 0,

--- a/app/component/ResetCustomizedSettingsButton.js
+++ b/app/component/ResetCustomizedSettingsButton.js
@@ -14,8 +14,8 @@ class ResetCustomizedSettingsButton extends React.Component {
   render() {
     return (
       <section className="offcanvas-section">
-        <button className="reset-settings">
-          <div className="reset-settings-button" onClick={this.resetSettings}>
+        <button className="reset-settings"  onClick={this.resetSettings}>
+          <div className="reset-settings-button">
             <FormattedMessage
               defaultMessage="Palauta oletusasetukset"
               id="settings-reset"

--- a/app/component/ResetCustomizedSettingsButton.js
+++ b/app/component/ResetCustomizedSettingsButton.js
@@ -14,7 +14,7 @@ class ResetCustomizedSettingsButton extends React.Component {
   render() {
     return (
       <section className="offcanvas-section">
-        <button className="reset-settings"  onClick={this.resetSettings}>
+        <button className="reset-settings" onClick={this.resetSettings}>
           <div className="reset-settings-button">
             <FormattedMessage
               defaultMessage="Palauta oletusasetukset"

--- a/app/component/Slider.js
+++ b/app/component/Slider.js
@@ -81,7 +81,8 @@ class Slider extends React.Component {
           min={this.props.min}
           max={this.props.max}
           step={this.props.step}
-          onInput={(e) => { this.props.onSliderChange(e); }}
+          onMouseUp={(e) => { this.props.onSliderChange(e); }}
+          onChange={(e) => { this.props.onSliderChange(e); }}
           value={this.props.value}
         />
         <span className="sub-header-h5 left">{this.props.minText}</span>

--- a/app/routes.js
+++ b/app/routes.js
@@ -146,8 +146,8 @@ function getSettings() {
     modes: custSettings.modes ? custSettings.modes
         .toString()
         .split(',')
-        .sort()
         .map(mode => (mode === 'CITYBIKE' ? 'BICYCLE_RENT' : mode))
+        .sort()
         .join(',') : undefined,
     minTransferTime: custSettings.minTransferTime ? Number(custSettings.minTransferTime)
       : undefined,
@@ -182,8 +182,8 @@ export default (config) => {
       numItineraries: numItineraries ? Number(numItineraries) : undefined,
       modes: modes ? modes
         .split(',')
-        .sort()
         .map(mode => (mode === 'CITYBIKE' ? 'BICYCLE_RENT' : mode))
+        .sort()
         .join(',')
       : settings.modes,
       date: time ? moment(time * 1000).format('YYYY-MM-DD') : undefined,


### PR DESCRIPTION
Fixes the functionality of the sliders in IE11 and allows the user to reset their settings. Note: React has issues with firing events in IE11 so the onChange is necessary in order to let the settings return to their default positions after reset. As a flipside this causes more load on the servers but since value is the attribute used in controlling sliders remotely, it's the best solution for the time being.