### PR TITLE
Do not include fullscreen components in the styleguide component list

### DIFF
--- a/app/component/StyleGuidePage.js
+++ b/app/component/StyleGuidePage.js
@@ -178,6 +178,9 @@ const components = {
   Error404,
   StopMarkerPopup,
   SelectStreetModeDialog,
+};
+
+const fullscreenComponents = {
   SelectMapLayersDialog,
   MainMenuContainer,
 };
@@ -525,7 +528,10 @@ function StyleGuidePage(props) {
     return (
       <ComponentDocumentation
         mode="examples-only"
-        component={components[props.params.componentName]}
+        component={
+          components[props.params.componentName] ||
+          fullscreenComponents[props.params.componentName]
+        }
       />
     );
   }


### PR DESCRIPTION
The purpose of this pull request is to disable showing fullscreen components in the component listing. Previously showing these components would effectively break the purpose of that list.