### PR TITLE
Enable pointer events for the modal close icon link

### DIFF
--- a/app/component/AppBarLarge.js
+++ b/app/component/AppBarLarge.js
@@ -62,7 +62,7 @@ const AppBarLarge = (
               defaultMessage: 'Disruptions',
             })}
           >
-            <Icon img="icon-icon_caution" />
+            <Icon img="icon-icon_caution" pointerEvents />
           </a>
         </div>
         <div className="padding-horizontal-large navi-margin">

--- a/app/component/Modal.js
+++ b/app/component/Modal.js
@@ -53,7 +53,7 @@ class Modal extends React.Component {
                 onClick={this.props.toggleVisibility}
                 className="close-button cursor-pointer"
               >
-                <Icon img="icon-icon_close" />
+                <Icon img="icon-icon_close" pointerEvents />
               </a>
             </div>
           </div>

--- a/test/unit/AppBarLarge.test.js
+++ b/test/unit/AppBarLarge.test.js
@@ -3,7 +3,9 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { shallowWithIntl } from './helpers/mock-intl-enzyme';
+
 import AppBarLarge from '../../app/component/AppBarLarge';
+import Icon from '../../app/component/Icon';
 
 describe('<AppBarLarge />', () => {
   it('should show logo image', () => {
@@ -36,5 +38,13 @@ describe('<AppBarLarge />', () => {
 
     expect(wrapper.find('.title span')).to.have.lengthOf(1);
     expect(wrapper.find('div.navi-logo')).to.have.lengthOf(0);
+  });
+
+  it('should enable pointer events for the disruptions info icon', () => {
+    const wrapper = shallowWithIntl(<AppBarLarge titleClicked={() => {}} />, {
+      context: { config: { textLogo: false } },
+    });
+    const icon = wrapper.find(Icon);
+    expect(icon.props().pointerEvents).to.equal(true);
   });
 });

--- a/test/unit/component/Modal.test.js
+++ b/test/unit/component/Modal.test.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import React from 'react';
+
+import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
+import Icon from '../../../app/component/Icon';
+import Modal from '../../../app/component/Modal';
+
+describe('<Modal />', () => {
+  it('should set pointerEvents on for the close icon', () => {
+    const wrapper = shallowWithIntl(<Modal toggleVisibility={() => {}} />);
+    const icon = wrapper.find(Icon);
+    expect(icon.props().pointerEvents).to.equal(true);
+  });
+});


### PR DESCRIPTION
The purpose of this pull request is to re-enable the close icon link pointer events. This should allow the user to close the modal dialog.