### PR TITLE
DT-2295

### DIFF
--- a/app/component/AppBarLarge.js
+++ b/app/component/AppBarLarge.js
@@ -7,6 +7,7 @@ import DisruptionInfo from './DisruptionInfo';
 import Icon from './Icon';
 import ComponentUsageExample from './ComponentUsageExample';
 import LangSelect from './LangSelect';
+import MessageBar from './MessageBar';
 
 const AppBarLarge = ({ titleClicked }, { router, location, config, intl }) => {
   const openDisruptionInfo = () => {
@@ -51,6 +52,7 @@ const AppBarLarge = ({ titleClicked }, { router, location, config, intl }) => {
           <ExternalLink className="external-top-bar" {...config.appBarLink} />
         </div>
       </div>
+      <MessageBar />
       <DisruptionInfo />
     </div>
   );

--- a/app/component/AppBarSmall.js
+++ b/app/component/AppBarSmall.js
@@ -5,6 +5,7 @@ import BackButton from './BackButton';
 import DisruptionInfo from './DisruptionInfo';
 import MainMenuContainer from './MainMenuContainer';
 import ComponentUsageExample from './ComponentUsageExample';
+import MessageBar from './MessageBar';
 
 const AppBarSmall = (
   { disableBackButton, showLogo, title, homeUrl },
@@ -23,6 +24,7 @@ const AppBarSmall = (
       </section>
       <MainMenuContainer homeUrl={homeUrl} />
     </nav>
+    <MessageBar />
   </div>
 );
 

--- a/app/component/ErrorBoundary.js
+++ b/app/component/ErrorBoundary.js
@@ -54,6 +54,6 @@ export default class ErrorBoundary extends React.Component {
       );
     }
     // when there's not an error, render children untouched
-    return this.props.children;
+    return this.props.children || null;
   }
 }

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -39,12 +39,6 @@ const feedbackPanel = (
   </LazilyLoad>
 );
 
-const messageBarModules = { Bar: () => importLazy(import('./MessageBar')) };
-
-const messageBar = (
-  <LazilyLoad modules={messageBarModules}>{({ Bar }) => <Bar />}</LazilyLoad>
-);
-
 class IndexPage extends React.Component {
   static contextTypes = {
     location: locationShape.isRequired,
@@ -223,7 +217,6 @@ class IndexPage extends React.Component {
         className={`front-page flex-vertical fullscreen bp-${this.props
           .breakpoint}`}
       >
-        {messageBar}
         <MapWithTracking
           breakpoint={this.props.breakpoint}
           showStops
@@ -268,7 +261,6 @@ class IndexPage extends React.Component {
         className={`front-page flex-vertical fullscreen bp-${this.props
           .breakpoint}`}
       >
-        {messageBar}
         <div
           className={cx('flex-grow', 'map-container', {
             expanded: this.state.mapExpanded,


### PR DESCRIPTION
Move message bar to be a part of the title bar, which is the only component that is available on all pages.

Advantage:
- Message bar pushes all content below it down. That is what designers asked.

Disadvantage: 
- Part of the content below message bar gets outside the visible range (i.e. content does not rescale to compensate message bar height). On desktop, this adds a scrollbar although there is plenty of space, which is kind of silly.
