### PR TITLE
Make console warnings and errors throw in unit tests

### DIFF
--- a/app/component/PrintableItineraryHeader.js
+++ b/app/component/PrintableItineraryHeader.js
@@ -46,7 +46,7 @@ export default class PrintableItineraryHeader extends React.Component {
     );
     const language = this.context.getStore('PreferencesStore').getLanguage();
     const weekDay = moment(this.props.itinerary.startTime)
-      .lang(language)
+      .locale(language)
       .format('dddd');
     const weekDayUpperCase = weekDay.charAt(0).toUpperCase() + weekDay.slice(1);
 
@@ -80,7 +80,7 @@ export default class PrintableItineraryHeader extends React.Component {
               {` `}
               <span>
                 {moment(this.props.itinerary.startTime)
-                  .lang(language)
+                  .locale(language)
                   .format('DD.M.YYYY')}
               </span>
             </div>

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "relay-compiler": "1.6.0",
     "sass-loader": "7.0.3",
     "selenium-webdriver": "4.0.0-alpha.1",
+    "sinon": "7.0.0",
     "stats-webpack-plugin": "0.6.2",
     "style-loader": "0.21.0",
     "stylelint": "9.2.1",

--- a/test/unit/PrintableLeg.test.js
+++ b/test/unit/PrintableLeg.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import React from 'react';
 
 import { mockContext, mockChildContextTypes } from './helpers/mock-context';
-import { shallowWithIntl, mountWithIntl } from './helpers/mock-intl-enzyme';
+import { shallowWithIntl } from './helpers/mock-intl-enzyme';
 import {
   PrintableLeg,
   TransferMap,
@@ -17,6 +17,7 @@ describe('<PrintableLeg />', () => {
     const props = {
       ...dt2587,
       context: { config: {} },
+      index: 0,
     };
 
     const wrapper = shallowWithIntl(<PrintableLeg {...props} />, {
@@ -33,13 +34,11 @@ describe('<PrintableLeg />', () => {
       context: { config: {} },
     };
 
-    const wrapper = mountWithIntl(<PrintableLeg {...props} />, {
+    const wrapper = shallowWithIntl(<PrintableLeg {...props} />, {
       context: mockContext,
       childContextTypes: mockChildContextTypes,
     });
 
-    expect(wrapper.find('.itinerary-leg-stopname').text()).to.equal(
-      'Return the bike to Veturitori station',
-    );
+    expect(wrapper.find({ id: 'return-cycle-to' })).to.have.lengthOf(1);
   });
 });

--- a/test/unit/helpers/init.js
+++ b/test/unit/helpers/init.js
@@ -5,9 +5,11 @@ import { after, before } from 'mocha';
 import { stub } from 'sinon';
 
 before('setting up enzyme and jsdom', () => {
-  stub(console, 'error').callsFake(warning => {
+  const callback = warning => {
     throw new Error(warning);
-  });
+  };
+  stub(console, 'error').callsFake(callback);
+  stub(console, 'warn').callsFake(callback);
 
   const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
   const { window } = jsdom;
@@ -37,6 +39,7 @@ before('setting up enzyme and jsdom', () => {
 
 after('reset the error handler function', () => {
   console.error.restore();
+  console.warn.restore();
 });
 
 // prevent mocha from interpreting imported .png images

--- a/test/unit/helpers/init.js
+++ b/test/unit/helpers/init.js
@@ -1,9 +1,14 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { JSDOM } from 'jsdom';
-import { before } from 'mocha';
+import { after, before } from 'mocha';
+import { stub } from 'sinon';
 
 before('setting up enzyme and jsdom', () => {
+  stub(console, 'error').callsFake(warning => {
+    throw new Error(warning);
+  });
+
   const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
   const { window } = jsdom;
 
@@ -28,6 +33,10 @@ before('setting up enzyme and jsdom', () => {
   copyProps(window, global);
 
   configure({ adapter: new Adapter() });
+});
+
+after('reset the error handler function', () => {
+  console.error.restore();
 });
 
 // prevent mocha from interpreting imported .png images

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,6 +960,32 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@sinonjs/commons@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.0.2.tgz#3e0ac737781627b8844257fadc3d803997d0526e"
+  integrity sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@3.0.0", "@sinonjs/formatio@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.0.0.tgz#9d282d81030a03a03fa0c5ce31fd8786a4da311a"
+  integrity sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==
+  dependencies:
+    "@sinonjs/samsam" "2.1.0"
+
+"@sinonjs/samsam@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.0.tgz#b8b8f5b819605bd63601a6ede459156880f38ea3"
+  integrity sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==
+  dependencies:
+    array-from "^2.1.1"
+
+"@sinonjs/samsam@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.1.2.tgz#16947fce5f57258d01f1688fdc32723093c55d3f"
+  integrity sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==
+
 "@types/node@*":
   version "10.3.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.6.tgz#ea8aab9439b59f40d19ec5f13b44642344872b11"
@@ -1462,6 +1488,11 @@ array-flatten@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
   integrity sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-includes@^3.0.3:
   version "3.0.3"
@@ -8284,6 +8315,11 @@ jszip@^3.1.3:
     pako "~1.0.2"
     readable-stream "~2.0.6"
 
+just-extend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-3.0.0.tgz#cee004031eaabf6406da03a7b84e4fe9d78ef288"
+  integrity sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==
+
 kew@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
@@ -8691,7 +8727,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.get@^4.0:
+lodash.get@^4.0, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -8829,6 +8865,16 @@ loglevelnext@^1.0.1:
   dependencies:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
+
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
+
+lolex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
+  integrity sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==
 
 long@^3.2.0:
   version "3.2.0"
@@ -9629,6 +9675,17 @@ nightwatch@0.9.20:
     optimist "0.6.1"
     proxy-agent "2.0.0"
     q "1.4.1"
+
+nise@^1.4.5:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.6.tgz#76cc3915925056ae6c405dd8ad5d12bde570c19f"
+  integrity sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==
+  dependencies:
+    "@sinonjs/formatio" "3.0.0"
+    just-extend "^3.0.0"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 node-abi@^2.2.0:
   version "2.4.3"
@@ -10586,6 +10643,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
 
 path-to-regexp@^2.2.1:
   version "2.4.0"
@@ -13030,6 +13094,21 @@ simple-get@^2.7.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+sinon@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.0.0.tgz#99f2e5198d90a01ccbcebd4dc181a24827cb90dd"
+  integrity sha512-8OrSYFPZ9xaECfi1ayVMd0ihYCW2OZYgX3rBczrB990gHZMM+aftvhNTJazGz/luS0Us9NWgD5P3KGQ7kYZvGg==
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    "@sinonjs/formatio" "^3.0.0"
+    "@sinonjs/samsam" "^2.1.2"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^3.0.0"
+    nise "^1.4.5"
+    supports-color "^5.5.0"
+    type-detect "^4.0.8"
+
 sizzle@^2.2.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/sizzle/-/sizzle-2.3.3.tgz#4eb078c37231a56b52e4193f701e7ef8937e606b"
@@ -13713,6 +13792,13 @@ supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
 svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
@@ -13895,6 +13981,11 @@ test-exclude@^4.2.2:
     minimatch "^3.0.4"
     read-pkg-up "^3.0.0"
     require-main-filename "^1.0.1"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+  integrity sha1-45mpgiV6J22uQou5KEXLcb3CbRk=
 
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
@@ -14169,7 +14260,7 @@ type-detect@0.1.1:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
   integrity sha1-C6XsKohWQORw6k6FBZcZANrFiCI=
 
-type-detect@^4.0.0:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
The purpose of this pull request is to prevent any kinds of errors and warnings from creeping into the unit test suites. If something gets output to console.warn or console.error it automatically results in the unit test not passing.