### PR TITLE
Don't use localhost in dev server paths

### DIFF
--- a/server/hotLoadServer.js
+++ b/server/hotLoadServer.js
@@ -11,8 +11,7 @@ const config = require('../webpack.config');
 const port = process.env.HOT_LOAD_PORT || 9000;
 
 new WebpackDevServer(webpack(config), {
-  proxy: { '*': `http://localhost:${port}` },
-  publicPath: config.output.publicPath,
+  publicPath: '/',
   noInfo: true,
   hot: true,
 }).listen(port, '0.0.0.0', err => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -404,7 +404,7 @@ module.exports = {
     chunkFilename: 'js/[chunkhash].js',
     publicPath:
       (process.env.NODE_ENV === 'development'
-        ? 'http://localhost:' + port
+        ? '/proxy'
         : process.env.APP_PATH || '') + '/',
   },
   plugins: getPluginsConfig(process.env.NODE_ENV),


### PR DESCRIPTION
Because that causes a CONNECTION_REFUSED error when the browser is not running
in the same host as the UI server.