### PR TITLE
Exact versions by default 

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "classnames": "2.2.6",
     "cookie-parser": "1.4.3",
     "debug": "3.1.0",
-    "element-resize-detector": "^1.1.14",
+    "element-resize-detector": "1.1.14",
     "express": "4.16.3",
     "express-http-proxy": "1.2.0",
     "express-static-gzip": "0.3.2",
@@ -177,7 +177,7 @@
     "webpack": "4.12.0",
     "webpack-assets-manifest": "3.0.1",
     "webpack-bundle-analyzer": "2.13.1",
-    "webpack-cli": "^2.1.3",
+    "webpack-cli": "2.1.3",
     "webpack-dev-server": "3.1.4",
     "zopfli-webpack-plugin": "0.1.0"
   }


### PR DESCRIPTION
Fixed package.json to use exact versions.

Added save-exact setting to prevent similar mistakes in the future (https://docs.npmjs.com/misc/config#save-exact). yarn supports that setting too.