### PR TITLE
Stop appending the protocol to the configured asset url

### DIFF
--- a/app/util/manifestUtils.js
+++ b/app/util/manifestUtils.js
@@ -6,9 +6,9 @@ import trimEnd from 'lodash/trimEnd';
 export const ICON_SIZES = [36, 48, 72, 96, 144, 192, 256, 384, 512];
 
 export const getIconUrl = (config, protocol, host, size) => {
-  const iconHost = config.URL.ASSET_URL || config.APP_PATH || host;
+  const iconHost = config.URL.ASSET_URL || `${protocol}//${host}`;
   const iconPath = trimEnd(config.iconPath || 'icons', '/');
-  return `${protocol}//${iconHost}/${iconPath}/android-chrome-${size}x${size}.png`;
+  return `${iconHost}/${iconPath}/android-chrome-${size}x${size}.png`;
 };
 
 export const generateManifestIcons = (config, protocol, host) =>

--- a/test/unit/util/manifestUtils.test.js
+++ b/test/unit/util/manifestUtils.test.js
@@ -13,7 +13,7 @@ describe('manifestUtils', () => {
       const config = {
         iconPath: 'bar',
         URL: {
-          ASSET_URL: 'foo',
+          ASSET_URL: 'https://foo',
         },
       };
       const protocol = 'https:';
@@ -22,12 +22,13 @@ describe('manifestUtils', () => {
       expect(result).to.equal('https://foo/bar/android-chrome-32x32.png');
     });
 
-    it('should use config.APP_PATH and default iconPath', () => {
+    it('should use config.URL.ASSET_URL and default iconPath', () => {
       const config = {
-        APP_PATH: 'foobar',
-        URL: {},
+        URL: {
+          ASSET_URL: 'https://foobar',
+        },
       };
-      const protocol = 'https:';
+      const protocol = 'http:';
       const host = 'localhost:8080';
       const result = getIconUrl(config, protocol, host, 32);
       expect(result).to.equal('https://foobar/icons/android-chrome-32x32.png');


### PR DESCRIPTION
The purpose of this pull request is to disable adding the used protocol to the configured asset url. The configured url should contain this information already meaning that the resulting url is invalid.