### PR TITLE
DT-2136

### DIFF
--- a/app/component/CityBikeCard.js
+++ b/app/component/CityBikeCard.js
@@ -5,15 +5,8 @@ import CardHeader from './CardHeader';
 import { station as exampleStation } from './ExampleData';
 import ComponentUsageExample from './ComponentUsageExample';
 import Card from './Card';
-import Favourite from './Favourite';
 
-const CityBikeCard = ({
-  station,
-  children,
-  className,
-  isFavourite,
-  toggleFavourite,
-}) => {
+const CityBikeCard = ({ station, children, className }) => {
   if (!station || !children || children.length === 0) {
     return false;
   }
@@ -25,13 +18,6 @@ const CityBikeCard = ({
         description={station.stationId}
         icon="icon-icon_citybike"
         unlinked
-        icons={[
-          <Favourite
-            key="favourite"
-            favourite={isFavourite}
-            addFavourite={toggleFavourite}
-          />,
-        ]}
       />
       {children}
     </Card>
@@ -46,16 +32,6 @@ CityBikeCard.description = () => (
         Im content of the citybike card
       </CityBikeCard>
     </ComponentUsageExample>
-    <ComponentUsageExample description="Selected as favourite">
-      <CityBikeCard
-        className="padding-small"
-        toggleFavourite={() => {}}
-        isFavourite
-        station={exampleStation}
-      >
-        Im content of the favourite citybike card
-      </CityBikeCard>
-    </ComponentUsageExample>
   </div>
 );
 
@@ -65,8 +41,6 @@ CityBikeCard.propTypes = {
   station: PropTypes.object.isRequired,
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
-  toggleFavourite: PropTypes.func,
-  isFavourite: PropTypes.bool,
 };
 
 export default CityBikeCard;

--- a/app/component/map/GenericMarker.js
+++ b/app/component/map/GenericMarker.js
@@ -73,7 +73,6 @@ export default class GenericMarker extends React.Component {
     >
       <Popup
         offset={this.context.config.map.genericMarker.popup.offset}
-        closeButton={false}
         maxWidth={this.context.config.map.genericMarker.popup.maxWidth}
         minWidth={this.context.config.map.genericMarker.popup.minWidth}
         className="popup"

--- a/app/component/map/OriginPopup.js
+++ b/app/component/map/OriginPopup.js
@@ -45,7 +45,6 @@ class OriginPopup extends React.Component {
       <Popup
         context={this.context}
         offset={[50, this.props.yOffset]}
-        closeButton={false}
         maxWidth={this.context.config.map.genericMarker.popup.maxWidth}
         autoPan={false}
         className="origin-popup"

--- a/app/component/map/VehicleMarkerContainer.js
+++ b/app/component/map/VehicleMarkerContainer.js
@@ -185,7 +185,6 @@ export default class VehicleMarkerContainer extends React.PureComponent {
       >
         <Popup
           offset={[106, 16]}
-          closeButton={false}
           maxWidth={250}
           minWidth={250}
           className="popup"

--- a/app/component/map/popups/LocationPopup.js
+++ b/app/component/map/popups/LocationPopup.js
@@ -4,43 +4,100 @@ import { intlShape } from 'react-intl';
 import Card from '../../Card';
 import CardHeader from '../../CardHeader';
 import MarkerPopupBottom from '../MarkerPopupBottom';
+import { getLabel } from '../../../util/suggestionUtils';
+import { getJson } from '../../../util/xhrPromise';
+import Loading from '../../Loading';
 
-export default function LocationPopup({ name, lat, lon }, { intl }) {
-  return (
-    <Card>
-      <div className="padding-small">
-        <CardHeader
-          name={intl.formatMessage({
+class LocationPopup extends React.Component {
+  static contextTypes = {
+    config: PropTypes.object.isRequired,
+    getStore: PropTypes.func.isRequired,
+    intl: intlShape.isRequired,
+  };
+
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    lat: PropTypes.number.isRequired,
+    lon: PropTypes.number.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true,
+      location: {
+        lat: this.props.lat,
+        lon: this.props.lon,
+      },
+    };
+  }
+
+  componentDidMount() {
+    const language = this.context.getStore('PreferencesStore').getLanguage();
+    getJson(this.context.config.URL.PELIAS_REVERSE_GEOCODER, {
+      'point.lat': this.props.lat,
+      'point.lon': this.props.lon,
+      lang: language,
+      size: 1,
+      layers: 'address',
+    }).then(
+      data => {
+        if (data.features != null && data.features.length > 0) {
+          const match = data.features[0].properties;
+          this.setState({
+            loading: false,
+            location: {
+              ...this.state.location,
+              address: getLabel(match, true),
+            },
+          });
+        } else {
+          this.setState({
+            loading: false,
+            location: {
+              ...this.state.location,
+              address: this.context.intl.formatMessage({
+                id: 'location-from-map',
+                defaultMessage: 'Selected location',
+              }),
+            },
+          });
+        }
+      },
+      () => {
+        this.setState({
+          loading: false,
+          address: this.context.intl.formatMessage({
             id: 'location-from-map',
             defaultMessage: 'Selected location',
-          })}
-          description={name}
-          unlinked
-          className="padding-small"
-        />
-      </div>
-      <MarkerPopupBottom
-        location={{
-          // XXX Use name here when it's implemented.
-          address: intl.formatMessage({
-            id: 'location-from-map',
-            defaultMessage: 'Picked location',
           }),
-          lat,
-          lon,
-        }}
-      />
-    </Card>
-  );
+        });
+      },
+    );
+  }
+
+  render() {
+    if (this.state.loading) {
+      return (
+        <div className="card" style={{ height: '12rem' }}>
+          <Loading />
+        </div>
+      );
+    }
+    return (
+      <Card>
+        <div className="padding-small">
+          <CardHeader
+            name={this.state.location.address}
+            description={this.props.name}
+            unlinked
+            className="padding-small"
+          />
+        </div>
+        <MarkerPopupBottom location={this.state.location} />
+      </Card>
+    );
+  }
 }
 
-LocationPopup.contextTypes = {
-  intl: intlShape.isRequired,
-};
-
-LocationPopup.propTypes = {
-  name: PropTypes.string.isRequired,
-  lat: PropTypes.number.isRequired,
-  lon: PropTypes.number.isRequired,
-  closePopup: PropTypes.func.isRequired,
-};
+export default LocationPopup;

--- a/app/component/map/popups/LocationPopup.js
+++ b/app/component/map/popups/LocationPopup.js
@@ -42,4 +42,5 @@ LocationPopup.propTypes = {
   name: PropTypes.string.isRequired,
   lat: PropTypes.number.isRequired,
   lon: PropTypes.number.isRequired,
+  closePopup: PropTypes.func.isRequired,
 };

--- a/app/component/map/popups/LocationPopup.js
+++ b/app/component/map/popups/LocationPopup.js
@@ -1,4 +1,3 @@
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { intlShape } from 'react-intl';

--- a/app/component/map/popups/LocationPopup.js
+++ b/app/component/map/popups/LocationPopup.js
@@ -1,3 +1,4 @@
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import { intlShape } from 'react-intl';
@@ -79,7 +80,7 @@ class LocationPopup extends React.Component {
   render() {
     if (this.state.loading) {
       return (
-        <div className="card" style={{ height: '12rem' }}>
+        <div className="card" style={{ height: '4rem' }}>
           <Loading />
         </div>
       );

--- a/app/component/map/popups/SelectedStopPopup.js
+++ b/app/component/map/popups/SelectedStopPopup.js
@@ -28,7 +28,6 @@ class SelectedStopPopup extends React.Component {
       <Popup
         position={{ lat: this.props.lat, lng: this.props.lon }}
         offset={[50, 25]}
-        closeButton={false}
         maxWidth={this.context.config.map.genericMarker.popup.maxWidth}
         autoPan={false}
         className="origin-popup"

--- a/app/component/map/tile-layer/TileContainer.js
+++ b/app/component/map/tile-layer/TileContainer.js
@@ -123,10 +123,11 @@ class TileContainer {
         return false;
       });
 
-      if (nearest.length === 0 && e.type === 'click') {
-        return this.onSelectableTargetClicked(false, e.latlng); // close any open menu
-      } else if (nearest.length === 0 && e.type === 'contextmenu') {
-        return this.onSelectableTargetClicked([], e.latlng); // open menu for no stop
+      if (
+        nearest.length === 0 &&
+        (e.type === 'click' || e.type === 'contextmenu')
+      ) {
+        return this.onSelectableTargetClicked([], e.latlng); // close any open menu
       } else if (nearest.length === 1) {
         L.DomEvent.stopPropagation(e);
         // open menu for single stop

--- a/app/component/map/tile-layer/TileLayerContainer.js
+++ b/app/component/map/tile-layer/TileLayerContainer.js
@@ -84,6 +84,7 @@ const LocationPopupWithContext = provideContext(LocationPopup, {
   router: routerShape.isRequired,
   location: PropTypes.object.isRequired,
   config: PropTypes.object.isRequired,
+  getStore: PropTypes.func.isRequired,
 });
 
 const initialState = {

--- a/app/component/map/tile-layer/TileLayerContainer.js
+++ b/app/component/map/tile-layer/TileLayerContainer.js
@@ -182,7 +182,6 @@ class TileLayerContainer extends GridLayer {
 
   PopupOptions = {
     offset: [110, 16],
-    closeButton: false,
     minWidth: 260,
     maxWidth: 260,
     autoPanPaddingTopLeft: [5, 125],


### PR DESCRIPTION
Location pick from map improved:

Normal click on map opens origin/destination popup
Double click only zooms, does not open popup
Popups include close button so that they can be closed
Favourite toggle removed from citybike station popus (did nothing)
Popup and a route end point selected from it shows the real address, not a 'Picked location' label
