### PR TITLE
DCW-21: fix for handling invalid intermediatePlaces query parameter

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -25,9 +25,9 @@ import SummaryNavigation from './SummaryNavigation';
 import ItineraryLine from '../component/map/ItineraryLine';
 import LocationMarker from '../component/map/LocationMarker';
 import MobileItineraryWrapper from './MobileItineraryWrapper';
-import { otpToLocation } from '../util/otpStrings';
 import Loading from './Loading';
 import { getHomeUrl } from '../util/path';
+import { getIntermediatePlaces } from '../util/queryUtils';
 import withBreakpoint from '../util/withBreakpoint';
 
 export const ITINERARYFILTERING_DEFAULT = 2.0;
@@ -201,29 +201,16 @@ class SummaryPage extends React.Component {
       );
     }
 
-    if (query && query.intermediatePlaces) {
-      if (Array.isArray(query.intermediatePlaces)) {
-        query.intermediatePlaces.map(otpToLocation).forEach((location, i) => {
-          leafletObjs.push(
-            <LocationMarker
-              key={`via_${i}`}
-              position={location}
-              className="via"
-              noText
-            />,
-          );
-        });
-      } else {
-        leafletObjs.push(
-          <LocationMarker
-            key="via"
-            position={otpToLocation(query.intermediatePlaces)}
-            className="via"
-            noText
-          />,
-        );
-      }
-    }
+    getIntermediatePlaces(query).forEach((location, i) => {
+      leafletObjs.push(
+        <LocationMarker
+          key={`via_${i}`}
+          position={location}
+          className="via"
+          noText
+        />,
+      );
+    });
 
     // Decode all legs of all itineraries into latlong arrays,
     // and concatenate into one big latlong array

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -156,7 +156,7 @@ class SummaryPlanContainer extends React.Component {
       );
 
       const tunedParams = {
-        ...{ modes: getDefaultOTPModes(this.props.config).join(',') },
+        ...{ modes: getDefaultOTPModes(this.props.config) },
         ...params,
         numItineraries:
           this.props.itineraries.length > 0 ? this.props.itineraries.length : 3,
@@ -236,7 +236,7 @@ class SummaryPlanContainer extends React.Component {
       );
 
       const tunedParams = {
-        ...{ modes: getDefaultOTPModes(this.props.config).join(',') },
+        ...{ modes: getDefaultOTPModes(this.props.config) },
         ...params,
         numItineraries:
           this.props.itineraries.length > 0 ? this.props.itineraries.length : 3,

--- a/app/util/modeUtils.js
+++ b/app/util/modeUtils.js
@@ -158,7 +158,7 @@ export const getDefaultModes = config => [
  * both available and marked as default and maps them to their OTP counterparts.
  *
  * @param {*} config The configuration for the software installation
- * @returns {String[]} an array of OTP modes
+ * @returns {String} a comma-separated list of OTP modes
  */
 export const getDefaultOTPModes = config =>
   filterModes(config, getDefaultModes(config));

--- a/app/util/modeUtils.js
+++ b/app/util/modeUtils.js
@@ -1,4 +1,5 @@
 import { intersection, isEmpty, isString, sortedUniq, without } from 'lodash';
+import { replaceQueryParams } from './queryUtils';
 import { getCustomizedSettings } from '../store/localStorage';
 
 /**
@@ -83,23 +84,6 @@ export const buildStreetModeQuery = (
       ? streetMode.toUpperCase()
       : transportModes.concat(streetMode.toUpperCase()).join(','),
   };
-};
-
-/**
- * Updates the browser's url with the given parameters.
- *
- * @param {*} router The router
- * @param {*} location The current location
- * @param {*} newParams The location query params to apply
- */
-export const replaceQueryParams = (router, location, newParams) => {
-  router.replace({
-    ...location,
-    query: {
-      ...location.query,
-      ...newParams,
-    },
-  });
 };
 
 /**

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -1,10 +1,11 @@
 import omitBy from 'lodash/omitBy';
-
 import moment from 'moment';
+
 // Localstorage data
 import { getCustomizedSettings } from '../store/localStorage';
-import { otpToLocation } from './otpStrings';
 import { filterModes } from './modeUtils';
+import { otpToLocation } from './otpStrings';
+import { getIntermediatePlaces } from './queryUtils';
 
 export const WALKBOARDCOST_DEFAULT = 600;
 
@@ -17,17 +18,6 @@ export const defaultSettings = {
   walkSpeed: 1.2,
   ticketTypes: 'none',
 };
-
-function getIntermediatePlaces(intermediatePlaces) {
-  if (!intermediatePlaces) {
-    return [];
-  } else if (Array.isArray(intermediatePlaces)) {
-    return intermediatePlaces.map(otpToLocation);
-  } else if (typeof intermediatePlaces === 'string') {
-    return [otpToLocation(intermediatePlaces)];
-  }
-  return [];
-}
 
 function setTicketTypes(ticketType, settingsTicketType) {
   if (ticketType !== undefined && ticketType !== 'none') {
@@ -112,7 +102,7 @@ export const preparePlanParams = config => (
         toPlace: to,
         from: otpToLocation(from),
         to: otpToLocation(to),
-        intermediatePlaces: getIntermediatePlaces(intermediatePlaces),
+        intermediatePlaces: getIntermediatePlaces({ intermediatePlaces }),
         numItineraries: numItineraries ? Number(numItineraries) : undefined,
         modes: modes ? filterModes(config, modes) : settings.modes,
         date: time ? moment(time * 1000).format('YYYY-MM-DD') : undefined,

--- a/app/util/queryUtils.js
+++ b/app/util/queryUtils.js
@@ -1,0 +1,50 @@
+import isEmpty from 'lodash/isEmpty';
+import isString from 'lodash/isString';
+import trim from 'lodash/trim';
+
+import { otpToLocation } from './otpStrings';
+
+/**
+ * Updates the browser's url with the given parameters.
+ *
+ * @param {*} router The router
+ * @param {*} location The current location
+ * @param {*} newParams The location query params to apply
+ */
+export const replaceQueryParams = (router, location, newParams) => {
+  router.replace({
+    ...location,
+    query: {
+      ...location.query,
+      ...newParams,
+    },
+  });
+};
+
+/**
+ * Extracts the location information from the intermediatePlaces
+ * query parameter, if available.
+ *
+ * @typedef Query
+ * @prop {String|String[]} intermediatePlaces
+ *
+ * @param {Query} query The query to extract the information from.
+ * @returns an array of locations if available, or an empty array otherwise
+ */
+export const getIntermediatePlaces = query => {
+  if (!query) {
+    return [];
+  }
+  const { intermediatePlaces } = query;
+  if (!intermediatePlaces) {
+    return [];
+  } else if (Array.isArray(intermediatePlaces)) {
+    return intermediatePlaces.map(otpToLocation);
+  } else if (isString(intermediatePlaces)) {
+    if (isEmpty(trim(intermediatePlaces))) {
+      return [];
+    }
+    return [otpToLocation(intermediatePlaces)];
+  }
+  return [];
+};

--- a/test/flow/page_object/customizeSearch.js
+++ b/test/flow/page_object/customizeSearch.js
@@ -89,7 +89,7 @@ function disableAllModalitiesExcept(except) {
     this.api.debug(`iterating ${modality}`);
     if (modality !== except) {
       disableModality.call(this, modality);
-      this.api.pause(2 * this.api.globals.pause_ms);
+      this.api.pause(5 * this.api.globals.pause_ms);
     }
   });
   this.api.debug('all iterated');

--- a/test/unit/queryUtils.test.js
+++ b/test/unit/queryUtils.test.js
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import * as utils from '../../app/util/queryUtils';
+
+describe('queryUtils', () => {
+  describe('getIntermediatePlaces', () => {
+    it('should return an empty array for missing query', () => {
+      const query = null;
+      const result = utils.getIntermediatePlaces(query);
+      expect(Array.isArray(result)).to.equal(true);
+      expect(result.length).to.equal(0);
+    });
+
+    it('should return an empty array for missing intermediatePlaces', () => {
+      const query = {};
+      const result = utils.getIntermediatePlaces(query);
+      expect(Array.isArray(result)).to.equal(true);
+      expect(result.length).to.equal(0);
+    });
+
+    it('should return an empty array for whitespace intermediatePlaces', () => {
+      const query = {
+        intermediatePlaces: ' ',
+      };
+      const result = utils.getIntermediatePlaces(query);
+      expect(Array.isArray(result)).to.equal(true);
+      expect(result.length).to.equal(0);
+    });
+
+    it('should return a location parsed from a string-mode intermediatePlaces', () => {
+      const query = {
+        intermediatePlaces: 'Kera, Espoo::60.217992,24.75494',
+      };
+      const result = utils.getIntermediatePlaces(query);
+      expect(Array.isArray(result)).to.equal(true);
+      expect(result.length).to.equal(1);
+      expect(result[0].address).to.equal('Kera, Espoo');
+      expect(result[0].lat).to.equal(60.217992);
+      expect(result[0].lon).to.equal(24.75494);
+    });
+
+    it('should return locations parsed from an array-mode intermediatePlaces', () => {
+      const query = {
+        intermediatePlaces: [
+          'Kera, Espoo::60.217992,24.75494',
+          'Leppävaara, Espoo::60.219235,24.81329',
+        ],
+      };
+      const result = utils.getIntermediatePlaces(query);
+      expect(Array.isArray(result)).to.equal(true);
+      expect(result.length).to.equal(2);
+      expect(result[0].address).to.equal('Kera, Espoo');
+      expect(result[0].lat).to.equal(60.217992);
+      expect(result[0].lon).to.equal(24.75494);
+      expect(result[1].address).to.equal('Leppävaara, Espoo');
+      expect(result[1].lat).to.equal(60.219235);
+      expect(result[1].lon).to.equal(24.81329);
+    });
+
+    it('should return an empty array if intermediatePlaces is neither a string nor an array', () => {
+      const query = {
+        intermediatePlaces: {},
+      };
+      const result = utils.getIntermediatePlaces(query);
+      expect(Array.isArray(result)).to.equal(true);
+      expect(result.length).to.equal(0);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7923,22 +7923,14 @@ mocha@5.2.0:
     mkdirp "0.5.1"
     supports-color "5.4.0"
 
-<<<<<<< HEAD
-mock-local-storage@^1.0.5:
-=======
 mock-local-storage@1.0.5:
->>>>>>> cc6fb75fb982f2f3de07a549ebfded4a259b0f26
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/mock-local-storage/-/mock-local-storage-1.0.5.tgz#899ff300027cefed47816e6dc539bb059fcce489"
   dependencies:
     core-js "^0.8.3"
     global "^4.3.2"
 
-<<<<<<< HEAD
-mockdate@^2.0.2:
-=======
 mockdate@2.0.2:
->>>>>>> cc6fb75fb982f2f3de07a549ebfded4a259b0f26
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
 


### PR DESCRIPTION
The purpose of this pull request is to recover from a partly invalid intermediatePlaces url parameter.

Previously the UI would crash if the parameter `intermediatePlaces=+` was provided. This is no longer the case.

In addition, some unit testing logic was added to the functionality.