### PR TITLE
Prevent stop page tabs from wrapping to multiple rows

### DIFF
--- a/app/component/stop.scss
+++ b/app/component/stop.scss
@@ -138,7 +138,6 @@ button.stop-tab-singletab, button.stop-tab-singletab:hover {
 .stop-tab-singletab-container {
   display: block;
   margin: 0 auto;
-  max-width: 100px;
   font-weight: bold;
   line-height: 1.56;
   letter-spacing: -0.4px;


### PR DESCRIPTION
This fixes a small styling issue that lead to a UI bug on larger mobile viewports, such as iPad.

![image](https://user-images.githubusercontent.com/2109218/27224118-2bde4dda-529c-11e7-82f8-12d780bfa8e1.png)
