### PR TITLE
DT-2648: added handling for current location in via points

### DIFF
--- a/app/component/DTEndpointAutosuggest.js
+++ b/app/component/DTEndpointAutosuggest.js
@@ -16,7 +16,7 @@ import { PREFIX_STOPS, PREFIX_TERMINALS } from '../util/path';
 import { startLocationWatch } from '../action/PositionActions';
 import PositionStore from '../store/PositionStore';
 
-class DTEndpointAutosuggest extends React.Component {
+export class DTEndpointAutosuggest extends React.Component {
   static contextTypes = {
     executeAction: PropTypes.func.isRequired,
     router: routerShape.isRequired,
@@ -126,11 +126,7 @@ class DTEndpointAutosuggest extends React.Component {
 
     const location = suggestionToLocation(item);
 
-    if (
-      item.properties.layer === 'currentPosition' &&
-      !item.properties.lat &&
-      this.props.id !== 'viapoint'
-    ) {
+    if (item.properties.layer === 'currentPosition' && !item.properties.lat) {
       this.setState({ pendingCurrentLocation: true }, () =>
         this.context.executeAction(startLocationWatch),
       );

--- a/app/component/DTEndpointAutosuggest.js
+++ b/app/component/DTEndpointAutosuggest.js
@@ -16,7 +16,7 @@ import { PREFIX_STOPS, PREFIX_TERMINALS } from '../util/path';
 import { startLocationWatch } from '../action/PositionActions';
 import PositionStore from '../store/PositionStore';
 
-export class DTEndpointAutosuggest extends React.Component {
+export class DTEndpointAutosuggestComponent extends React.Component {
   static contextTypes = {
     executeAction: PropTypes.func.isRequired,
     router: routerShape.isRequired,
@@ -157,7 +157,7 @@ export class DTEndpointAutosuggest extends React.Component {
 }
 
 export default connectToStores(
-  DTEndpointAutosuggest,
+  DTEndpointAutosuggestComponent,
   ['PositionStore'],
   context => ({
     locationState: context.getStore('PositionStore').getLocationState(),

--- a/test/unit/DTEndpointAutosuggest.test.js
+++ b/test/unit/DTEndpointAutosuggest.test.js
@@ -1,10 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import PropTypes from 'prop-types';
 import React from 'react';
-import { routerShape } from 'react-router';
 
-import { mockContext, mockChildContextTypes } from './helpers/mock-context';
 import { shallowWithIntl } from './helpers/mock-intl-enzyme';
 import mockRouter from './helpers/mock-router';
 import { DTEndpointAutosuggest } from '../../app/component/DTEndpointAutosuggest';

--- a/test/unit/DTEndpointAutosuggest.test.js
+++ b/test/unit/DTEndpointAutosuggest.test.js
@@ -1,0 +1,133 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { routerShape } from 'react-router';
+
+import { mockContext, mockChildContextTypes } from './helpers/mock-context';
+import { shallowWithIntl } from './helpers/mock-intl-enzyme';
+import mockRouter from './helpers/mock-router';
+import { DTEndpointAutosuggest } from '../../app/component/DTEndpointAutosuggest';
+
+describe('<DTEndpointAutosuggest />', () => {
+  describe('onSuggestionSelected', () => {
+    it('should invoke onLocationSelected for a mapped via-point', () => {
+      let wasCalled = false;
+      const props = {
+        id: 'viapoint',
+        locationState: {
+          lat: 0,
+          lon: 0,
+          status: 'no-location',
+          hasLocation: false,
+          isLocationingInProgress: false,
+          locationingFailed: false,
+        },
+        onLocationSelected: () => {
+          wasCalled = true;
+        },
+        placeholder: 'via-point',
+        refPoint: {
+          lat: 60.199118,
+          lon: 24.940652,
+          address: 'Opastinsilta 6, Helsinki',
+          set: true,
+          ready: true,
+        },
+        searchType: 'endpoint',
+        value: ' ',
+      };
+      const wrapper = shallowWithIntl(<DTEndpointAutosuggest {...props} />, {
+        context: {
+          executeAction: () => {},
+          router: mockRouter,
+        },
+      });
+
+      const selectedItem = {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [24.940652, 60.199118] },
+        properties: {
+          id: 'node:5561515626',
+          gid: 'openstreetmap:address:node:5561515626',
+          layer: 'address',
+          source: 'openstreetmap',
+          source_id: 'node:5561515626',
+          name: 'Opastinsilta 6',
+          housenumber: '6',
+          street: 'Opastinsilta',
+          postalcode: '00520',
+          postalcode_gid: 'whosonfirst:postalcode:421473063',
+          confidence: 1,
+          distance: 196.673,
+          accuracy: 'point',
+          country: 'Suomi',
+          country_gid: 'whosonfirst:country:85633143',
+          country_a: 'FIN',
+          region: 'Uusimaa',
+          region_gid: 'whosonfirst:region:85683067',
+          localadmin: 'Helsinki',
+          localadmin_gid: 'whosonfirst:localadmin:907199715',
+          locality: 'Helsinki',
+          locality_gid: 'whosonfirst:locality:101748417',
+          neighbourhood: 'Itä-Pasila',
+          neighbourhood_gid: 'whosonfirst:neighbourhood:85907977',
+          label: 'Opastinsilta 6, Helsinki',
+        },
+      };
+      wrapper.instance().onSuggestionSelected(selectedItem);
+
+      expect(wasCalled).to.equal(true);
+    });
+
+    it('should invoke executeAction for a non-mapped via point (i.e. currentLocation)', () => {
+      const props = {
+        id: 'viapoint',
+        locationState: {
+          lat: 0,
+          lon: 0,
+          status: 'no-location',
+          hasLocation: false,
+          isLocationingInProgress: false,
+          locationingFailed: false,
+        },
+        onLocationSelected: () => {},
+        placeholder: 'via-point',
+        refPoint: {
+          lat: 60.199118,
+          lon: 24.940652,
+          address: 'Opastinsilta 6, Helsinki',
+          set: true,
+          ready: true,
+        },
+        searchType: 'endpoint',
+        value: ' ',
+      };
+
+      let wasCalled = false;
+      const wrapper = shallowWithIntl(<DTEndpointAutosuggest {...props} />, {
+        context: {
+          executeAction: () => {
+            wasCalled = true;
+          },
+          router: mockRouter,
+        },
+      });
+
+      const selectedItem = {
+        type: 'CurrentLocation',
+        lat: 0,
+        lon: 0,
+        properties: {
+          labelId: 'Käytä nykyistä sijaintia',
+          layer: 'currentPosition',
+          lat: 0,
+          lon: 0,
+        },
+      };
+      wrapper.instance().onSuggestionSelected(selectedItem);
+
+      expect(wasCalled).to.equal(true);
+    });
+  });
+});

--- a/test/unit/DTEndpointAutosuggest.test.js
+++ b/test/unit/DTEndpointAutosuggest.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { shallowWithIntl } from './helpers/mock-intl-enzyme';
 import mockRouter from './helpers/mock-router';
-import { DTEndpointAutosuggest } from '../../app/component/DTEndpointAutosuggest';
+import { DTEndpointAutosuggestComponent } from '../../app/component/DTEndpointAutosuggest';
 
 describe('<DTEndpointAutosuggest />', () => {
   describe('onSuggestionSelected', () => {
@@ -34,12 +34,15 @@ describe('<DTEndpointAutosuggest />', () => {
         searchType: 'endpoint',
         value: ' ',
       };
-      const wrapper = shallowWithIntl(<DTEndpointAutosuggest {...props} />, {
-        context: {
-          executeAction: () => {},
-          router: mockRouter,
+      const wrapper = shallowWithIntl(
+        <DTEndpointAutosuggestComponent {...props} />,
+        {
+          context: {
+            executeAction: () => {},
+            router: mockRouter,
+          },
         },
-      });
+      );
 
       const selectedItem = {
         type: 'Feature',
@@ -102,14 +105,17 @@ describe('<DTEndpointAutosuggest />', () => {
       };
 
       let wasCalled = false;
-      const wrapper = shallowWithIntl(<DTEndpointAutosuggest {...props} />, {
-        context: {
-          executeAction: () => {
-            wasCalled = true;
+      const wrapper = shallowWithIntl(
+        <DTEndpointAutosuggestComponent {...props} />,
+        {
+          context: {
+            executeAction: () => {
+              wasCalled = true;
+            },
+            router: mockRouter,
           },
-          router: mockRouter,
         },
-      });
+      );
 
       const selectedItem = {
         type: 'CurrentLocation',

--- a/test/unit/helpers/mock-router.js
+++ b/test/unit/helpers/mock-router.js
@@ -1,0 +1,11 @@
+const mockRouter = {
+  push: () => {},
+  replace: () => {},
+  go: () => {},
+  goBack: () => {},
+  goForward: () => {},
+  setRouteLeaveHook: () => {},
+  isActive: () => {},
+};
+
+export default mockRouter;


### PR DESCRIPTION
The purpose of this pull request is to enable the use of current position in via points. Previously this would crash the UI. Now the current location gets properly mapped through geocoding into a valid address.

Relevant JIRA task: https://digitransit.atlassian.net/browse/DT-2648

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/42220011-73035fa4-7ed6-11e8-88f7-69f0b5c254b1.png)
