### PR TITLE
Fix timeUtils unit test

### DIFF
--- a/app/util/timeUtils.js
+++ b/app/util/timeUtils.js
@@ -42,7 +42,7 @@ export const sameDay = (x, y) => dateOrEmpty(x, y) === '';
 export const RANGE_PAST = 7;
 
 /**
- * The deafult number of days to include to the service time range from the future.
+ * The default number of days to include to the service time range from the future.
  */
 export const RANGE_FUTURE = 30;
 

--- a/app/util/timeUtils.js
+++ b/app/util/timeUtils.js
@@ -36,9 +36,17 @@ export const dateOrEmpty = (momentTime, momentRefTime) => {
 
 export const sameDay = (x, y) => dateOrEmpty(x, y) === '';
 
+/**
+ * The default number of days to include to the service time range from the past.
+ */
+export const RANGE_PAST = 7;
+
+/**
+ * The deafult number of days to include to the service time range from the future.
+ */
+export const RANGE_FUTURE = 30;
+
 export const validateServiceTimeRange = (serviceTimeRange, now) => {
-  const RANGE_PAST = 7; // sensible range as days
-  const RANGE_FUTURE = 30;
   const NOW = now ? moment.unix(now) : moment();
   const START = NOW.clone()
     .subtract(RANGE_PAST, 'd')

--- a/test/unit/util/timeUtils.test.js
+++ b/test/unit/util/timeUtils.test.js
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import moment from 'moment';
-import { validateServiceTimeRange } from '../../../app/util/timeUtils';
+import {
+  validateServiceTimeRange,
+  RANGE_FUTURE,
+  RANGE_PAST,
+} from '../../../app/util/timeUtils';
 
 const now = moment().unix();
 
@@ -43,19 +47,20 @@ describe('timeUtils', () => {
       );
     });
 
-    it('should not return too long range', () => {
+    it('should not return too long a range', () => {
       const range = {
         start: now - 3600 * 24 * 365 * 2, // 2 years in the past
         end: now + 3600 * 24 * 365 * 2,
       };
       const validated = validateServiceTimeRange(range, now);
-      test(validateServiceTimeRange(range, now));
-      expect(moment.unix(validated.start).dayOfYear()).to.be.below(
-        moment.unix(range.start).dayOfYear(),
-      );
-      expect(moment.unix(validated.end).dayOfYear()).to.be.above(
-        moment.unix(range.end).dayOfYear(),
-      );
+      test(validated);
+      expect(
+        moment
+          .duration(
+            moment.unix(validated.end).diff(moment.unix(validated.start)),
+          )
+          .asDays(),
+      ).to.be.at.most(RANGE_FUTURE + RANGE_PAST + 1); // +1 for today
     });
   });
 });


### PR DESCRIPTION
The purpose of this pull request is to fix the unit test logic to not consider dayOfYear as this will fail when the end of the range is at the beginning of the following year.