### PR TITLE
Update favorite locations panel when locations change

### DIFF
--- a/app/component/FavouritesPanel.js
+++ b/app/component/FavouritesPanel.js
@@ -94,6 +94,7 @@ const FilteredFavouritesPanel = shouldUpdate(
   (props, nextProps) =>
     nextProps.currentTime !== props.currentTime ||
     nextProps.routes !== props.routes ||
+    nextProps.favouriteLocations !== props.favouriteLocations ||
     nextProps.origin.gps !== props.origin.gps ||
     (!nextProps.origin.gps &&
       (nextProps.origin.lat !== props.origin.lat ||


### PR DESCRIPTION
Favourites panel ignored changes from favourite location editing.
Any change was displayed usually after 30s delay i.e. when time store
changed its value.