### PR TITLE
DCW-43: Fixed the street mode popup overflow issue in the mobile view

### DIFF
--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -179,18 +179,16 @@ div.leaflet-marker-icon.vehicle-icon.small-map-icon {
   }
 }
 
-.bp-medium {
-  & .map-with-tracking-buttons {
-    bottom: 20px;
-    left: 1em;
-  }
+.bp-large .map-with-tracking-buttons {
+  bottom: 32px;
 }
 
 .map-with-tracking-buttons {
-  bottom: 36px;
+  bottom: 18px;
   display: flex;
-  left: 20px;
+  left: 1em;
   max-height: 36px;
+  max-width: calc(100% - 2em);
   position: absolute;
   z-index: index($zindex, map-buttons);
 
@@ -595,7 +593,7 @@ div.map-click-prevent-overlay {
 
 .smallspinner {
   div.spinner-loader {
-    width: $spinner-size*0.5;
-    height: $spinner-size*0.5;
+    width: $spinner-size * 0.5;
+    height: $spinner-size * 0.5;
   }
 }

--- a/app/component/street-mode-selector-popup.scss
+++ b/app/component/street-mode-selector-popup.scss
@@ -1,6 +1,7 @@
 @import './street-mode-selector.scss';
 
 .street-mode-selector-popup-container {
+  max-width: 100%;
   position: relative;
 
   & .street-mode-selector-popup-header {
@@ -17,8 +18,7 @@
     box-shadow: 1.5px 2.6px 10px 0 rgba(0, 0, 0, 0.2);
 
     &.direction-up {
-      bottom: 0;
-      position: absolute;
+      margin-top: -7em;
     }
   }
 

--- a/sass/base/_elements.scss
+++ b/sass/base/_elements.scss
@@ -155,7 +155,7 @@ $border-radius-rounded: 30px;
   right: 10px;
   font-size: 17px;
   border-radius: $border-radius;
-  z-index: index($zindex, map-buttons);
+  z-index: index($zindex, map-fullscreen-toggle);
   .icon {
     margin: 0.5em 0.5em 0 0.5em;
     fill: rgb(255, 255, 255);

--- a/sass/base/_zindex.scss
+++ b/sass/base/_zindex.scss
@@ -1,5 +1,5 @@
-$zindex: base, map-container, footer, map-gradient, map-buttons, context-panel,
-  search-panel, search-overlay, destination-input, viapoint-input-5,
-  viapoint-input-4, viapoint-input-3, viapoint-input-2, viapoint-input-1,
-  origin-input;
+$zindex: base, map-container, footer, map-gradient, map-fullscreen-toggle,
+  map-buttons, context-panel, search-panel, search-overlay, destination-input,
+  viapoint-input-5, viapoint-input-4, viapoint-input-3, viapoint-input-2,
+  viapoint-input-1, origin-input;
 $leaflet-overlay: 800;


### PR DESCRIPTION
Previously the popup was drawn partially out of the screen area. This also prevents the fullscreen toggle button from being drawn over the menu.

Screenshots:
![image](https://user-images.githubusercontent.com/2669201/41644735-a427e956-7477-11e8-802f-d4bb5dc8f834.png)
![image](https://user-images.githubusercontent.com/2669201/41644768-bd464a4a-7477-11e8-861c-2c2f1b3c8f53.png)

Link to the JIRA task: https://digitransit.atlassian.net/browse/DCW-43