### PR TITLE
DT-2654: iOS PWA partial fix

### DIFF
--- a/app/client.js
+++ b/app/client.js
@@ -32,6 +32,7 @@ import ErrorBoundary from './component/ErrorBoundary';
 import oldParamParser from './util/oldParamParser';
 import { ClientProvider as ClientBreakpointProvider } from './util/withBreakpoint';
 import meta from './meta';
+import { isIOSApp } from './util/browser';
 
 const plugContext = f => () => ({
   plugComponentContext: f,
@@ -187,6 +188,12 @@ const callback = () =>
             props => {
               const root = document.getElementById('app');
               const { initialBreakpoint } = root.dataset;
+
+              // KLUDGE: SSR and CSR mismatch breaks the UI in iOS PWA mode
+              // see: https://github.com/facebook/react/issues/11336
+              if (isIOSApp) {
+                root.innerHTML = '';
+              }
 
               const content = (
                 <ClientBreakpointProvider

--- a/app/component/AppBarSmall.js
+++ b/app/component/AppBarSmall.js
@@ -11,7 +11,7 @@ const AppBarSmall = (
   { disableBackButton, showLogo, title, homeUrl },
   { config },
 ) => (
-  <div>
+  <React.Fragment>
     <DisruptionInfo />
     <nav className="top-bar">
       {!disableBackButton && <BackButton />}
@@ -25,7 +25,7 @@ const AppBarSmall = (
       <MainMenuContainer homeUrl={homeUrl} />
     </nav>
     <MessageBar />
-  </div>
+  </React.Fragment>
 );
 
 AppBarSmall.displayName = 'AppBarSmall';

--- a/app/component/DisruptionInfo.js
+++ b/app/component/DisruptionInfo.js
@@ -11,8 +11,15 @@ import ComponentUsageExample from './ComponentUsageExample';
 import { isBrowser } from '../util/browser';
 
 function DisruptionInfo(props, context) {
+  if (!((props && props.isBrowser) || isBrowser)) {
+    return null;
+  }
+
   const isOpen = () =>
     context.location.state ? context.location.state.disruptionInfoOpen : false;
+  if (!isOpen()) {
+    return null;
+  }
 
   const toggleVisibility = () => {
     if (isOpen()) {
@@ -28,40 +35,37 @@ function DisruptionInfo(props, context) {
     }
   };
 
-  if (isBrowser && isOpen()) {
-    return (
-      <Modal
-        open
-        title={
-          <FormattedMessage
-            id="disruption-info"
-            defaultMessage="Disruption info"
-          />
-        }
-        toggleVisibility={toggleVisibility}
-      >
-        <Relay.RootContainer
-          Component={DisruptionListContainer}
-          forceFetch
-          route={{
-            name: 'ViewerRoute',
-            queries: {
-              root: (Component, { feedIds }) => Relay.QL`
+  return (
+    <Modal
+      open
+      title={
+        <FormattedMessage
+          id="disruption-info"
+          defaultMessage="Disruption info"
+        />
+      }
+      toggleVisibility={toggleVisibility}
+    >
+      <Relay.RootContainer
+        Component={DisruptionListContainer}
+        forceFetch
+        route={{
+          name: 'ViewerRoute',
+          queries: {
+            root: (Component, { feedIds }) => Relay.QL`
                 query {
                   viewer {
                     ${Component.getFragment('root', { feedIds })}
                   }
                 }
              `,
-            },
-            params: { feedIds: context.config.feedIds },
-          }}
-          renderLoading={() => <Loading />}
-        />
-      </Modal>
-    );
-  }
-  return <div />;
+          },
+          params: { feedIds: context.config.feedIds },
+        }}
+        renderLoading={() => <Loading />}
+      />
+    </Modal>
+  );
 }
 
 DisruptionInfo.contextTypes = {

--- a/app/component/DisruptionInfo.js
+++ b/app/component/DisruptionInfo.js
@@ -76,6 +76,14 @@ DisruptionInfo.contextTypes = {
   }).isRequired,
 };
 
+DisruptionInfo.propTypes = {
+  isBrowser: PropTypes.bool,
+};
+
+DisruptionInfo.defaultProps = {
+  isBrowser: false,
+};
+
 DisruptionInfo.description = () => (
   <div>
     <p>

--- a/app/component/MainMenuContainer.js
+++ b/app/component/MainMenuContainer.js
@@ -61,45 +61,43 @@ class MainMenuContainer extends Component {
     MainMenu: () => importLazy(import('./MainMenu')),
   };
 
-  render() {
-    return (
-      <div>
-        <LazilyLoad modules={this.mainMenuModules}>
-          {({ Drawer, MainMenu }) => (
-            <Drawer
-              className="offcanvas"
-              disableSwipeToOpen
-              docked={false}
-              open={this.getOffcanvasState()}
-              openSecondary
-              onRequestChange={this.onRequestChange}
-            >
-              <MainMenu
-                toggleVisibility={this.toggleOffcanvas}
-                showDisruptionInfo={this.getOffcanvasState()}
-                visible={this.getOffcanvasState()}
-                homeUrl={this.props.homeUrl}
-              />
-            </Drawer>
-          )}
-        </LazilyLoad>
-        {this.context.config.mainMenu.show ? (
-          <div className="icon-holder cursor-pointer main-menu-toggle">
-            <button
-              aria-label={this.context.intl.formatMessage({
-                id: 'main-menu-label-open',
-                defaultMessage: 'Open the main menu',
-              })}
-              onClick={this.toggleOffcanvas}
-              className="noborder cursor-pointer"
-            >
-              <Icon img="icon-icon_menu" className="icon" />
-            </button>
-          </div>
-        ) : null}
-      </div>
-    );
-  }
+  render = () => (
+    <React.Fragment>
+      <LazilyLoad modules={this.mainMenuModules}>
+        {({ Drawer, MainMenu }) => (
+          <Drawer
+            className="offcanvas"
+            disableSwipeToOpen
+            docked={false}
+            open={this.getOffcanvasState()}
+            openSecondary
+            onRequestChange={this.onRequestChange}
+          >
+            <MainMenu
+              toggleVisibility={this.toggleOffcanvas}
+              showDisruptionInfo={this.getOffcanvasState()}
+              visible={this.getOffcanvasState()}
+              homeUrl={this.props.homeUrl}
+            />
+          </Drawer>
+        )}
+      </LazilyLoad>
+      {this.context.config.mainMenu.show ? (
+        <div className="icon-holder cursor-pointer main-menu-toggle">
+          <button
+            aria-label={this.context.intl.formatMessage({
+              id: 'main-menu-label-open',
+              defaultMessage: 'Open the main menu',
+            })}
+            onClick={this.toggleOffcanvas}
+            className="noborder cursor-pointer"
+          >
+            <Icon img="icon-icon_menu" className="icon" />
+          </button>
+        </div>
+      ) : null}
+    </React.Fragment>
+  );
 }
 
 export default MainMenuContainer;

--- a/test/unit/DisruptionInfo.test.js
+++ b/test/unit/DisruptionInfo.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { shallowWithIntl } from './helpers/mock-intl-enzyme';
+
+import DisruptionInfo from '../../app/component/DisruptionInfo';
+import Modal from '../../app/component/Modal';
+
+describe('DisruptionInfo', () => {
+  it('should return null when isBrowser=false', () => {
+    const wrapper = shallowWithIntl(<DisruptionInfo isBrowser={false} />);
+    expect(wrapper.getElement()).to.equal(null);
+  });
+
+  it('should return null when no disruptionInfoOpen has been given', () => {
+    const wrapper = shallowWithIntl(<DisruptionInfo isBrowser />, {
+      context: {
+        location: {
+          state: {},
+        },
+      },
+    });
+    expect(wrapper.getElement()).to.equal(null);
+  });
+
+  it('should return null when disruptionInfoOpen=false', () => {
+    const wrapper = shallowWithIntl(<DisruptionInfo isBrowser />, {
+      context: {
+        location: {
+          state: {
+            disruptionInfoOpen: false,
+          },
+        },
+      },
+    });
+    expect(wrapper.getElement()).to.equal(null);
+  });
+
+  it('should return a Modal when disruptionInfoOpen=true', () => {
+    const wrapper = shallowWithIntl(<DisruptionInfo isBrowser />, {
+      context: {
+        config: {
+          feedIds: [],
+        },
+        location: {
+          state: {
+            disruptionInfoOpen: true,
+          },
+        },
+      },
+    });
+    expect(wrapper.find(Modal)).to.have.lengthOf(1);
+  });
+});


### PR DESCRIPTION
The purpose of this pull request is to prevent an iOS PWA installation from completely breaking up upon re-entering the app. This does not fix the underlying problem with the mismatch between client and server side rendering results. Further work for a complete fix is still required.

In addition, some empty `div`s were removed from the markup.

Link to the relevant JIRA ticket: https://digitransit.atlassian.net/browse/DT-2654

Related discussion: https://github.com/facebook/react/issues/10591