### PR TITLE
mobile-view-walk-distance-fix

### DIFF
--- a/app/component/ItinerarySummary.js
+++ b/app/component/ItinerarySummary.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Duration from './Duration';
 import WalkDistance from './WalkDistance';
+import { getTotalWalkingDistance } from '../util/legUtils';
 
 const ItinerarySummary = ({ itinerary, children }) => (
   <div className="itinerary-summary">
@@ -10,7 +11,7 @@ const ItinerarySummary = ({ itinerary, children }) => (
       className="duration--itinerary-summary"
     />
     {children}
-    <WalkDistance walkDistance={itinerary.walkDistance} />
+    <WalkDistance walkDistance={getTotalWalkingDistance(itinerary)} />
   </div>
 );
 


### PR DESCRIPTION
The purpose of this pull request is to fix the incorrect walking distance total shown in the mobile view. This previously used the backend-provided walkDistance field. Now the functionality is similar to e.g. PrintableItineraryHeader.

Bug report:
![total_walking_distance_is_wrong](https://user-images.githubusercontent.com/2669201/39822063-5b24c638-53b2-11e8-8e14-3eec19949349.png)
