### PR TITLE
Disruptions tab for terminals

### DIFF
--- a/app/component/RouteAlertsContainer.js
+++ b/app/component/RouteAlertsContainer.js
@@ -4,9 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Relay from 'react-relay/classic';
 import { FormattedMessage, intlShape } from 'react-intl';
-import moment from 'moment';
 import find from 'lodash/find';
-import upperFirst from 'lodash/upperFirst';
 import connectToStores from 'fluxible-addons-react/connectToStores';
 
 import RouteAlertsRow from './RouteAlertsRow';
@@ -60,9 +58,8 @@ const getAlerts = (route, patternId, currentTime, intl) => {
         description = description.text;
       }
 
-      const startTime = moment(alert.effectiveStartDate * 1000);
-      const endTime = moment(alert.effectiveEndDate * 1000);
-      const sameDay = startTime.isSame(endTime, 'day');
+      const startTime = alert.effectiveStartDate * 1000;
+      const endTime = alert.effectiveEndDate * 1000;
 
       return (
         <RouteAlertsRow
@@ -72,12 +69,6 @@ const getAlerts = (route, patternId, currentTime, intl) => {
           routeLine={routeLine}
           header={header}
           description={description}
-          endTime={
-            sameDay
-              ? intl.formatTime(endTime)
-              : upperFirst(endTime.calendar(currentTime))
-          }
-          startTime={upperFirst(startTime.calendar(currentTime))}
           expired={startTime > currentTime || currentTime > endTime}
         />
       );

--- a/app/component/RouteAlertsContainer.js
+++ b/app/component/RouteAlertsContainer.js
@@ -85,7 +85,7 @@ const getAlerts = (route, patternId, currentTime, intl) => {
 };
 
 function RouteAlertsContainer(
-  { route, patternId, currentTime, isScrolling },
+  { route, patternId, currentTime, isScrollable },
   { intl },
 ) {
   const hasAlert =
@@ -102,7 +102,7 @@ function RouteAlertsContainer(
   return hasAlert ? (
     <div
       className={cx('route-alerts-list', {
-        'momentum-scroll': isScrolling,
+        'momentum-scroll': isScrollable,
       })}
     >
       {getAlerts(route, patternId, currentTime, intl)}
@@ -119,13 +119,13 @@ function RouteAlertsContainer(
 
 RouteAlertsContainer.propTypes = {
   currentTime: PropTypes.object,
-  isScrolling: PropTypes.bool,
+  isScrollable: PropTypes.bool,
   patternId: PropTypes.string,
   route: PropTypes.object.isRequired,
 };
 
 RouteAlertsContainer.defaultProps = {
-  isScrolling: true,
+  isScrollable: true,
   patternId: undefined,
 };
 

--- a/app/component/RouteAlertsRow.js
+++ b/app/component/RouteAlertsRow.js
@@ -7,8 +7,6 @@ import ComponentUsageExample from './ComponentUsageExample';
 export default function RouteAlertsRow({
   header,
   description,
-  startTime,
-  endTime,
   routeMode,
   routeLine,
   expired,
@@ -24,9 +22,6 @@ export default function RouteAlertsRow({
         vertical
       />
       <div className="route-alert-contents">
-        <div className="route-alert-duration">
-          {startTime} – {endTime}
-        </div>
         <div className={cx('route-alert-header', routeMode)}>{header}</div>
         <div className="route-alert-body">{description}</div>
       </div>
@@ -37,8 +32,6 @@ export default function RouteAlertsRow({
 RouteAlertsRow.propTypes = {
   header: PropTypes.string,
   description: PropTypes.string.isRequired,
-  startTime: PropTypes.string.isRequired,
-  endTime: PropTypes.string.isRequired,
   routeMode: PropTypes.string.isRequired,
   routeLine: PropTypes.string.isRequired,
   expired: PropTypes.bool.isRequired,
@@ -57,11 +50,8 @@ RouteAlertsRow.description = () => (
             'suuntaan, myöhästyy. Syy: tekninen vika. Paikka: Kauppatori, Hakaniemi. ' +
             'Arvioitu kesto: 14:29 - 15:20.'
           }
-          startTime="11:32"
-          endTime="12:20"
           routeMode="tram"
           routeLine="2"
-          day="Today"
           expired={false}
         />
       </ComponentUsageExample>
@@ -73,11 +63,8 @@ RouteAlertsRow.description = () => (
             'suuntaan, myöhästyy. Syy: tekninen vika. Paikka: Kauppatori, Hakaniemi. ' +
             'Arvioitu kesto: 14:29 - 15:20.'
           }
-          startTime="11:32"
-          endTime="12:20"
           routeMode="tram"
           routeLine="2"
-          day="Yesterday"
           expired
         />
       </ComponentUsageExample>

--- a/app/component/StopAlertsContainer.js
+++ b/app/component/StopAlertsContainer.js
@@ -1,15 +1,10 @@
-import orderBy from 'lodash/orderBy';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import Relay from 'react-relay/classic';
 
 import RouteAlertsContainer from './RouteAlertsContainer';
-
-const getSortKey = ({ shortName }) => {
-  const matchGroups = shortName && shortName.match(/[0-9]+/g);
-  return matchGroups ? Number.parseInt(matchGroups[0], 10) : shortName;
-};
+import { routeNameCompare } from '../util/searchUtils';
 
 const StopAlertsContainer = ({ stop }) => {
   const patternsWithAlerts = stop.stoptimesForPatterns
@@ -27,16 +22,16 @@ const StopAlertsContainer = ({ stop }) => {
   }
   return (
     <div className="momentum-scroll">
-      {orderBy(patternsWithAlerts, pattern => getSortKey(pattern.route)).map(
-        pattern => (
+      {patternsWithAlerts
+        .sort((a, b) => routeNameCompare(a.route, b.route))
+        .map(pattern => (
           <RouteAlertsContainer
             key={pattern.code}
             isScrollable={false}
             patternId={pattern.code}
             route={pattern.route}
           />
-        ),
-      )}
+        ))}
     </div>
   );
 };
@@ -45,7 +40,13 @@ StopAlertsContainer.propTypes = {
   stop: PropTypes.shape({
     stoptimesForPatterns: PropTypes.arrayOf(
       PropTypes.shape({
-        pattern: PropTypes.object.isRequired,
+        pattern: PropTypes.shape({
+          code: PropTypes.string.isRequired,
+          route: PropTypes.shape({
+            alerts: PropTypes.array.isRequired,
+            shortName: PropTypes.string,
+          }).isRequired,
+        }),
       }),
     ).isRequired,
   }).isRequired,

--- a/app/component/StopPageTabContainer.js
+++ b/app/component/StopPageTabContainer.js
@@ -102,26 +102,21 @@ function StopPageTabContainer({
               </div>
             </div>
           </Link>
-          {!isTerminal && (
-            <Link
-              to={`${urlBase}/${Tab.Disruptions}`}
-              className={cx('stop-tab-singletab', {
-                active: activeTab === Tab.Disruptions,
-              })}
-            >
-              <div className="stop-tab-singletab-container">
-                <div>
-                  <Icon
-                    className="stop-page-tab_icon"
-                    img="icon-icon_caution"
-                  />
-                </div>
-                <div>
-                  <FormattedMessage id="disruptions" />
-                </div>
+          <Link
+            to={`${urlBase}/${Tab.Disruptions}`}
+            className={cx('stop-tab-singletab', {
+              active: activeTab === Tab.Disruptions,
+            })}
+          >
+            <div className="stop-tab-singletab-container">
+              <div>
+                <Icon className="stop-page-tab_icon" img="icon-icon_caution" />
               </div>
-            </Link>
-          )}
+              <div>
+                <FormattedMessage id="disruptions" />
+              </div>
+            </div>
+          </Link>
         </div>
         <div className="stop-tabs-fillerline" />
       </div>

--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -828,13 +828,6 @@ div.route-tabs {
       }
     }
 
-    .route-alert-duration {
-      color: $gray;
-      font-size: $font-size-xxsmall;
-      margin-bottom: 0.2em;
-      font-weight: 200;
-    }
-
     .route-alert-body {
       color: $gray;
       font-size: $font-size-small;

--- a/app/stopRoutes.js
+++ b/app/stopRoutes.js
@@ -53,6 +53,7 @@ function getDisruptions(location, cb) {
 }
 
 export default function getStopRoutes(isTerminal = false) {
+  const queries = isTerminal ? terminalQueries : stopQueries;
   return (
     <Route path={`/${isTerminal ? PREFIX_TERMINALS : PREFIX_STOPS}`}>
       <IndexRoute component={Error404} />
@@ -84,28 +85,28 @@ export default function getStopRoutes(isTerminal = false) {
           );
         }}
         queries={{
-          header: isTerminal ? terminalQueries : stopQueries,
-          map: isTerminal ? terminalQueries : stopQueries,
-          meta: isTerminal ? terminalQueries : stopQueries,
+          header: queries,
+          map: queries,
+          meta: queries,
         }}
         render={ComponentLoading404Renderer}
       >
         <IndexRoute
           getComponent={getStopPageContentPage}
-          queries={isTerminal ? terminalQueries : stopQueries}
+          queries={queries}
           render={RelayRenderer}
         />
         <Route
           path="kartta"
           fullscreenMap
           getComponent={getStopPageContentPage}
-          queries={isTerminal ? terminalQueries : stopQueries}
+          queries={queries}
           render={RelayRenderer}
         />
         <Route
           path="aikataulu"
           getComponent={getTimetablePage}
-          queries={isTerminal ? terminalQueries : stopQueries}
+          queries={queries}
           render={RelayRenderer}
         >
           <Route path="kartta" fullscreenMap />
@@ -113,21 +114,19 @@ export default function getStopRoutes(isTerminal = false) {
         <Route
           path="linjat"
           getComponent={getRoutesAndPlatformsForStops}
-          queries={isTerminal ? terminalQueries : stopQueries}
+          queries={queries}
           render={RelayRenderer}
         >
           <Route path="kartta" fullscreenMap />
         </Route>
-        {!isTerminal && (
-          <Route
-            path="hairiot"
-            getComponent={getDisruptions}
-            queries={stopQueries}
-            render={RelayRenderer}
-          >
-            <Route path="kartta" fullscreenMap />
-          </Route>
-        )}
+        <Route
+          path="hairiot"
+          getComponent={getDisruptions}
+          queries={queries}
+          render={RelayRenderer}
+        >
+          <Route path="kartta" fullscreenMap />
+        </Route>
       </Route>
     </Route>
   );

--- a/test/unit/component/StopAlertsContainer.test.js
+++ b/test/unit/component/StopAlertsContainer.test.js
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import React from 'react';
+
+import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
+import { Component as StopAlertsContainer } from '../../../app/component/StopAlertsContainer';
+import RouteAlertsContainer from '../../../app/component/RouteAlertsContainer';
+
+import data from '../test-data/StopAlertsContainer.data';
+
+describe('<StopAlertsContainer />', () => {
+  it('should show a "no alerts" message', () => {
+    const props = {
+      ...data.withoutAlerts,
+    };
+    const wrapper = shallowWithIntl(<StopAlertsContainer {...props} />);
+    expect(wrapper.find('.no-stop-alerts-message')).to.have.lengthOf(1);
+  });
+
+  it('should show all the alerts', () => {
+    const props = {
+      ...data.withAlerts,
+    };
+    const wrapper = shallowWithIntl(<StopAlertsContainer {...props} />);
+    expect(wrapper.find(RouteAlertsContainer)).to.have.lengthOf(18);
+  });
+
+  it('should order the alerts by route shortName', () => {
+    const props = {
+      stop: {
+        stoptimesForPatterns: [
+          {
+            pattern: {
+              code: 'second',
+              route: {
+                alerts: [{}],
+                shortName: '37N',
+              },
+            },
+          },
+          {
+            pattern: {
+              code: 'fourth',
+              route: {
+                alerts: [{}],
+                shortName: 'A',
+              },
+            },
+          },
+          {
+            pattern: {
+              code: 'third',
+              route: {
+                alerts: [{}],
+                shortName: '138',
+              },
+            },
+          },
+          {
+            pattern: {
+              code: 'first',
+              route: {
+                alerts: [{}],
+                shortName: '8A',
+              },
+            },
+          },
+        ],
+      },
+    };
+    const wrapper = shallowWithIntl(<StopAlertsContainer {...props} />);
+    expect(
+      wrapper
+        .find(RouteAlertsContainer)
+        .at(0)
+        .props().patternId,
+    ).to.equal('first');
+    expect(
+      wrapper
+        .find(RouteAlertsContainer)
+        .at(1)
+        .props().patternId,
+    ).to.equal('second');
+    expect(
+      wrapper
+        .find(RouteAlertsContainer)
+        .at(2)
+        .props().patternId,
+    ).to.equal('third');
+    expect(
+      wrapper
+        .find(RouteAlertsContainer)
+        .at(3)
+        .props().patternId,
+    ).to.equal('fourth');
+  });
+});

--- a/test/unit/component/StopPageTabContainer.test.js
+++ b/test/unit/component/StopPageTabContainer.test.js
@@ -28,7 +28,7 @@ describe('<StopPageTabContainer />', () => {
     ).to.contain('/hairiot');
   });
 
-  it('should not render the disruptions tab for terminals', () => {
+  it('should render the disruptions tab for terminals', () => {
     const props = {
       breakpoint: 'large',
       children: <div />,
@@ -41,6 +41,6 @@ describe('<StopPageTabContainer />', () => {
       routes: [],
     };
     const wrapper = shallowWithIntl(<StopPageTabContainer {...props} />);
-    expect(wrapper.find('.stop-tab-singletab')).to.have.lengthOf(3);
+    expect(wrapper.find('.stop-tab-singletab')).to.have.lengthOf(4);
   });
 });

--- a/test/unit/test-data/StopAlertsContainer.data.js
+++ b/test/unit/test-data/StopAlertsContainer.data.js
@@ -1,0 +1,1131 @@
+export default {
+  withAlerts: {
+    stop: {
+      stoptimesForPatterns: [
+        {
+          pattern: {
+            code: 'HSL:2206:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIyMDY=',
+              gtfsId: 'HSL:2206',
+              shortName: '206',
+              longName: 'Kamppi-Meilahti-Etelä-Leppävaara-Kera',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547065800,
+                  effectiveStartDate: 1546491600,
+                  id:
+                    'QWxlcnQ6NTgyNiAgbnVsbCAgMjIwNiAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Linjalla 206 poikkeusreitti 5.-9.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Undantagsrutt för linje 206 5-9.1 ',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Divertion route 206 5-9 January',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Linja 206 Kampista ajaa Runeberginkadun ja Topeliuksenkadun kautta 5.-9.1. klo 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Linje 206 från Kampen kör via Runebergsgatan och Topeliusgatan 5-9.1 kl. 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Bus 206 departing from Kamppi will run via Runeberginkatu and Topeliuksenkatu 5-9 January 4.30pm-10.55pm. Info: hsl.fi.',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjIwNjowOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2213:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIyMTM=',
+              gtfsId: 'HSL:2213',
+              shortName: '213',
+              longName: 'Kamppi-Meilahti-Suvela-Espoon keskus-Kauklahti',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547065800,
+                  effectiveStartDate: 1546491600,
+                  id:
+                    'QWxlcnQ6NTgyOCAgbnVsbCAgMjIxMyAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Linjoilla 213 ja 213N poikkeusreitti 5.-9.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Undantagsrutt för linjerna 213 och 213N 5-9.1 ',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Divertion routes 213 and 213N 5-9 January',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Linjat 213 ja 213N Kampista ajavat Runeberginkadun ja Topeliuksenkadun kautta 5.-9.1. klo 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Linjerna 213 och 213N från Kampen kör via Runebergsgatan och Topeliusgatan 5-9.1 kl. 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Buses 213 and 213N departing from Kamppi will run via Runeberginkatu and Topeliuksenkatu 5-9 January 4.30pm-10.55pm. Info: hsl.fi.',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjIxMzowOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2212:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIyMTI=',
+              gtfsId: 'HSL:2212',
+              shortName: '212',
+              longName: 'Kamppi-Meilahti-Laajalahti-Kauniainen',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547065800,
+                  effectiveStartDate: 1546491600,
+                  id:
+                    'QWxlcnQ6NTgyNyAgbnVsbCAgMjIxMiAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Linjalla 212 poikkeusreitti 5.-9.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Undantagsrutt för linje 212 5-9.1 ',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Divertion route 212  5-9 January',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Linja 212 Kampista ajaa Runeberginkadun ja Topeliuksenkadun kautta 5.-9.1. klo 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Linje 212 från Kampen kör via Runebergsgatan och Topeliusgatan 5-9.1 kl. 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Bus 212 departing from Kamppi will run via Runeberginkatu and Topeliuksenkatu 5-9 January 4.30pm-10.55pm. Info: hsl.fi.',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjIxMjowOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:1063:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjEwNjM=',
+              gtfsId: 'HSL:1063',
+              shortName: '63',
+              longName: 'Kamppi-Ruskeasuo-Maunula-Paloheinä',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547065800,
+                  effectiveStartDate: 1546491600,
+                  id:
+                    'QWxlcnQ6NTgyNSAgbnVsbCAgMTA2MyAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Linjalla 63 poikkeusreitti 5.-9.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Undantagsrutt för linje 63 5-9.1 ',
+                      language: 'sv',
+                    },
+                    { text: 'Divertion route 63 5-9 January', language: 'en' },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Linja 63 Kampista ajaa Runeberginkadun ja Topeliuksenkadun kautta 5.-9.1. klo 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Linje 63 från Kampen kör via Runebergsgatan och Topeliusgatan 5-9.1 kl. 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Bus 63 departing from Kamppi will run via Runeberginkatu and Topeliuksenkatu 5-9 January 4.30pm-10.55pm. Info: hsl.fi.',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MTA2MzowOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:1037:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjEwMzc=',
+              gtfsId: 'HSL:1037',
+              shortName: '37',
+              longName: 'Kamppi - Honkasuo',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMTAzNyAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MTAzNzowOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2143A:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxNDNB',
+              gtfsId: 'HSL:2143A',
+              shortName: '143A',
+              longName: 'Kamppi-Soukka',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMjE0M0EgIG51bGwgICBudWxsICAgbnVsbCAgIG51bGwg',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjE0M0E6MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2147A:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxNDdB',
+              gtfsId: 'HSL:2147A',
+              shortName: '147A',
+              longName: 'Kamppi-Espoonlahti',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMjE0N0EgIG51bGwgICBudWxsICAgbnVsbCAgIG51bGwg',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjE0N0E6MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2164A:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxNjRB',
+              gtfsId: 'HSL:2164A',
+              shortName: '164A',
+              longName: 'Kamppi-Kivenlahti-Saunalahti',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMjE2NEEgIG51bGwgICBudWxsICAgbnVsbCAgIG51bGwg',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjE2NEE6MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2164A:1:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxNjRB',
+              gtfsId: 'HSL:2164A',
+              shortName: '164A',
+              longName: 'Kamppi-Kivenlahti-Saunalahti',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMjE2NEEgIG51bGwgICBudWxsICAgbnVsbCAgIG51bGwg',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjE2NEE6MTowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2143A:1:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxNDNB',
+              gtfsId: 'HSL:2143A',
+              shortName: '143A',
+              longName: 'Kamppi-Soukka',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMjE0M0EgIG51bGwgICBudWxsICAgbnVsbCAgIG51bGwg',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjE0M0E6MTowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2147A:1:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxNDdB',
+              gtfsId: 'HSL:2147A',
+              shortName: '147A',
+              longName: 'Kamppi-Espoonlahti',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMjE0N0EgIG51bGwgICBudWxsICAgbnVsbCAgIG51bGwg',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjE0N0E6MTowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2146A:1:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxNDZB',
+              gtfsId: 'HSL:2146A',
+              shortName: '146A',
+              longName: 'Kamppi-Kivenlahti',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMjE0NkEgIG51bGwgICBudWxsICAgbnVsbCAgIG51bGwg',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjE0NkE6MTowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:1037:1:01',
+            route: {
+              id: 'Um91dGU6SFNMOjEwMzc=',
+              gtfsId: 'HSL:1037',
+              shortName: '37',
+              longName: 'Kamppi - Honkasuo',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMTAzNyAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MTAzNzoxOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2212:1:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIyMTI=',
+              gtfsId: 'HSL:2212',
+              shortName: '212',
+              longName: 'Kamppi-Meilahti-Laajalahti-Kauniainen',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547065800,
+                  effectiveStartDate: 1546491600,
+                  id:
+                    'QWxlcnQ6NTgyNyAgbnVsbCAgMjIxMiAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Linjalla 212 poikkeusreitti 5.-9.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Undantagsrutt för linje 212 5-9.1 ',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Divertion route 212  5-9 January',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Linja 212 Kampista ajaa Runeberginkadun ja Topeliuksenkadun kautta 5.-9.1. klo 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Linje 212 från Kampen kör via Runebergsgatan och Topeliusgatan 5-9.1 kl. 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Bus 212 departing from Kamppi will run via Runeberginkatu and Topeliuksenkatu 5-9 January 4.30pm-10.55pm. Info: hsl.fi.',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjIxMjoxOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:1063:1:01',
+            route: {
+              id: 'Um91dGU6SFNMOjEwNjM=',
+              gtfsId: 'HSL:1063',
+              shortName: '63',
+              longName: 'Kamppi-Ruskeasuo-Maunula-Paloheinä',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547065800,
+                  effectiveStartDate: 1546491600,
+                  id:
+                    'QWxlcnQ6NTgyNSAgbnVsbCAgMTA2MyAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Linjalla 63 poikkeusreitti 5.-9.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Undantagsrutt för linje 63 5-9.1 ',
+                      language: 'sv',
+                    },
+                    { text: 'Divertion route 63 5-9 January', language: 'en' },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Linja 63 Kampista ajaa Runeberginkadun ja Topeliuksenkadun kautta 5.-9.1. klo 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Linje 63 från Kampen kör via Runebergsgatan och Topeliusgatan 5-9.1 kl. 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Bus 63 departing from Kamppi will run via Runeberginkatu and Topeliuksenkatu 5-9 January 4.30pm-10.55pm. Info: hsl.fi.',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MTA2MzoxOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2206:1:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIyMDY=',
+              gtfsId: 'HSL:2206',
+              shortName: '206',
+              longName: 'Kamppi-Meilahti-Etelä-Leppävaara-Kera',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547065800,
+                  effectiveStartDate: 1546491600,
+                  id:
+                    'QWxlcnQ6NTgyNiAgbnVsbCAgMjIwNiAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Linjalla 206 poikkeusreitti 5.-9.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Undantagsrutt för linje 206 5-9.1 ',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Divertion route 206 5-9 January',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Linja 206 Kampista ajaa Runeberginkadun ja Topeliuksenkadun kautta 5.-9.1. klo 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Linje 206 från Kampen kör via Runebergsgatan och Topeliusgatan 5-9.1 kl. 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Bus 206 departing from Kamppi will run via Runeberginkatu and Topeliuksenkatu 5-9 January 4.30pm-10.55pm. Info: hsl.fi.',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjIwNjoxOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2213:1:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIyMTM=',
+              gtfsId: 'HSL:2213',
+              shortName: '213',
+              longName: 'Kamppi-Meilahti-Suvela-Espoon keskus-Kauklahti',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547065800,
+                  effectiveStartDate: 1546491600,
+                  id:
+                    'QWxlcnQ6NTgyOCAgbnVsbCAgMjIxMyAgbnVsbCAgIG51bGwgICBudWxsICAgbnVsbCA=',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Linjoilla 213 ja 213N poikkeusreitti 5.-9.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Undantagsrutt för linjerna 213 och 213N 5-9.1 ',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Divertion routes 213 and 213N 5-9 January',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Linjat 213 ja 213N Kampista ajavat Runeberginkadun ja Topeliuksenkadun kautta 5.-9.1. klo 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Linjerna 213 och 213N från Kampen kör via Runebergsgatan och Topeliusgatan 5-9.1 kl. 16.30 - 22.15. Info: hsl.fi.',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Buses 213 and 213N departing from Kamppi will run via Runeberginkatu and Topeliuksenkatu 5-9 January 4.30pm-10.55pm. Info: hsl.fi.',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjIxMzoxOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2146A:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxNDZB',
+              gtfsId: 'HSL:2146A',
+              shortName: '146A',
+              longName: 'Kamppi-Kivenlahti',
+              mode: 'BUS',
+              color: null,
+              alerts: [
+                {
+                  effectiveEndDate: 1547222400,
+                  effectiveStartDate: 1546869600,
+                  id:
+                    'QWxlcnQ6NTg1NiAgbnVsbCAgMjE0NkEgIG51bGwgICBudWxsICAgbnVsbCAgIG51bGwg',
+                  trip: null,
+                  alertHeaderTextTranslations: [
+                    {
+                      text: 'Bussit korvaavat metroa 11.1 iltana -13.1.',
+                      language: 'fi',
+                    },
+                    {
+                      text: 'Metron ersätts med bussarna på 11.1-13.1.',
+                      language: 'sv',
+                    },
+                    {
+                      text: 'Metro replaced by buses on Friday evening 11 JAN',
+                      language: 'en',
+                    },
+                  ],
+                  alertDescriptionTextTranslations: [
+                    {
+                      text:
+                        'Bussit korvaavat metron Itäkeskuksesta itään perjantai-iltana 11.1. ja Lauttasaaresta itään. 12.-13.1.  Info: HSL.fi',
+                      language: 'fi',
+                    },
+                    {
+                      text:
+                        'Metron från Östra Centrum österut ersätts med bussarna på fredagskvällen 11.1. och från Drumsö österut 12.-13.1. Info:HSL.fi',
+                      language: 'sv',
+                    },
+                    {
+                      text:
+                        'Metro services from Itäkeskus eastwards replaced by buses on Friday evening 11 Jan and on 12 and 13 Jan from Lauttasaari eastwards.  Info: HSL.fi',
+                      language: 'en',
+                    },
+                  ],
+                },
+              ],
+            },
+            id: 'UGF0dGVybjpIU0w6MjE0NkE6MDowMQ==',
+          },
+        },
+      ],
+    },
+  },
+  withoutAlerts: {
+    stop: {
+      stoptimesForPatterns: [
+        {
+          pattern: {
+            code: 'HSL:2125N:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxMjVO',
+              gtfsId: 'HSL:2125N',
+              shortName: '125N',
+              longName: 'Kamppi-Tapiola (M)-Niittykumpu (M)-Olari- Latokaski',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MjEyNU46MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2206A:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIyMDZB',
+              gtfsId: 'HSL:2206A',
+              shortName: '206A',
+              longName: 'Kamppi-Meilahti-Etelä-Leppävaara-Kilo-Karakallio-Kera',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MjIwNkE6MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2134N:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxMzRO',
+              gtfsId: 'HSL:2134N',
+              shortName: '134N',
+              longName: 'Kamppi-Niittykumpu (M)-Espoon keskus-Suvela-Tuomarila',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MjEzNE46MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2213N:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIyMTNO',
+              gtfsId: 'HSL:2213N',
+              shortName: '213N',
+              longName:
+                'Kamppi-Meilahti-Laajalahti-Suvela-Espoon keskus-Kauklahti',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MjIxM046MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:1069:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjEwNjk=',
+              gtfsId: 'HSL:1069',
+              shortName: '69',
+              longName: 'Kamppi-Pasila-Käpylä-Malmi-Jakomäki',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MTA2OTowOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2551N:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjI1NTFO',
+              gtfsId: 'HSL:2551N',
+              shortName: '551N',
+              longName: 'Kamppi-Teekkarikylä-Tapiola (M)',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MjU1MU46MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2113N:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxMTNO',
+              gtfsId: 'HSL:2113N',
+              shortName: '113N',
+              longName: 'Kamppi-Tapiola (M)-Laajalahti-Perkkaa-Leppävaara',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MjExM046MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2114N:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxMTRO',
+              gtfsId: 'HSL:2114N',
+              shortName: '114N',
+              longName: 'Kamppi-Leppävaara',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MjExNE46MDowMQ==',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:1070:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjEwNzA=',
+              gtfsId: 'HSL:1070',
+              shortName: '70',
+              longName: 'Kamppi-Töölö-Pihlajamäki-Pukinmäki-Malmi',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MTA3MDowOjAx',
+          },
+        },
+        {
+          pattern: {
+            code: 'HSL:2118N:0:01',
+            route: {
+              id: 'Um91dGU6SFNMOjIxMThO',
+              gtfsId: 'HSL:2118N',
+              shortName: '118N',
+              longName: 'Kamppi-Tapiola (M)-Suurpelto-Kauniainen-Jorvi',
+              mode: 'BUS',
+              color: null,
+              alerts: [],
+            },
+            id: 'UGF0dGVybjpIU0w6MjExOE46MDowMQ==',
+          },
+        },
+      ],
+    },
+  },
+};


### PR DESCRIPTION
The purpose of this pull request is to enable showing the disruptions tab for terminals.

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/50830755-6936f980-1351-11e9-9fb2-bda71ba50ecd.png)
