### PR TITLE
Reset state of old stop searches

### DIFF
--- a/app/util/searchUtils.js
+++ b/app/util/searchUtils.js
@@ -134,6 +134,7 @@ function getOldSearches(oldSearches, input, dropLayers) {
     take(matchingOldSearches, 10).map(item => ({
       ...item,
       type: 'OldSearch',
+      timetableClicked: false, // reset latest selection action
     })),
   );
 }


### PR DESCRIPTION
Old searches to stops stored the timetable link selection action with the search data all the way to the local storage. Attempt to pick such an old search in adding/editing a favourite place moved the application
suddenly and confusingly to the stop page. Fixed by resetting old search item state when composing a new search. 
