### PR TITLE
Fix route search redirection from hsl.fi 

### DIFF
--- a/app/util/oldParamParser.js
+++ b/app/util/oldParamParser.js
@@ -42,8 +42,9 @@ function parseLocation(location, input, config) {
       .then(parseGeocodingResults)
       .catch(() => ' ');
   } else if (input) {
+    const decoded = input.replace('+', ' ');
     return getGeocodingResult(
-      input,
+      decoded,
       config.searchParams,
       null,
       null,

--- a/test/flow/tests/redirect/search-from-hsl.js
+++ b/test/flow/tests/redirect/search-from-hsl.js
@@ -11,7 +11,7 @@ module.exports = {
 
     const url = `${
       browser.launch_url
-    }&from_in=kamppi&to_in=pasila&when=now&timetype=departure&hour=${hour}&minute=${minute}&daymonthyear=${day}.${month}.${year}&form_build_id=form-wdOvinqH72XqTtDZF0cHQOz8d9o3bU3nrzDbFIv5-Lc&form_id=reittiopas_search_form&day=${day}&month=${month}&year=${year}`;
+    }&from_in=malmin%2bkauppatie&to_in=pasila&when=now&timetype=departure&hour=${hour}&minute=${minute}&daymonthyear=${day}.${month}.${year}&form_build_id=form-wdOvinqH72XqTtDZF0cHQOz8d9o3bU3nrzDbFIv5-Lc&form_id=reittiopas_search_form&day=${day}&month=${month}&year=${year}`;
 
     browser.url(url);
     const itinerarySummary = browser.page.itinerarySummary();
@@ -21,7 +21,7 @@ module.exports = {
 
     const itineraryInstructions = browser.page.itineraryInstructions();
     itineraryInstructions.waitForFirstItineraryInstructionColumn();
-    itineraryInstructions.verifyOrigin('Kamppi');
+    itineraryInstructions.verifyOrigin('Malmin kauppatie');
     itineraryInstructions.verifyDestination('Pasila');
     browser.end();
   },


### PR DESCRIPTION
Route equests from hsl.fi use + sign (hex %2b) as a separator between address components. This seems to confuse geocoder parsing. Fixed by converting + into blank space.