### PR TITLE
Stop autosuggest box from intersecting with search

### DIFF
--- a/app/component/search.scss
+++ b/app/component/search.scss
@@ -397,7 +397,6 @@ div.autosuggest-panel {
         height: auto;
         position: absolute;
         width: 100%;
-        margin-top: -8px;
         display: block;
         overflow: visible;
         z-index: 1006;
@@ -476,7 +475,6 @@ div.autosuggest-panel {
     overflow-x: hidden;
     overflow-y: scroll;
     z-index: 1005;
-    margin-top: -8px;
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     }
@@ -714,11 +712,6 @@ input.react-autosuggest__input{
     border-top: 1px solid #ddd;
     border-left: 1px solid #ddd;
     border-bottom: 1px solid #ddd;
-  }
-  #react-autowhatever-origin, #react-autowhatever-destination, #react-autowhatever-viapoint {
-    &.react-autosuggest__suggestions-container--open {
-      margin: -8px 0 0 0;
-    }
   }
 }
 


### PR DESCRIPTION
Currently the autosuggest box is intersecting slightly with the search box:

![image](https://user-images.githubusercontent.com/2262772/38777600-74a7ec1e-40b3-11e8-83b7-72d8080a7ad3.png)

The PR removes the negative margins causing this.