### PR TITLE
DT-2601 regression fix: wrap window usage inside isBrowser check

### DIFF
--- a/app/component/RoutePageMeta.js
+++ b/app/component/RoutePageMeta.js
@@ -35,7 +35,6 @@ const RoutePageMeta = compose(
         title,
       },
       config,
-      window && window.location,
     );
   }),
 )(Helmet);

--- a/app/component/StopPageMeta.js
+++ b/app/component/StopPageMeta.js
@@ -41,7 +41,6 @@ const StopPageMeta = compose(
         title,
       },
       config,
-      window && window.location,
     );
   }),
 )(Helmet);

--- a/app/component/SummaryPageMeta.js
+++ b/app/component/SummaryPageMeta.js
@@ -35,10 +35,8 @@ export default compose(
         title,
       },
       config,
-      window && {
-        host: window.location.host,
+      {
         pathname: `/${encodeURIComponent(from)}/${encodeURIComponent(to)}`,
-        protocol: window.location.protocol,
       },
     );
   }),

--- a/app/util/metaUtils.js
+++ b/app/util/metaUtils.js
@@ -8,9 +8,13 @@ import { generateManifestUrl } from '../util/manifestUtils';
  *
  * @param {{ title: string, description: string}} props The title and description to apply to the meta data.
  * @param {*} config The configuration for the software installation.
- * @param {*} location The current location.
+ * @param {{ pathname: string }} location The current location.
  */
-export const generateMetaData = ({ title, description }, config, location) => ({
+export const generateMetaData = (
+  { title, description },
+  config,
+  { pathname } = {},
+) => ({
   title,
   meta: [
     {
@@ -38,10 +42,18 @@ export const generateMetaData = ({ title, description }, config, location) => ({
     link: [
       {
         rel: 'manifest',
-        href: generateManifestUrl(config, location, {
-          title,
-          description,
-        }),
+        href: generateManifestUrl(
+          config,
+          {
+            host: window.location.host,
+            pathname: pathname || window.location.pathname,
+            protocol: window.location.protocol,
+          },
+          {
+            title,
+            description,
+          },
+        ),
       },
     ],
   }),


### PR DESCRIPTION
The purpose of this pull request is to fix the server side rendering of page metadata.