### PR TITLE
DT-2695: do not show an extra scrollbar in Firefox

### DIFF
--- a/app/component/SummaryNavigation.js
+++ b/app/component/SummaryNavigation.js
@@ -135,6 +135,7 @@ class SummaryNavigation extends React.Component {
           ? Math.min(600, 0.5 * window.innerWidth)
           : 291;
     }
+    const isOpen = this.getOffcanvasState();
 
     return (
       <div style={{ background: '#f4f4f5' }}>
@@ -145,18 +146,18 @@ class SummaryNavigation extends React.Component {
               disableSwipeToOpen
               openSecondary
               docked={false}
-              open={this.getOffcanvasState()}
+              open={isOpen}
               onRequestChange={this.onRequestChange}
               // Needed for the closing arrow button that's left of the drawer.
               containerStyle={{
                 background: 'transparent',
                 boxShadow: 'none',
-                '-moz-transform': 'none', // needed to prevent showing an extra scrollbar in FF
+                ...(isOpen && { '-moz-transform': 'none' }), // needed to prevent showing an extra scrollbar in FF
               }}
               width={drawerWidth}
             >
               <CustomizeSearch
-                isOpen={this.getOffcanvasState()}
+                isOpen={isOpen}
                 params={this.props.params}
                 onToggleClick={this.toggleCustomizeSearchOffcanvas}
               />


### PR DESCRIPTION
The purpose of this pull request is to disable showing an extra scrollbar when the advanced settings menu is open. It is up to Firefox to show the other scrollbar when necessary.

Link to the JIRA task: https://digitransit.atlassian.net/browse/DT-2695
