### PR TITLE
Do not return an empty modes list

### DIFF
--- a/app/store/localStorage.js
+++ b/app/store/localStorage.js
@@ -69,7 +69,7 @@ export function removeItem(k) {
 }
 
 export function getCustomizedSettings() {
-  return getItemAsJson('customizedSettings');
+  return getItemAsJson('customizedSettings', '{}');
 }
 
 export function setCustomizedSettings(data) {

--- a/app/util/modeUtils.js
+++ b/app/util/modeUtils.js
@@ -176,8 +176,10 @@ export const getModes = (location, config) => {
       .split('?')[0]
       .split(',')
       .map(m => m.toUpperCase());
-  } else if (getCustomizedSettings().modes) {
-    return getCustomizedSettings().modes;
+  }
+  const { modes } = getCustomizedSettings();
+  if (Array.isArray(modes) && !isEmpty(modes)) {
+    return modes;
   }
   return getDefaultModes(config);
 };

--- a/test/unit/localStorage.test.js
+++ b/test/unit/localStorage.test.js
@@ -5,6 +5,7 @@ import {
   resetRoutingSettings,
   getRoutingSettings,
   setRoutingSettings,
+  getCustomizedSettings,
 } from '../../app/store/localStorage';
 
 const ROUTING_SETTINGS = {
@@ -61,7 +62,13 @@ describe('localStorage', () => {
     it('reseting routing settings should work', () => {
       resetRoutingSettings();
       // eslint-disable-next-line
-      expect(getRoutingSettings()).to.be.empty; 
+      expect(getRoutingSettings()).to.be.empty;
+    });
+  });
+
+  describe('getCustomizedSettings', () => {
+    it('should return an empty object by default', () => {
+      expect(getCustomizedSettings()).to.deep.equal({});
     });
   });
 });

--- a/test/unit/modeUtils.test.js
+++ b/test/unit/modeUtils.test.js
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import { createMemoryHistory } from 'react-router';
 import { StreetMode, TransportMode } from '../../app/constants';
 import * as utils from '../../app/util/modeUtils';
+import { setCustomizedSettings } from '../../app/store/localStorage';
 
 const config = {
   transportModes: {
@@ -79,7 +80,44 @@ describe('modeUtils', () => {
       expect(modes).to.contain(TransportMode.Bus);
     });
 
-    it('should retrieve all modes with "defaultValue": true from config if the location query is not available', () => {
+    it('should retrieve modes from localStorage if the location query is not available', () => {
+      setCustomizedSettings({
+        modes: [StreetMode.ParkAndRide, TransportMode.Bus],
+      });
+      const location = {
+        query: {
+          modes: undefined,
+        },
+      };
+
+      const modes = utils.getModes(location, config);
+      expect(modes.length).to.equal(2);
+      expect(modes).to.contain(StreetMode.ParkAndRide);
+      expect(modes).to.contain(TransportMode.Bus);
+
+      global.localStorage.clear();
+    });
+
+    it('should retrieve all modes with "defaultValue": true from config if the location query is not available and localStorage has an empty modes list', () => {
+      setCustomizedSettings({
+        modes: [],
+      });
+      const location = {
+        query: {
+          modes: undefined,
+        },
+      };
+
+      const modes = utils.getModes(location, config);
+      expect(modes.length).to.equal(3);
+      expect(modes).to.contain(StreetMode.Walk);
+      expect(modes).to.contain(TransportMode.Bus);
+      expect(modes).to.contain(TransportMode.Rail);
+
+      global.localStorage.clear();
+    });
+
+    it('should retrieve all modes with "defaultValue": true from config if the location query and localStorage are not available', () => {
       const location = {
         query: {
           modes: undefined,

--- a/test/unit/planParamUtil.test.js
+++ b/test/unit/planParamUtil.test.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { preparePlanParams } from '../../app/util/planParamUtil';
+
+describe('planParamUtil', () => {
+  describe('preparePlanParams', () => {
+    it('should return mode defaults from config if modes are missing from both the current URI and localStorage', () => {
+      const config = {
+        modeToOTP: {
+          bus: 'bus',
+          walk: 'walk',
+        },
+        streetModes: {
+          walk: {
+            availableForSelection: true,
+            defaultValue: true,
+            icon: 'walk',
+          },
+        },
+        transportModes: {
+          bus: {
+            availableForSelection: true,
+            defaultValue: true,
+          },
+        },
+      };
+      const params = preparePlanParams(config)(
+        {
+          from: 'Kera, Espoo::60.217992,24.75494',
+          to: 'Leppävaara, Espoo::60.219235,24.81329',
+        },
+        {
+          location: {
+            query: {},
+          },
+        },
+      );
+
+      const { modes } = params;
+      expect(modes).to.equal('BUS,WALK');
+    });
+  });
+});


### PR DESCRIPTION
Changed the way customized settings are handled. Now an empty modes list from localStorage will be overridden by default modes.