### PR TITLE
Fix route timetable scroll bug on MS Edge

### DIFF
--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -285,6 +285,7 @@ $route-schedule-date-height: 36px;
 .route-schedule-list {
   padding-bottom: 0.7em;
   flex: 1;
+  flex-basis: 0;
 
   @media print {
     .row {


### PR DESCRIPTION
This should fix the following bug

![image](https://user-images.githubusercontent.com/2109218/33203608-58fbd7f6-d109-11e7-88f6-77c097e7168f.png)
