### PR TITLE
Autosuggest panel positioning

### DIFF
--- a/app/component/search.scss
+++ b/app/component/search.scss
@@ -333,7 +333,7 @@ div.map {
 }
 
 div.autosuggest-panel {
-  position: fixed;
+  position: absolute;
   z-index: 1000;
   margin-top: 1em;
   width: 52.5%;


### PR DESCRIPTION
Change positioning from fixed to absolute.
This stop autosuggest panel from moving with the page if the page has scrolling.

