### PR TITLE
DCW-20: fix the handling of via point keyboard events

### DIFF
--- a/app/component/DTAutosuggestPanel.js
+++ b/app/component/DTAutosuggestPanel.js
@@ -7,7 +7,7 @@ import Icon from './Icon';
 import DTEndpointAutosuggest from './DTEndpointAutosuggest';
 import { dtLocationShape } from '../util/shapes';
 import { navigateTo, PREFIX_ITINERARY_SUMMARY } from '../util/path';
-import { isIe } from '../util/browser';
+import { isIe, isKeyboardSelectionEvent } from '../util/browser';
 import withBreakpoint from '../util/withBreakpoint';
 
 /**
@@ -199,7 +199,12 @@ class DTAutosuggestPanel extends React.Component {
                       ? this.props.removeViapoints(i)
                       : this.props.toggleViaPoint(false)
                   }
-                  onKeyPress={() => this.props.removeViapoints(i)}
+                  onKeyPress={e =>
+                    isKeyboardSelectionEvent(e) &&
+                    this.props.viaPointNames.length > 1
+                      ? this.props.removeViapoints(i)
+                      : this.props.toggleViaPoint(false)
+                  }
                 >
                   <span>
                     <Icon img="icon-icon_close" />
@@ -217,7 +222,10 @@ class DTAutosuggestPanel extends React.Component {
                         : 'block',
                   }}
                   onClick={() => this.props.addMoreViapoints(i)}
-                  onKeyPress={() => this.props.addMoreViapoints(i)}
+                  onKeyPress={e =>
+                    isKeyboardSelectionEvent(e) &&
+                    this.props.addMoreViapoints(i)
+                  }
                 >
                   <span>
                     <Icon img="icon-icon_plus" />

--- a/app/component/Icon.js
+++ b/app/component/Icon.js
@@ -4,7 +4,7 @@ import cx from 'classnames';
 
 function Icon(props) {
   return (
-    <span aria-hidden>
+    <span aria-hidden style={{ pointerEvents: 'none' }}>
       <svg
         id={props.id}
         style={{ fill: props.color ? props.color : null }}

--- a/app/component/OriginDestinationBar.js
+++ b/app/component/OriginDestinationBar.js
@@ -8,6 +8,7 @@ import { dtLocationShape } from '../util/shapes';
 import Icon from './Icon';
 import DTAutosuggestPanel from './DTAutosuggestPanel';
 import { PREFIX_ITINERARY_SUMMARY, navigateTo } from '../util/path';
+import { isKeyboardSelectionEvent } from '../util/browser';
 
 export default class OriginDestinationBar extends React.Component {
   static propTypes = {
@@ -114,15 +115,26 @@ export default class OriginDestinationBar extends React.Component {
           toggleViaPoint={this.toggleViaPoint}
         />
         <div className="itinerary-search-controls">
-          <div className="switch" onClick={() => this.swapEndpoints()}>
+          <div
+            className="switch"
+            onClick={() => this.swapEndpoints()}
+            onKeyPress={e =>
+              isKeyboardSelectionEvent(e) && this.swapEndpoints()
+            }
+            tabIndex="0"
+          >
             <span>
               <Icon img="icon-icon_direction-b" />
             </span>
           </div>
           <div
             className="addViaPoint"
-            style={{ display: !this.state.isViaPoint ? 'block' : 'none' }}
             onClick={() => this.toggleViaPoint(true)}
+            onKeyPress={e =>
+              isKeyboardSelectionEvent(e) && this.toggleViaPoint(true)
+            }
+            style={{ display: !this.state.isViaPoint ? 'block' : 'none' }}
+            tabIndex="0"
           >
             <span>
               <Icon img="icon-icon_plus" />

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "codecov": "3.0.2",
     "css-loader": "0.28.11",
     "enzyme": "3.3.0",
-    "enzyme-adapter-react-16": "1.1.1",
+    "enzyme-adapter-react-16": "npm:enzyme-react-adapter-future",
     "eslint": "4.19.1",
     "eslint-config-airbnb": "16.1.0",
     "eslint-config-prettier": "2.9.0",

--- a/test/unit/OriginDestinationBar.test.js
+++ b/test/unit/OriginDestinationBar.test.js
@@ -2,6 +2,9 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { before, describe, it } from 'mocha';
+
+import { mockContext, mockChildContextTypes } from './helpers/mock-context';
+import { mountWithIntl } from './helpers/mock-intl-enzyme';
 import OriginDestinationBar from '../../app/component/OriginDestinationBar';
 
 describe('<OriginDestinationBar />', () => {
@@ -85,5 +88,62 @@ describe('<OriginDestinationBar />', () => {
     });
     wrapperNoParams.instance().removeViapoints(0);
     expect(wrapperNoParams.state('isViaPoint')).to.equal(false);
+  });
+
+  it('should show the add via point button after removing an empty via point with a keypress', () => {
+    const props = {
+      initialViaPoints: [' '],
+      origin: {},
+    };
+    const comp = mountWithIntl(<OriginDestinationBar {...props} />, {
+      context: {
+        ...mockContext,
+        location: { query: '' },
+        router: { replace: mockFunction },
+      },
+      childContextTypes: mockChildContextTypes,
+    });
+
+    comp.find('.itinerary-search-controls > .addViaPoint').simulate('click');
+    comp.find('.removeViaPoint').simulate('keypress', { key: 'Enter' });
+
+    expect(comp.find('.viapoints-list').prop('style')).to.deep.equal({
+      display: 'none',
+    });
+    expect(
+      comp.find('.itinerary-search-controls > .addViaPoint').prop('style'),
+    ).to.deep.equal({
+      display: 'block',
+    });
+  });
+
+  it('should add a via point after adding and then removing a viapoint with a keypress', () => {
+    const props = {
+      initialViaPoints: [' '],
+      origin: {},
+    };
+    const comp = mountWithIntl(<OriginDestinationBar {...props} />, {
+      context: {
+        ...mockContext,
+        location: { query: '' },
+        router: { replace: mockFunction },
+      },
+      childContextTypes: mockChildContextTypes,
+    });
+
+    comp.find('.itinerary-search-controls > .addViaPoint').simulate('click');
+    comp.find('.removeViaPoint').simulate('keypress', { key: 'Enter' });
+    comp.find('.itinerary-search-controls > .addViaPoint').simulate('click');
+
+    expect(
+      comp.find('.itinerary-search-controls > .addViaPoint').prop('style'),
+    ).to.deep.equal({
+      display: 'none',
+    });
+    expect(comp.find('.viapoints-list').length).to.equal(1);
+    expect(comp.find('.viapoints-list').prop('style')).to.deep.equal({
+      display: 'block',
+    });
+    expect(comp.find('.removeViaPoint').length).to.equal(1);
   });
 });

--- a/test/unit/helpers/mock-context.js
+++ b/test/unit/helpers/mock-context.js
@@ -1,9 +1,22 @@
 import PropTypes from 'prop-types';
+import PositionStore from '../../../app/store/PositionStore';
+
+const noop = () => {};
 
 export const mockContext = {
   getStore: () => ({
-    on: () => {},
+    on: noop,
     getLanguage: () => 'en',
+    getLocationState: () => ({
+      lat: '',
+      lon: '',
+      address: '',
+      status: PositionStore.STATUS_NO_LOCATION,
+      hasLocation: false,
+      isLocationingInProgress: false,
+      locationingFailed: false,
+    }),
+    removeListener: noop,
   }),
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4164,13 +4164,13 @@ envinfo@^5.7.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-5.10.0.tgz#503a9774ae15b93ea68bdfae2ccd6306624ea6df"
 
-enzyme-adapter-react-16@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
+"enzyme-adapter-react-16@npm:enzyme-react-adapter-future":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/enzyme-react-adapter-future/-/enzyme-react-adapter-future-1.1.3.tgz#f0c102f098086a0ad0270bbdaf9da5113297dc05"
   dependencies:
     enzyme-adapter-utils "^1.3.0"
     lodash "^4.17.4"
-    object.assign "^4.0.4"
+    object.assign "^4.1.0"
     object.values "^1.0.4"
     prop-types "^15.6.0"
     react-reconciler "^0.7.0"


### PR DESCRIPTION
The purpose of this pull request is to allow editing the via point list with the keyboard. Previously no tab index was available for the switch and add via point buttons. In addition, the UI broke when removing a via point with keyboard.

Also, titles are now disabled for all icons as they are irrelevant to the icon's meaning. These were hidden from screen readers anyway, so it should not affect anyone not examining the page visually.

Link to the JIRA task: https://digitransit.atlassian.net/browse/DCW-20