### PR TITLE
Add default map bounding coordinates to SummaryPage

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -189,6 +189,9 @@ class SummaryPage extends React.Component {
       from,
       to,
     } = this.props;
+    const {
+      config: { defaultEndpoint },
+    } = this.context;
     const activeIndex = getActiveIndex(state);
     const itineraries = (plan && plan.itineraries) || [];
 
@@ -252,12 +255,19 @@ class SummaryPage extends React.Component {
       ),
     );
 
+    const delta = 0.0269; // this is roughly equal to 3 km
+    const defaultBounds = [
+      [defaultEndpoint.lat - delta, defaultEndpoint.lon - delta],
+      [defaultEndpoint.lat + delta, defaultEndpoint.lon + delta],
+    ];
     return (
       <MapContainer
         className="summary-map"
         leafletObjs={leafletObjs}
         fitBounds
-        bounds={bounds}
+        bounds={
+          bounds.filter(a => a[0] && a[1]).length > 0 ? bounds : defaultBounds
+        }
         showScaleBar
       />
     );

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -246,28 +246,34 @@ class SummaryPage extends React.Component {
 
     // Decode all legs of all itineraries into latlong arrays,
     // and concatenate into one big latlong array
-    const bounds = [].concat(
-      [[from.lat, from.lon], [to.lat, to.lon]],
-      ...itineraries.map(itinerary =>
-        [].concat(
-          ...itinerary.legs.map(leg => polyline.decode(leg.legGeometry.points)),
+    const bounds = []
+      .concat(
+        [[from.lat, from.lon], [to.lat, to.lon]],
+        ...itineraries.map(itinerary =>
+          [].concat(
+            ...itinerary.legs.map(leg =>
+              polyline.decode(leg.legGeometry.points),
+            ),
+          ),
         ),
-      ),
-    );
+      )
+      .filter(a => a[0] && a[1]);
 
+    const centerPoint = {
+      lat: from.lat || to.lat || defaultEndpoint.lat,
+      lon: from.lon || to.lon || defaultEndpoint.lon,
+    };
     const delta = 0.0269; // this is roughly equal to 3 km
     const defaultBounds = [
-      [defaultEndpoint.lat - delta, defaultEndpoint.lon - delta],
-      [defaultEndpoint.lat + delta, defaultEndpoint.lon + delta],
+      [centerPoint.lat - delta, centerPoint.lon - delta],
+      [centerPoint.lat + delta, centerPoint.lon + delta],
     ];
     return (
       <MapContainer
         className="summary-map"
         leafletObjs={leafletObjs}
         fitBounds
-        bounds={
-          bounds.filter(a => a[0] && a[1]).length > 0 ? bounds : defaultBounds
-        }
+        bounds={bounds.length > 1 ? bounds : defaultBounds}
         showScaleBar
       />
     );


### PR DESCRIPTION
This pull request adds default bounding coordinates for the map shown on SummaryPage. The bounds are based on the coordinates of "from", "to" and "default" endpoints, depending on which of these are available. This prevents the SummaryPage view from crashing if there is no geolocation information available in the url.

The next step would be to add retrieving the coordinates for "from" and "to" endpoints in case this information is missing.

One of the related Sentry entries: https://sentry.hsl.fi/sentry/digitransit-ui/issues/1311