### PR TITLE
Remove console warnings from unit tests

### DIFF
--- a/test/unit/component/SaveCustomizedSettingsButton.test.js
+++ b/test/unit/component/SaveCustomizedSettingsButton.test.js
@@ -55,6 +55,7 @@ describe('<SaveCustomizedSettingsButton />', () => {
           ...mockContext,
           config: defaultConfig,
           location: {
+            ...mockContext.location,
             query: {},
           },
         },
@@ -78,6 +79,7 @@ describe('<SaveCustomizedSettingsButton />', () => {
           ...mockContext,
           config: defaultConfig,
           location: {
+            ...mockContext.location,
             query: {
               optimize: OptimizeType.Safe,
             },
@@ -123,6 +125,7 @@ describe('<SaveCustomizedSettingsButton />', () => {
       ...mockContext,
       config: defaultConfig,
       location: {
+        ...mockContext.location,
         query,
       },
     };
@@ -156,6 +159,7 @@ describe('<SaveCustomizedSettingsButton />', () => {
       ...mockContext,
       config: defaultConfig,
       location: {
+        ...mockContext.location,
         query,
       },
     };


### PR DESCRIPTION
The change to making console warnings throw results in the master build not succeeding. The purpose of this pull request is to provide a context object that passes PropType validation in order to not log any warnings to the console. 