### PR TITLE
DT-2819: Added a check and test for an empty itinerary legs array

### DIFF
--- a/app/component/ItineraryLegs.js
+++ b/app/component/ItineraryLegs.js
@@ -41,6 +41,10 @@ class ItineraryLegs extends React.Component {
     let nextLeg;
     const legs = [];
     const compressedLegs = compressLegs(this.props.itinerary.legs);
+    const numberOfLegs = compressedLegs.length;
+    if (numberOfLegs === 0) {
+      return null;
+    }
 
     compressedLegs.forEach((leg, j) => {
       if (j + 1 < compressedLegs.length) {
@@ -206,7 +210,6 @@ class ItineraryLegs extends React.Component {
       }
     });
 
-    const numberOfLegs = compressedLegs.length;
     legs.push(
       <EndLeg
         key={numberOfLegs}

--- a/test/unit/component/ItineraryLegs.test.js
+++ b/test/unit/component/ItineraryLegs.test.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import React from 'react';
 
 import { mockContext, mockChildContextTypes } from '../helpers/mock-context';
-import { mountWithIntl } from '../helpers/mock-intl-enzyme';
+import { mountWithIntl, shallowWithIntl } from '../helpers/mock-intl-enzyme';
 import ItineraryLegs from '../../../app/component/ItineraryLegs';
 
 import data from '../test-data/dcw12';
@@ -29,5 +29,25 @@ describe('<ItineraryLegs />', () => {
     });
 
     expect(wrapper).to.have.lengthOf(1);
+  });
+
+  it("should not fail to render even if the itinerary's legs array is empty", () => {
+    const props = {
+      itinerary: {
+        endTime: 1542814001000,
+        legs: [],
+      },
+    };
+    const wrapper = shallowWithIntl(<ItineraryLegs {...props} />, {
+      context: {
+        config: {
+          itinerary: {
+            waitThreshold: 180,
+          },
+        },
+      },
+    });
+
+    expect(wrapper.isEmptyRender()).to.equal(true);
   });
 });


### PR DESCRIPTION
The purpose of this pull request is to prevent the UI from crashing if an itinerary contains no legs. Instead, an empty container will be rendered. This may happen when the legs are really short (a few seconds in duration). However, recent changes in OTP should usually prevent this from happening in the first place.

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/48909162-399d6200-ee75-11e8-8a22-c44accef1319.png)
