### PR TITLE
Fixed the empty coordinate bug

### DIFF
--- a/app/component/RouteMapContainer.js
+++ b/app/component/RouteMapContainer.js
@@ -61,7 +61,10 @@ function RouteMapContainer({ pattern, trip, vehicles, routes }, { router, locati
       className={'full'}
       leafletObjs={leafletObjs}
       fitBounds={fitBounds}
-      bounds={(pattern.geometry || pattern.stops).map(p => [p.lat, p.lon])}
+      bounds={(
+        pattern.geometry.filter(point => (point.lat != null && point.lon != null)) ||
+        pattern.stops).map(p => [p.lat, p.lon],
+      )}
       zoom={zoom}
       showScaleBar={showScale}
     >

--- a/app/component/RouteMapContainer.js
+++ b/app/component/RouteMapContainer.js
@@ -62,7 +62,7 @@ function RouteMapContainer({ pattern, trip, vehicles, routes }, { router, locati
       leafletObjs={leafletObjs}
       fitBounds={fitBounds}
       bounds={(
-        pattern.geometry.filter(point => (point.lat != null && point.lon != null)) ||
+        pattern.geometry.filter(point => (point.lat !== null && point.lon !== null)) ||
         pattern.stops).map(p => [p.lat, p.lon],
       )}
       zoom={zoom}

--- a/app/component/map/Line.js
+++ b/app/component/map/Line.js
@@ -47,6 +47,9 @@ export default class Line extends React.Component {
   render() {
     const className = cx([this.props.mode, { thin: this.props.thin }]);
 
+    const filteredPoints =
+      this.props.geometry.filter(point => point.lat != null && point.lot !== null);
+
     const lineConfig = this.context.config.map.line;
     let haloWeight = this.props.thin ? lineConfig.halo.thinWeight : lineConfig.halo.weight;
     let legWeight = this.props.thin ? lineConfig.leg.thinWeight : lineConfig.leg.weight;
@@ -61,7 +64,7 @@ export default class Line extends React.Component {
         <Polyline
           key="halo"
           ref={(el) => { this.halo = el; }}
-          positions={this.props.geometry}
+          positions={filteredPoints}
           className={`leg-halo ${className}`}
           weight={haloWeight}
           interactive={false}
@@ -69,7 +72,7 @@ export default class Line extends React.Component {
         <Polyline
           key="line"
           ref={(el) => { this.line = el; }}
-          positions={this.props.geometry}
+          positions={filteredPoints}
           className={`leg ${className}`}
           color={this.props.passive ? '#758993' : 'currentColor'}
           weight={legWeight}

--- a/app/component/map/Line.js
+++ b/app/component/map/Line.js
@@ -47,9 +47,6 @@ export default class Line extends React.Component {
   render() {
     const className = cx([this.props.mode, { thin: this.props.thin }]);
 
-    const filteredPoints =
-      this.props.geometry.filter(point => point.lat != null && point.lot !== null);
-
     const lineConfig = this.context.config.map.line;
     let haloWeight = this.props.thin ? lineConfig.halo.thinWeight : lineConfig.halo.weight;
     let legWeight = this.props.thin ? lineConfig.leg.thinWeight : lineConfig.leg.weight;
@@ -64,7 +61,7 @@ export default class Line extends React.Component {
         <Polyline
           key="halo"
           ref={(el) => { this.halo = el; }}
-          positions={filteredPoints}
+          positions={this.props.geometry.filter(point => point.lat !== null && point.lon !== null)}
           className={`leg-halo ${className}`}
           weight={haloWeight}
           interactive={false}
@@ -72,7 +69,7 @@ export default class Line extends React.Component {
         <Polyline
           key="line"
           ref={(el) => { this.line = el; }}
-          positions={filteredPoints}
+          positions={this.props.geometry.filter(point => point.lat !== null && point.lon !== null)}
           className={`leg ${className}`}
           color={this.props.passive ? '#758993' : 'currentColor'}
           weight={legWeight}


### PR DESCRIPTION
We have recently experienced this bug.
When investigated more closely, it was found out that one of the coordinates was lat: {lat: null lon: null}

This pull request fixes a possibility for such an issue by performing a check on the data before drawing the line.

<img width="1261" alt="screen shot 2017-05-25 at 5 10 38 pm" src="https://cloud.githubusercontent.com/assets/13985766/26471350/5bae6cae-416f-11e7-8d16-69d7b6a8b44a.png">
