### PR TITLE
DT-2694: apply initial focus on the search field programmatically

### DIFF
--- a/app/component/DTSearchAutosuggest.js
+++ b/app/component/DTSearchAutosuggest.js
@@ -19,20 +19,21 @@ class DTAutosuggest extends React.Component {
 
   static propTypes = {
     autoFocus: PropTypes.bool,
-    className: PropTypes.string.isRequired,
+    className: PropTypes.string,
     executeSearch: PropTypes.func,
     id: PropTypes.string.isRequired,
     isFocused: PropTypes.func,
     layers: PropTypes.arrayOf(PropTypes.string).isRequired,
     placeholder: PropTypes.string.isRequired,
     refPoint: dtLocationShape.isRequired,
-    searchType: PropTypes.string.isRequired,
+    searchType: PropTypes.oneOf(['all', 'endpoint']).isRequired,
     selectedFunction: PropTypes.func.isRequired,
     value: PropTypes.string,
   };
 
   static defaultProps = {
     autoFocus: false,
+    className: '',
     executeSearch,
     isFocused: () => {},
     value: '',

--- a/app/component/DTSearchAutosuggest.js
+++ b/app/component/DTSearchAutosuggest.js
@@ -12,27 +12,30 @@ import Icon from './Icon';
 
 class DTAutosuggest extends React.Component {
   static contextTypes = {
-    getStore: PropTypes.func.isRequired,
     config: PropTypes.object.isRequired,
+    getStore: PropTypes.func.isRequired,
     intl: intlShape.isRequired,
   };
 
   static propTypes = {
-    selectedFunction: PropTypes.func,
-    placeholder: PropTypes.string.isRequired,
-    value: PropTypes.string,
     autoFocus: PropTypes.bool,
-    searchType: PropTypes.string.isRequired,
     className: PropTypes.string.isRequired,
+    executeSearch: PropTypes.func,
     id: PropTypes.string.isRequired,
     isFocused: PropTypes.func,
+    layers: PropTypes.arrayOf(PropTypes.string).isRequired,
+    placeholder: PropTypes.string.isRequired,
     refPoint: dtLocationShape.isRequired,
-    layers: PropTypes.array.isRequired,
+    searchType: PropTypes.string.isRequired,
+    selectedFunction: PropTypes.func.isRequired,
+    value: PropTypes.string,
   };
 
   static defaultProps = {
-    isFocused: () => {},
     autoFocus: false,
+    executeSearch,
+    isFocused: () => {},
+    value: '',
   };
 
   constructor(props) {
@@ -46,6 +49,12 @@ class DTAutosuggest extends React.Component {
       valid: true,
     };
   }
+
+  componentDidMount = () => {
+    if (this.props.autoFocus && this.input) {
+      this.input.focus();
+    }
+  };
 
   componentWillReceiveProps = nextProps => {
     if (nextProps.value !== this.state.value && !this.state.editing) {
@@ -143,7 +152,7 @@ class DTAutosuggest extends React.Component {
 
   fetchFunction = ({ value }) =>
     this.setState({ valid: false }, () => {
-      executeSearch(
+      this.props.executeSearch(
         this.context.getStore,
         this.props.refPoint,
         {
@@ -253,8 +262,6 @@ class DTAutosuggest extends React.Component {
       value,
       onChange: this.onChange,
       onBlur: this.onBlur,
-      onFocus: this.onFocus,
-      autoFocus: this.props.autoFocus,
       className: `react-autosuggest__input ${this.props.className}`,
     };
 

--- a/test/unit/DTSearchAutosuggest.test.js
+++ b/test/unit/DTSearchAutosuggest.test.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { mockContext, mockChildContextTypes } from './helpers/mock-context';
+import { mountWithIntl } from './helpers/mock-intl-enzyme';
+import DTSearchAutosuggest from '../../app/component/DTSearchAutosuggest';
+
+describe('<DTSearchAutosuggest />', () => {
+  it('should render with focus set', () => {
+    const props = {
+      autoFocus: true,
+      id: 'origin',
+      layers: [],
+      placeholder: 'search-origin',
+      refPoint: {},
+      searchType: 'all',
+      selectedFunction: () => {},
+    };
+    const wrapper = mountWithIntl(<DTSearchAutosuggest {...props} />, {
+      context: { ...mockContext, config: {} },
+      childContextTypes: {
+        ...mockChildContextTypes,
+        config: PropTypes.object,
+      },
+    });
+    const focusedElement = document.activeElement;
+
+    expect(wrapper.find('input').instance()).to.equal(focusedElement);
+  });
+});

--- a/test/unit/helpers/mock-intl-enzyme.js
+++ b/test/unit/helpers/mock-intl-enzyme.js
@@ -10,10 +10,10 @@
 import React from 'react';
 import { IntlProvider, intlShape } from 'react-intl';
 import { mount, shallow } from 'enzyme';
-import locales from '../../../app/translations';
+import { en } from '../../../app/translations';
 
 // Create the IntlProvider to retrieve context for wrapping around.
-const intlProvider = new IntlProvider({ locale: 'en', locales }, {});
+const intlProvider = new IntlProvider({ locale: 'en', messages: en }, {});
 const { intl } = intlProvider.getChildContext();
 
 /**

--- a/test/unit/helpers/mock-intl-enzyme.js
+++ b/test/unit/helpers/mock-intl-enzyme.js
@@ -10,10 +10,13 @@
 import React from 'react';
 import { IntlProvider, intlShape } from 'react-intl';
 import { mount, shallow } from 'enzyme';
-import { en } from '../../../app/translations';
+import translations from '../../../app/translations';
 
 // Create the IntlProvider to retrieve context for wrapping around.
-const intlProvider = new IntlProvider({ locale: 'en', messages: en }, {});
+const intlProvider = new IntlProvider(
+  { locale: 'en', messages: translations.en },
+  {},
+);
 const { intl } = intlProvider.getChildContext();
 
 /**


### PR DESCRIPTION
The purpose of this pull request is to enable having focus and getting suggestions on the search field after page load and typing in a letter. Relying on the input field's autoFocus prop would correctly set the focus but suggestions would not show up.

Link to the relevant JIRA task: https://digitransit.atlassian.net/browse/DT-2694