### PR TITLE
Pass piwik id to otp requests

### DIFF
--- a/app/client.js
+++ b/app/client.js
@@ -113,6 +113,7 @@ const callback = () =>
         next => req => {
           // eslint-disable-next-line no-param-reassign
           req.headers.OTPTimeout = config.OTPTimeout;
+          req.headers.id = piwik.getVisitorId();
           return next(req);
         },
       ]),


### PR DESCRIPTION
Try to ease problem solving by passing piwik id to otp queries so that we can correlate ui logging with OTP