### PR TITLE
Regression: fix TypeError on IE11 due to missing 'normalize' function

### DIFF
--- a/app/util/searchUtils.js
+++ b/app/util/searchUtils.js
@@ -1,5 +1,4 @@
 import Relay from 'react-relay/classic';
-
 import get from 'lodash/get';
 import isString from 'lodash/isString';
 import take from 'lodash/take';
@@ -8,6 +7,8 @@ import sortBy from 'lodash/sortBy';
 import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
 import merge from 'lodash/merge';
+import unorm from 'unorm';
+
 import { getJson } from './xhrPromise';
 import routeCompare from './route-compare';
 import { distance } from './geo-utils';
@@ -389,13 +390,16 @@ export const sortSearchResults = (results, term = '') => {
     }
   };
 
-  const normalize = str =>
-    isString(str)
-      ? `${str
-          .toLowerCase()
-          .normalize('NFD')
-          .replace(/[\u0300-\u036f]/g, '')}`
-      : '';
+  const normalize = str => {
+    if (!isString(str)) {
+      return '';
+    }
+    const lowerCaseStr = str.toLowerCase();
+    return `${(lowerCaseStr.normalize
+      ? lowerCaseStr.normalize('NFD')
+      : unorm.nfd(lowerCaseStr)
+    ).replace(/[\u0300-\u036f]/g, '')}`;
+  };
 
   const isMatch = (value, comparison) =>
     value.length > 0 && comparison.length > 0 && value === comparison;

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "react-transition-group": "1.2.1",
     "recompose": "0.27.1",
     "serialize-javascript": "1.5.0",
+    "unorm": "1.4.1",
     "zurb-foundation-5": "5.4.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12398,6 +12398,10 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
+unorm@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.4.1.tgz#364200d5f13646ca8bcd44490271335614792300"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"


### PR DESCRIPTION
The purpose of this pull request is to fix the TypeError on IE11 due to missing 'normalize' function. The bug results in no suggestion entries being shown for IE11.

Related Sentry entry: https://sentry.hsl.fi/sentry/digitransit-ui/issues/42910/