### PR TITLE
Search Earlier routes with 'Arrive By' option now works correctly

### DIFF
--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -165,7 +165,6 @@ class SummaryPlanContainer extends React.Component {
   };
 
   onEarlier = () => {
-    this.props.setLoading(true);
     const start = moment.unix(this.props.serviceTimeRange.start);
 
     const earliestArrivalTime = this.props.itineraries.reduce(
@@ -184,7 +183,7 @@ class SummaryPlanContainer extends React.Component {
 
     earliestArrivalTime.subtract(1, 'minutes');
 
-    if (this.context.location.query.arriveBy === true) {
+    if (this.context.location.query.arriveBy === 'true') {
       // user has arriveBy already
       this.context.router.replace({
         ...this.context.location,
@@ -194,6 +193,8 @@ class SummaryPlanContainer extends React.Component {
         },
       });
     } else {
+      this.props.setLoading(true);
+
       const params = preparePlanParams(this.props.config)(
         this.context.router.params,
         this.context,


### PR DESCRIPTION
Correct logic was skipped this way:
  if(true == 'true') { // local var vs URL param value
    // do the right thing
  }

Also, clear the spinner correctly.