### PR TITLE
re-enabled test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ jobs:
       node_js: "8"
       script:
       - yarn install
-      - yarn run test-unit
+      - yarn run test-coverage
+      - yarn run test-report
 
     - stage: visual
       env: VISUAL=chrome


### PR DESCRIPTION
Re-enable test coverage. It was disabled in #2360. It's should be fixed now #2392. 