### PR TITLE
Improve saved route search label comparison

### DIFF
--- a/app/store/OldSearchesStore.js
+++ b/app/store/OldSearchesStore.js
@@ -41,11 +41,9 @@ class OldSearchesStore extends Store {
   saveSearch(destination) {
     const { items } = this.getStorageObject();
 
+    const key = getNameLabel(destination.item.properties, true);
     const found = find(items, oldItem =>
-      isEqual(
-        getNameLabel(destination.item.properties),
-        getNameLabel(oldItem.item.properties),
-      ),
+      isEqual(key, getNameLabel(oldItem.item.properties, true)),
     );
 
     const timestamp = moment().unix();

--- a/app/util/suggestionUtils.js
+++ b/app/util/suggestionUtils.js
@@ -76,7 +76,11 @@ export const getNameLabel = memoize(
               </span>,
               suggestion.longName,
             ]
-          : [suggestion.shortName, suggestion.longName];
+          : [
+              suggestion.shortName,
+              suggestion.longName,
+              suggestion.agency ? suggestion.agency.name : undefined,
+            ];
       case 'venue':
       case 'address':
         return [

--- a/test/unit/OldSearchesStore.test.js
+++ b/test/unit/OldSearchesStore.test.js
@@ -245,5 +245,70 @@ describe('OldSearchesStore', () => {
       const storedDestination = getOldSearchesStorage().items[0];
       expect(storedDestination.lastUpdated).to.equal(timestamp.unix());
     });
+
+    it("should update a route item's properties if found from store", () => {
+      const oldData = {
+        item: {
+          type: 'Route',
+          properties: {
+            gtfsId: 'foobar',
+            agency: {
+              name: 'Tampereen joukkoliikenne',
+            },
+            shortName: '32',
+            mode: 'BUS',
+            longName: 'TAYS - Hervanta - Hatanpää-Tampella',
+            patterns: [
+              {
+                code: 'foobar:0:01',
+              },
+              {
+                code: 'foobar:1:01',
+              },
+            ],
+            layer: 'route-BUS',
+            link: '/linjat/foobar/pysakit/foobar:0:01',
+          },
+          geometry: {
+            coordinates: null,
+          },
+        },
+        type: 'search',
+      };
+      const newData = {
+        item: {
+          type: 'Route',
+          properties: {
+            gtfsId: 'tampere:32',
+            agency: {
+              name: 'Tampereen joukkoliikenne',
+            },
+            shortName: '32',
+            mode: 'BUS',
+            longName: 'TAYS - Hervanta - Hatanpää-Tampella',
+            patterns: [
+              {
+                code: 'tampere:32:0:01',
+              },
+              {
+                code: 'tampere:32:1:01',
+              },
+            ],
+            layer: 'route-BUS',
+            link: '/linjat/tampere:32/pysakit/tampere:32:0:01',
+          },
+          geometry: {
+            coordinates: null,
+          },
+        },
+        type: 'search',
+      };
+      const store = new OldSearchesStore();
+      store.saveSearch(oldData);
+      store.saveSearch(newData);
+
+      const result = store.getOldSearches()[0];
+      expect(result).to.deep.equal(newData.item);
+    });
   });
 });

--- a/test/unit/util/suggestionUtils.test.js
+++ b/test/unit/util/suggestionUtils.test.js
@@ -37,9 +37,44 @@ describe('suggestionUtils', () => {
       const wrapper = shallowWithIntl(label[1], {});
       expect(wrapper.find('span').text()).to.have.string('Helsinki');
     });
+
     it('should include locality in plaintext gtfs stop label', () => {
       const label = getNameLabel(testdata.stop, true);
       expect(label[1]).to.equal('Helsinki');
+    });
+
+    it('should include agency in the plaintext for routes', () => {
+      const properties = {
+        agency: {
+          name: 'Tampereen joukkoliikenne',
+        },
+        layer: 'route-BUS',
+        longName: 'TAYS - Hervanta - Hatanpää-Tampella',
+        shortName: '32',
+      };
+
+      const label = getNameLabel(properties, true);
+      expect(label).to.deep.equal([
+        '32',
+        'TAYS - Hervanta - Hatanpää-Tampella',
+        'Tampereen joukkoliikenne',
+      ]);
+    });
+
+    it('should ignore a missing agency in the plaintext for routes', () => {
+      const properties = {
+        agency: null,
+        layer: 'route-BUS',
+        longName: 'TAYS - Hervanta - Hatanpää-Tampella',
+        shortName: '32',
+      };
+
+      const label = getNameLabel(properties, true);
+      expect(label).to.deep.equal([
+        '32',
+        'TAYS - Hervanta - Hatanpää-Tampella',
+        undefined,
+      ]);
     });
   });
 });


### PR DESCRIPTION
The purpose of this pull request is to improve the label-based matching of routes when querying old searches. Previously the rich version was used instead of the plain-text one resulting in gtfsIds not getting updated for routes.