### PR TITLE
DT-2679

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -70,8 +70,10 @@ const productionPlugins = [
     ServiceWorker: {
       entry: './app/util/font-sw.js',
       events: true,
+      publicPath: 'sw.js',
     },
     version: '[hash]',
+    relativePaths: true,
   }),
   new MiniCssExtractPlugin({
     filename: 'css/[name].[contenthash].css',
@@ -101,7 +103,7 @@ module.exports = {
     path: path.join(__dirname, '_static'),
     filename: isDevelopment ? 'js/bundle.js' : 'js/[name].[chunkhash].js',
     chunkFilename: 'js/[chunkhash].js',
-    publicPath: isDevelopment ? '/proxy/' : `${process.env.APP_PATH || ''}`,
+    publicPath: isDevelopment ? '/proxy/' : `${process.env.APP_PATH || '../'}`,
     crossOriginLoading: 'anonymous',
   },
   module: {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -101,7 +101,7 @@ module.exports = {
     path: path.join(__dirname, '_static'),
     filename: isDevelopment ? 'js/bundle.js' : 'js/[name].[chunkhash].js',
     chunkFilename: 'js/[chunkhash].js',
-    publicPath: isDevelopment ? '/proxy/' : `${process.env.APP_PATH || ''}/`,
+    publicPath: isDevelopment ? '/proxy/' : `${process.env.APP_PATH || ''}`,
     crossOriginLoading: 'anonymous',
   },
   module: {


### PR DESCRIPTION
Requires ASSET_URL env to be set as https://digitransit-dev-cdn-origin.azureedge.net/ui/v1/hsl-next/ (notice trailing slash!). Also available in docker hub as `hsldevcom/digitransit-ui:asset-test`. Should be tested using a docker build in next-dev environment as this is a obscure combination of service worker and cdn.