### PR TITLE
Itinerary filtering fixes

### DIFF
--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -79,7 +79,7 @@ export default {
 
   maxWalkDistance: 10000,
   maxBikingDistance: 100000,
-  itineraryFiltering: 2.5, // drops 40% worse routes
+  itineraryFiltering: 1.5, // drops 66% worse routes
   availableLanguages: ['fi', 'sv', 'en', 'fr', 'nb', 'de'],
   defaultLanguage: 'en',
   // This timezone data will expire on 31.12.2020

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -46,6 +46,8 @@ export default {
   },
 
   maxWalkDistance: 2500,
+  itineraryFiltering: 2.5, // drops 40% worse routes
+
   parkAndRide: {
     showParkAndRide: true,
     parkAndRideMinZoom: 14,

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -174,6 +174,7 @@ export const preparePlanParams = config => (
         preferred: { agencies: config.preferredAgency || '' },
         disableRemainingWeightHeuristic:
           modes && modes.split(',').includes('CITYBIKE'),
+        itineraryFiltering: config.itineraryFiltering,
       },
       nullOrUndefined,
     ),


### PR DESCRIPTION
- Separate matka/hsl default values
- 'Ealier' button generated a query where filtering variable was not set
