### PR TITLE
Fix the clear-input action for autosuggest components

### DIFF
--- a/app/component/DTAutosuggestPanel.js
+++ b/app/component/DTAutosuggestPanel.js
@@ -167,9 +167,7 @@ class DTAutosuggestPanel extends React.Component {
 
   handleViaPointLocationSelected = (viaPointLocation, i) => {
     const { viaPoints } = this.state;
-    viaPoints[i] = {
-      ...viaPointLocation,
-    };
+    viaPoints[i] = viaPointLocation.cleared ? {} : { ...viaPointLocation };
     this.setState({ viaPoints }, () => this.updateViaPoints(viaPoints));
   };
 
@@ -307,7 +305,7 @@ class DTAutosuggestPanel extends React.Component {
             value={this.value(origin)}
             isFocused={this.isFocused}
             onLocationSelected={location => {
-              let newOrigin = { ...location, ready: true };
+              let newOrigin = { ...location, ready: !location.cleared };
               let { destination } = this.props;
               if (location.type === 'CurrentLocation') {
                 newOrigin = { ...location, gps: true, ready: !!location.lat };
@@ -364,7 +362,7 @@ class DTAutosuggestPanel extends React.Component {
                   id="viapoint"
                   autoFocus={
                     // Disable autofocus if using IE11
-                    isIe ? false : breakpoint === 'large'
+                    isIe ? false : breakpoint === 'large' && origin.ready
                   }
                   refPoint={this.props.origin}
                   searchType="endpoint"
@@ -443,7 +441,7 @@ class DTAutosuggestPanel extends React.Component {
               id="destination"
               autoFocus={
                 // Disable autofocus if using IE11
-                isIe ? false : breakpoint === 'large'
+                isIe ? false : breakpoint === 'large' && origin.ready
               }
               refPoint={origin}
               searchType={this.props.searchType}
@@ -453,7 +451,7 @@ class DTAutosuggestPanel extends React.Component {
               value={this.value(this.props.destination)}
               onLocationSelected={location => {
                 let updatedOrigin = origin;
-                let destination = { ...location, ready: true };
+                let destination = { ...location, ready: !location.cleared };
                 if (location.type === 'CurrentLocation') {
                   destination = {
                     ...location,

--- a/app/component/DTEndpointAutosuggest.js
+++ b/app/component/DTEndpointAutosuggest.js
@@ -134,7 +134,11 @@ export class DTEndpointAutosuggestComponent extends React.Component {
     }
     const location = suggestionToLocation(item);
 
-    if (item && item.properties.layer === 'currentPosition' && !item.properties.lat) {
+    if (
+      item &&
+      item.properties.layer === 'currentPosition' &&
+      !item.properties.lat
+    ) {
       this.setState({ pendingCurrentLocation: true }, () =>
         this.context.executeAction(startLocationWatch),
       );

--- a/app/component/DTEndpointAutosuggest.js
+++ b/app/component/DTEndpointAutosuggest.js
@@ -119,7 +119,7 @@ export class DTEndpointAutosuggestComponent extends React.Component {
       return;
     }
     // stop
-    if (item.timetableClicked === true) {
+    if (item && item.timetableClicked === true) {
       const prefix = isStop(item.properties) ? PREFIX_STOPS : PREFIX_TERMINALS;
 
       const url = `/${prefix}/${getGTFSId(item.properties)}`;
@@ -128,13 +128,13 @@ export class DTEndpointAutosuggestComponent extends React.Component {
     }
 
     // route
-    if (item.properties.link) {
+    if (item && item.properties.link) {
       this.context.router.push(item.properties.link);
       return;
     }
     const location = suggestionToLocation(item);
 
-    if (item.properties.layer === 'currentPosition' && !item.properties.lat) {
+    if (item && item.properties.layer === 'currentPosition' && !item.properties.lat) {
       this.setState({ pendingCurrentLocation: true }, () =>
         this.context.executeAction(startLocationWatch),
       );

--- a/app/component/DTOldSearchSavingAutosuggest.js
+++ b/app/component/DTOldSearchSavingAutosuggest.js
@@ -35,7 +35,7 @@ class DTOldSearchSavingAutosuggest extends React.Component {
   onSelect = item => {
     // type is destination unless timetable or route was clicked
     let type = 'endpoint';
-    switch (item.type) {
+    switch (item && item.type) {
       case 'Stop': // stop can be timetable or
         if (item.timetableClicked === true) {
           type = 'search';
@@ -47,7 +47,7 @@ class DTOldSearchSavingAutosuggest extends React.Component {
       default:
     }
 
-    if (item.type.indexOf('Favourite') === -1) {
+    if (item && item.type.indexOf('Favourite') === -1) {
       this.context.executeAction(saveSearch, { item, type });
     }
     this.props.onSelect(item, type);

--- a/app/component/DTSearchAutosuggest.js
+++ b/app/component/DTSearchAutosuggest.js
@@ -196,15 +196,17 @@ class DTAutosuggest extends React.Component {
     });
 
   clearInput = () => {
-    const newState = {
-      editing: true,
-      value: '',
-    };
-    // must update suggestions
-    this.setState(newState, () => this.fetchFunction({ value: '' }));
-
-    this.props.isFocused(true);
-    this.input.focus();
+    this.props.isFocused(false);
+    this.setState(
+      {
+        editing: false,
+        value: '',
+      },
+      () => {
+        this.input.blur();
+        this.props.selectedFunction(null);
+      },
+    );
   };
 
   inputClicked = () => {

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -192,7 +192,8 @@ class IndexPage extends React.Component {
       ...routes.map(route => route.footerOptions),
     );
     const selectedMainTab = this.getSelectedTab();
-    const mapLocation = destination && destination.ready && !origin.ready ? destination : origin;
+    const mapLocation =
+      destination && destination.ready && !origin.ready ? destination : origin;
 
     return breakpoint === 'large' ? (
       <div

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -192,6 +192,7 @@ class IndexPage extends React.Component {
       ...routes.map(route => route.footerOptions),
     );
     const selectedMainTab = this.getSelectedTab();
+    const mapLocation = destination && destination.ready && !origin.ready ? destination : origin;
 
     return breakpoint === 'large' ? (
       <div
@@ -224,7 +225,7 @@ class IndexPage extends React.Component {
           breakpoint={breakpoint}
           showStops
           showScaleBar
-          origin={origin}
+          origin={mapLocation}
           renderCustomButtons={() => (
             <React.Fragment>
               {this.renderStreetModeSelector(config, router)}
@@ -257,7 +258,7 @@ class IndexPage extends React.Component {
           <MapWithTracking
             breakpoint={breakpoint}
             showStops
-            origin={origin}
+            origin={mapLocation}
             renderCustomButtons={() => (
               <React.Fragment>
                 {this.renderStreetModeSelector(config, router)}

--- a/app/util/otpStrings.js
+++ b/app/util/otpStrings.js
@@ -49,7 +49,7 @@ export const locationToOTP = location => {
   if (location.gps) {
     return 'POS';
   }
-  if (location.set === false) {
+  if (location.set === false || location.cleared === true) {
     return '-';
   }
   return `${location.address}::${location.lat},${location.lon}`;

--- a/app/util/suggestionUtils.js
+++ b/app/util/suggestionUtils.js
@@ -143,6 +143,7 @@ export function getLabel(properties) {
 }
 
 export function suggestionToLocation(item) {
+  if (!item) return { cleared: true };
   const name = getLabel(item.properties);
 
   return {

--- a/app/util/suggestionUtils.js
+++ b/app/util/suggestionUtils.js
@@ -143,7 +143,9 @@ export function getLabel(properties) {
 }
 
 export function suggestionToLocation(item) {
-  if (!item) return { cleared: true };
+  if (!item) {
+    return { cleared: true };
+  }
   const name = getLabel(item.properties);
 
   return {

--- a/test/flow/tests/favourite/addRoute.js
+++ b/test/flow/tests/favourite/addRoute.js
@@ -1,15 +1,15 @@
 module.exports = {
   tags: ['favourite'],
   'Add route 615 as favourite': browser => {
-    browser.url(
-      'http://127.0.0.1:8080/Opastinsilta%206,%20Helsinki::60.199437,24.940472/-',
-    );
+    const homeUrl =
+      'http://127.0.0.1:8080/Opastinsilta%206,%20Helsinki::60.199437,24.940472/-';
+    browser.url(homeUrl);
 
     browser.page.searchFields().selectFirstRouteSuggestion('615');
 
     const route = browser.page.route();
     route.addRouteAsFavourite();
-    browser.back();
+    browser.url(homeUrl);
 
     const myFavourites = browser.page.myFavourites();
     myFavourites.clickFavourites();

--- a/test/unit/DTEndpointAutosuggest.test.js
+++ b/test/unit/DTEndpointAutosuggest.test.js
@@ -80,6 +80,50 @@ describe('<DTEndpointAutosuggest />', () => {
       expect(wasCalled).to.equal(true);
     });
 
+    it('should invoke onLocationSelected for cleared input', () => {
+      let wasCalled = false;
+      let selectedLocation = undefined;
+      const props = {
+        id: 'viapoint',
+        locationState: {
+          lat: 0,
+          lon: 0,
+          status: 'no-location',
+          hasLocation: false,
+          isLocationingInProgress: false,
+          locationingFailed: false,
+        },
+        onLocationSelected: (loc) => {
+          wasCalled = true;
+          selectedLocation = loc;
+        },
+        placeholder: 'via-point',
+        refPoint: {
+          lat: 60.199118,
+          lon: 24.940652,
+          address: 'Opastinsilta 6, Helsinki',
+          set: true,
+          ready: true,
+        },
+        searchType: 'endpoint',
+        value: ' ',
+      };
+      const wrapper = shallowWithIntl(
+        <DTEndpointAutosuggestComponent {...props} />,
+        {
+          context: {
+            executeAction: () => {},
+            router: mockRouter,
+          },
+        },
+      );
+
+      wrapper.instance().onSuggestionSelected(null);
+
+      expect(wasCalled).to.equal(true);
+      expect(selectedLocation).to.eql({ cleared: true });
+    });
+
     it('should invoke executeAction for a non-mapped via point (i.e. currentLocation)', () => {
       const props = {
         id: 'viapoint',

--- a/test/unit/DTEndpointAutosuggest.test.js
+++ b/test/unit/DTEndpointAutosuggest.test.js
@@ -82,7 +82,7 @@ describe('<DTEndpointAutosuggest />', () => {
 
     it('should invoke onLocationSelected for cleared input', () => {
       let wasCalled = false;
-      let selectedLocation = undefined;
+      let selectedLocation;
       const props = {
         id: 'viapoint',
         locationState: {
@@ -93,7 +93,7 @@ describe('<DTEndpointAutosuggest />', () => {
           isLocationingInProgress: false,
           locationingFailed: false,
         },
-        onLocationSelected: (loc) => {
+        onLocationSelected: loc => {
           wasCalled = true;
           selectedLocation = loc;
         },


### PR DESCRIPTION
At the moment, clicking on the X icon at the right end of the autosuggest input box does not in fact clear the selection, but just focuses the input box. This is rather surprising. There is in fact no way of removing a selection once it's already been made. This is very frustrating especially when using the site as a homescreen app at least on Android, in which use case it never forgets a prior state.

This PR makes tapping the X icon actually clear the selection, by:
- Refactoring the behavious of clearItem() in DTSearchAutosuggest
- Supporting a `null` value for the item used in the DTEndpointAutosuggest, DTOldSearchSavingAutosuggest, and DTSearchAutosuggest
- Adding an optional `cleared` field to the location object, and using it where appropriate

As a related change, the IndexPage map will now show the destination location if the origin has been cleared but the destination is set. I've also added a unit test for the changes, for the DTEndpointAutosuggest component.