### PR TITLE
Increased the size of frontpage panel in mobile size to remove scrolling

### DIFF
--- a/app/component/front-page.scss
+++ b/app/component/front-page.scss
@@ -25,7 +25,7 @@ $heading-color: #858585;
 }
 
 .frontpage-panel-wrapper {
-  height: 200px;
+  height: 250px;
   //overflow: scroll;
   &.expanded-panel {
     flex-grow: 0;

--- a/app/component/nolocation-panel.scss
+++ b/app/component/nolocation-panel.scss
@@ -84,6 +84,8 @@
 
     li:last-child {
       border: none;
+      margin-bottom: 0;
+      padding-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
OLD (899px):

![nayttokuva 2018-3-26 kello 13 00 31](https://user-images.githubusercontent.com/1543527/37900085-d473e454-30f5-11e8-91f3-701751518d4e.png)

NEW (899px):
![nayttokuva 2018-3-26 kello 12 59 53](https://user-images.githubusercontent.com/1543527/37900093-d9d504aa-30f5-11e8-9cf1-7de7a06d0a09.png)

OLD (320px):
![nayttokuva 2018-3-26 kello 13 03 33](https://user-images.githubusercontent.com/1543527/37900187-2c64417c-30f6-11e8-8597-7cbca3e42cb2.png)

NEW (320px):
![nayttokuva 2018-3-26 kello 13 03 02](https://user-images.githubusercontent.com/1543527/37900191-2f24571c-30f6-11e8-97d0-e848db59c28c.png)
