### PR TITLE
DCW-51: make the left content wrapper scrollable

### DIFF
--- a/app/component/DesktopView.js
+++ b/app/component/DesktopView.js
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
@@ -7,7 +8,7 @@ import Icon from './Icon';
 import ErrorBoundary from './ErrorBoundary';
 
 export default function DesktopView(
-  { title, header, map, content, homeUrl },
+  { title, header, map, content, homeUrl, scrollable },
   { intl: { formatMessage } },
 ) {
   return (
@@ -31,8 +32,14 @@ export default function DesktopView(
             {title}
           </h2>
         </div>
-        {header}
-        <ErrorBoundary>{content}</ErrorBoundary>
+        <div
+          className={cx('scrollable-content-wrapper', {
+            'momentum-scroll': scrollable,
+          })}
+        >
+          {header}
+          <ErrorBoundary>{content}</ErrorBoundary>
+        </div>
       </div>
       <div className="map-content">
         <ErrorBoundary>{map}</ErrorBoundary>
@@ -47,6 +54,11 @@ DesktopView.propTypes = {
   map: PropTypes.node,
   content: PropTypes.node,
   homeUrl: PropTypes.string,
+  scrollable: PropTypes.bool,
+};
+
+DesktopView.defaultProps = {
+  scrollable: false,
 };
 
 DesktopView.contextTypes = {

--- a/app/component/ItinerarySummaryListContainer.js
+++ b/app/component/ItinerarySummaryListContainer.js
@@ -7,22 +7,38 @@ import ExternalLink from './ExternalLink';
 import SummaryRow from './SummaryRow';
 import Icon from './Icon';
 
-function ItinerarySummaryListContainer(props, context) {
-  if (!props.error && props.itineraries && props.itineraries.length > 0) {
-    const open = props.open && Number(props.open);
-    const summaries = props.itineraries.map((itinerary, i) => (
+function ItinerarySummaryListContainer(
+  {
+    activeIndex,
+    children,
+    currentTime,
+    error,
+    from,
+    intermediatePlaces,
+    itineraries,
+    onSelect,
+    onSelectImmediately,
+    open,
+    searchTime,
+    to,
+  },
+  { config },
+) {
+  if (!error && itineraries && itineraries.length > 0) {
+    const openedIndex = open && Number(open);
+    const summaries = itineraries.map((itinerary, i) => (
       <SummaryRow
-        refTime={props.searchTime}
+        refTime={searchTime}
         key={i} // eslint-disable-line react/no-array-index-key
         hash={i}
         data={itinerary}
-        passive={i !== props.activeIndex}
-        currentTime={props.currentTime}
-        onSelect={props.onSelect}
-        onSelectImmediately={props.onSelectImmediately}
-        intermediatePlaces={props.relay.route.params.intermediatePlaces}
+        passive={i !== activeIndex}
+        currentTime={currentTime}
+        onSelect={onSelect}
+        onSelectImmediately={onSelectImmediately}
+        intermediatePlaces={intermediatePlaces}
       >
-        {i === open && props.children}
+        {i === openedIndex && children}
       </SummaryRow>
     ));
 
@@ -30,8 +46,7 @@ function ItinerarySummaryListContainer(props, context) {
       <div className="summary-list-container momentum-scroll">{summaries}</div>
     );
   }
-  const { from, to } = props.relay.route.params;
-  if (!props.error && (!from.lat || !from.lon || !to.lat || !to.lon)) {
+  if (!error && (!from.lat || !from.lon || !to.lat || !to.lon)) {
     return (
       <div className="summary-list-container summary-no-route-found">
         <FormattedMessage
@@ -44,19 +59,19 @@ function ItinerarySummaryListContainer(props, context) {
 
   let msg;
   let outside;
-  if (props.error) {
-    msg = props.error;
-  } else if (!inside([from.lon, from.lat], context.config.areaPolygon)) {
+  if (error) {
+    msg = error;
+  } else if (!inside([from.lon, from.lat], config.areaPolygon)) {
     msg = 'origin-outside-service';
     outside = true;
-  } else if (!inside([to.lon, to.lat], context.config.areaPolygon)) {
+  } else if (!inside([to.lon, to.lat], config.areaPolygon)) {
     msg = 'destination-outside-service';
     outside = true;
   } else {
     msg = 'no-route-msg';
   }
   let linkPart = null;
-  if (outside && context.config.nationalServiceLink) {
+  if (outside && config.nationalServiceLink) {
     linkPart = (
       <div>
         <FormattedMessage
@@ -65,7 +80,7 @@ function ItinerarySummaryListContainer(props, context) {
         />
         <ExternalLink
           className="external-no-route"
-          {...context.config.nationalServiceLink}
+          {...config.nationalServiceLink}
         />
       </div>
     );
@@ -90,33 +105,30 @@ function ItinerarySummaryListContainer(props, context) {
   );
 }
 
+const locationShape = PropTypes.shape({
+  lat: PropTypes.number,
+  lon: PropTypes.number,
+  address: PropTypes.string,
+});
+
 ItinerarySummaryListContainer.propTypes = {
-  searchTime: PropTypes.number.isRequired,
-  itineraries: PropTypes.array,
   activeIndex: PropTypes.number.isRequired,
   currentTime: PropTypes.number.isRequired,
+  children: PropTypes.node,
+  error: PropTypes.string,
+  from: locationShape.isRequired,
+  intermediatePlaces: PropTypes.arrayOf(locationShape),
+  itineraries: PropTypes.array,
   onSelect: PropTypes.func.isRequired,
   onSelectImmediately: PropTypes.func.isRequired,
   open: PropTypes.number,
-  error: PropTypes.string,
-  children: PropTypes.node,
-  relay: PropTypes.shape({
-    route: PropTypes.shape({
-      params: PropTypes.shape({
-        to: PropTypes.shape({
-          lat: PropTypes.number,
-          lon: PropTypes.number,
-          address: PropTypes.string.isRequired,
-        }).isRequired,
-        from: PropTypes.shape({
-          lat: PropTypes.number,
-          lon: PropTypes.number,
-          address: PropTypes.string.isRequired,
-        }).isRequired,
-        intermediatePlaces: PropTypes.array,
-      }).isRequired,
-    }).isRequired,
-  }).isRequired,
+  searchTime: PropTypes.number.isRequired,
+  to: locationShape.isRequired,
+};
+
+ItinerarySummaryListContainer.defaultProps = {
+  intermediatePlaces: [],
+  itineraries: [],
 };
 
 ItinerarySummaryListContainer.contextTypes = {

--- a/app/component/ItinerarySummaryListContainer.js
+++ b/app/component/ItinerarySummaryListContainer.js
@@ -42,9 +42,7 @@ function ItinerarySummaryListContainer(
       </SummaryRow>
     ));
 
-    return (
-      <div className="summary-list-container momentum-scroll">{summaries}</div>
-    );
+    return <div className="summary-list-container">{summaries}</div>;
   }
   if (!error && (!from.lat || !from.lon || !to.lat || !to.lon)) {
     return (

--- a/app/component/ItineraryTimePicker.js
+++ b/app/component/ItineraryTimePicker.js
@@ -136,11 +136,7 @@ class ItineraryTimePicker extends React.Component {
   render() {
     const { hour, minute } = this.state;
     return (
-      <div
-        className={`time-input-container time-selector ${
-          !isMobile ? 'time-selector' : ''
-        }`}
-      >
+      <div className="time-input-container time-selector">
         <form id="time" onBlur={this.handleBlur}>
           <input
             type="tel"

--- a/app/component/ItineraryTimePicker.js
+++ b/app/component/ItineraryTimePicker.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
-import { isMobile } from '../util/browser';
 
 class ItineraryTimePicker extends React.Component {
   static propTypes = {

--- a/app/component/SummaryNavigation.js
+++ b/app/component/SummaryNavigation.js
@@ -121,7 +121,6 @@ class SummaryNavigation extends React.Component {
 
   render() {
     const { config, router } = this.context;
-    // const quickSettingsIcon = this.checkQuickSettingsIcon();
     const className = cx({ 'bp-large': this.props.breakpoint === 'large' });
     let drawerWidth = 291;
     if (typeof window !== 'undefined') {
@@ -147,7 +146,6 @@ class SummaryNavigation extends React.Component {
               containerStyle={{
                 background: 'transparent',
                 boxShadow: 'none',
-                // width: this.props.breakpoint !== 'large' ? '100%' : '600px',
                 ...(isOpen && { MozTransform: 'none' }), // needed to prevent showing an extra scrollbar in FF
               }}
               width={drawerWidth}

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -314,6 +314,7 @@ class SummaryPage extends React.Component {
           // TODO: Chceck preferences
           content={content}
           map={map}
+          scrollable
         />
       );
     }

--- a/app/component/TimeNavigationButtons.js
+++ b/app/component/TimeNavigationButtons.js
@@ -12,19 +12,22 @@ import { BreakpointConsumer } from '../util/withBreakpoint';
 
 class TimeNavigationButtons extends React.Component {
   static propTypes = {
-    itineraries: PropTypes.arrayOf(
-      PropTypes.shape({
-        endTime: PropTypes.number.isRequired,
-        startTime: PropTypes.number.isRequired,
-      }).isRequired,
-    ).isRequired,
+    isEarlierDisabled: PropTypes.bool.isRequired,
+    isLaterDisabled: PropTypes.bool.isRequired,
     onEarlier: PropTypes.func.isRequired,
     onLater: PropTypes.func.isRequired,
     onNow: PropTypes.func.isRequired,
   };
 
   static contextTypes = {
-    config: PropTypes.object.isRequired,
+    config: PropTypes.shape({
+      itinerary: PropTypes.shape({
+        enableFeedback: PropTypes.bool,
+        timeNavigation: PropTypes.shape({
+          enableButtonArrows: PropTypes.bool,
+        }).isRequired,
+      }).isRequired,
+    }).isRequired,
   };
 
   static displayName = 'TimeNavigationButtons';
@@ -44,9 +47,6 @@ class TimeNavigationButtons extends React.Component {
   render() {
     const { config } = this.context;
 
-    if (!this.props.itineraries || !this.props.itineraries[0]) {
-      return null;
-    }
     const itineraryFeedback = config.itinerary.enableFeedback ? (
       <ItineraryFeedback />
     ) : null;
@@ -69,6 +69,7 @@ class TimeNavigationButtons extends React.Component {
             {itineraryFeedback}
             <button
               className="standalone-btn time-navigation-earlier-btn"
+              disabled={this.props.isEarlierDisabled}
               onClick={this.props.onEarlier}
             >
               {leftArrow}
@@ -82,6 +83,7 @@ class TimeNavigationButtons extends React.Component {
             </button>
             <button
               className="standalone-btn time-navigation-later-btn"
+              disabled={this.props.isLaterDisabled}
               onClick={this.props.onLater}
             >
               <FormattedMessage id="later" defaultMessage="Later" />

--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -76,7 +76,6 @@ $content-background-color: $background-color;
     background-size: contain;
     background-repeat: no-repeat;
     background-position: left center;
-
   }
   .navi-logo {
     margin-left: 32px;
@@ -247,6 +246,18 @@ section.content {
         height: auto;
         width: 100%;
         display: inline;
+      }
+
+      .scrollable-content-wrapper {
+        display: flex;
+        flex: 1 0 0;
+        flex-direction: column;
+
+        @media print {
+          display: inline;
+          height: auto;
+          width: 100%;
+        }
       }
     }
 

--- a/app/component/summary.scss
+++ b/app/component/summary.scss
@@ -1,16 +1,7 @@
 .desktop .summary {
-  flex: 1 0 0px;
-  flex-basis: 0px;
   display: flex;
+  flex: 1 0 0;
   flex-direction: column;
-  overflow-x: auto;
-}
-
-@media print {
-  .desktop .summary {
-    display: block;
-    height: auto;
-  }
 }
 
 .summary-no-route-found {
@@ -345,14 +336,10 @@
   }
 }
 
-.desktop {
-  & .street-mode-selector-panel-container {
-    padding: 0 $padding-medium;
-  }
+.desktop .street-mode-selector-panel-container {
+  padding: 0 $padding-medium;
 }
 
-.mobile {
-  & .street-mode-selector-panel-container {
-    padding: 0 $padding-small;
-  }
+.mobile .street-mode-selector-panel-container {
+  padding: 0 $padding-small;
 }

--- a/test/unit/component/SummaryPlanContainer.test.js
+++ b/test/unit/component/SummaryPlanContainer.test.js
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import React from 'react';
+
+import { mockContext, mockChildContextTypes } from '../helpers/mock-context';
+import { mountWithIntl } from '../helpers/mock-intl-enzyme';
+import {
+  getRelayContextMock,
+  mockRelayChildContextTypes,
+} from '../helpers/mock-relay';
+import defaultConfig from '../../../app/configurations/config.default';
+
+import { Component as SummaryPlanContainer } from '../../../app/component/SummaryPlanContainer';
+
+describe('<SummaryPlanContainer />', () => {
+  it('should disable the earlier/later buttons if there are no itineraries available', () => {
+    const config = {
+      areaPolygon: defaultConfig.areaPolygon,
+      itinerary: {
+        timeNavigation: {},
+      },
+    };
+    const props = {
+      breakpoint: 'large',
+      config,
+      itineraries: [],
+      params: {
+        from: 'Kamppi, Helsinki::60.169022,24.931691',
+        to: 'Vuosaari, Helsinki::60.207129,25.144063',
+      },
+      plan: {
+        date: 1535490633000,
+      },
+      serviceTimeRange: {
+        end: 1538341199,
+        start: 1535490000,
+      },
+      setError: () => {},
+      setLoading: () => {},
+    };
+    const wrapper = mountWithIntl(<SummaryPlanContainer {...props} />, {
+      context: {
+        ...mockContext,
+        ...getRelayContextMock(),
+        config,
+      },
+      childContextTypes: {
+        ...mockChildContextTypes,
+        ...mockRelayChildContextTypes,
+      },
+    });
+    expect(
+      wrapper.find('.time-navigation-earlier-btn[disabled=true]'),
+    ).to.have.lengthOf(1);
+    expect(
+      wrapper.find('.time-navigation-later-btn[disabled=true]'),
+    ).to.have.lengthOf(1);
+  });
+});

--- a/test/unit/helpers/mock-relay.js
+++ b/test/unit/helpers/mock-relay.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+import Relay from 'react-relay/classic';
+
+/**
+ * Returns a valid react-relay classic context that can be used for unit testing.
+ *
+ * @param {*} variables Any relay variables that should be applied, defaults to {}.
+ * @param {*} params Any route params that should be applied, defaults to variables.
+ */
+export const getRelayContextMock = (variables = {}, params = variables) => ({
+  relay: {
+    environment: Relay.Store,
+    variables: { ...variables },
+  },
+  route: {
+    name: '',
+    params: { ...params },
+    queries: {},
+  },
+});
+
+export const mockRelayChildContextTypes = {
+  relay: PropTypes.object,
+  route: PropTypes.object,
+};


### PR DESCRIPTION
The purpose of this pull request is to make the whole main content wrapper scrollable if need be. This prevents the scrollable list from being squished to nothing on the desktop view with multiple via points and lots of routes.

In addition:
- the routes list should now always show the ealier/now/later buttons (but disabled, if no routes are available)
- some PropTypes were updated to better reflect the reality