### PR TITLE
Hsl-fi-75: scroll to top of the page on origin/destination select

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -10,6 +10,7 @@ import Loading from './component/LoadingPage';
 import TopLevel from './component/TopLevel';
 import Title from './component/Title';
 import { isBrowser } from './util/browser';
+import scrollTop from './util/scroll';
 import {
   PREFIX_ROUTES,
   PREFIX_STOPS,
@@ -489,6 +490,7 @@ export default config => {
           title: Title,
           content: IndexPage,
         }}
+        onEnter={scrollTop}
       />
       <Route
         path="/?mock"

--- a/app/util/scroll.js
+++ b/app/util/scroll.js
@@ -1,0 +1,7 @@
+import { isBrowser } from './browser';
+
+export default function scrollTop() {
+  if (isBrowser) {
+    window.scrollTo(0, 0);
+  }
+}


### PR DESCRIPTION
Steps to reproduce:
- Resize browser to mobile size (320x568)
- Search for `rauta`
- Select any suggestion
- Click origin select again, scroll to the bottom of the page and select one of the suggestions

Expected: 
![nayttokuva 2018-4-11 kello 11 32 20](https://user-images.githubusercontent.com/1543527/38605455-0711d118-3d7c-11e8-9f88-9abc5299ea15.png)


Result:  
![nayttokuva 2018-4-11 kello 11 32 13](https://user-images.githubusercontent.com/1543527/38605462-0b73f024-3d7c-11e8-90d5-4f5f9c2c5714.png)
