### PR TITLE
DT-2139: As a user without origin location detected, index page (start screen) should always display Nearby ("Lähelläsi") tab.

### DIFF
--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -59,7 +59,7 @@ class IndexPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      panelExpanded: false, // Show right-now as default
+      panelExpanded: true, // Show right-now as default
     };
   }
 


### PR DESCRIPTION
From JIRA description: "Without location selected, the Nearby tab should include suggestions for locations. See layout: https://zpl.io/a4A7P Map would be in minimized mode (layout has it in maximized mode).
"
Displays Map in minimized mode, nearby is always default. 