### PR TITLE
Fix routing results overlap in IE11

### DIFF
--- a/app/component/SummaryNavigation.js
+++ b/app/component/SummaryNavigation.js
@@ -125,7 +125,7 @@ class SummaryNavigation extends React.Component {
     const isOpen = this.getOffcanvasState();
 
     return (
-      <div style={{ background: '#f4f4f5' }}>
+      <div className="summary-navigation-container">
         <LazilyLoad modules={this.customizeSearchModules}>
           {({ Drawer, CustomizeSearch }) => (
             <Drawer

--- a/app/component/summary.scss
+++ b/app/component/summary.scss
@@ -343,3 +343,8 @@
 .mobile .street-mode-selector-panel-container {
   padding: 0 $padding-small;
 }
+
+.summary-navigation-container {
+  background-color: $background-color-lighter;
+  flex: 0 0 auto;
+}


### PR DESCRIPTION
The purpose of this pull request is to prevent IE11 from rendering the routing results on top of the summary navigation component.

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/46394231-309fd800-c6f1-11e8-8a20-14a5d44e80cb.png)
