### PR TITLE
Timetable shows canceled departures

### DIFF
--- a/app/component/Timetable.js
+++ b/app/component/Timetable.js
@@ -12,6 +12,7 @@ import FilterTimeTableModal from './FilterTimeTableModal';
 import TimeTableOptionsPanel from './TimeTableOptionsPanel';
 import TimetableRow from './TimetableRow';
 import ComponentUsageExample from './ComponentUsageExample';
+import { RealtimeStateType } from '../constants';
 
 class Timetable extends React.Component {
   static propTypes = {
@@ -32,6 +33,7 @@ class Timetable extends React.Component {
           }).isRequired,
           stoptimes: PropTypes.arrayOf(
             PropTypes.shape({
+              realtimeState: PropTypes.string.isRequired,
               scheduledDeparture: PropTypes.number.isRequired,
               serviceDay: PropTypes.number.isRequired,
             }),
@@ -116,6 +118,7 @@ class Timetable extends React.Component {
           serviceDay: st.serviceDay,
           headsign: stoptime.pattern.headsign,
           longName: stoptime.pattern.route.longName,
+          isCanceled: st.realtimeState === RealtimeStateType.Canceled,
         })),
       )
       .reduce((acc, val) => acc.concat(val), []);

--- a/app/component/TimetableContainer.js
+++ b/app/component/TimetableContainer.js
@@ -10,7 +10,7 @@ export default Relay.createContainer(Timetable, {
         name
         url
         locationType
-        stoptimesForServiceDate(date:$date) {
+        stoptimesForServiceDate(date:$date omitCanceled:false) {
           pattern {
             headsign
             code
@@ -26,6 +26,7 @@ export default Relay.createContainer(Timetable, {
             }
           }
           stoptimes {
+            realtimeState
             scheduledDeparture
             serviceDay
             headsign

--- a/app/component/TimetableRow.js
+++ b/app/component/TimetableRow.js
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
@@ -27,7 +28,9 @@ const TimetableRow = ({ title, stoptimes, showRoutes, timerows }) => (
         )
         .map(time => (
           <div
-            className="timetablerow-linetime"
+            className={cx('timetablerow-linetime', {
+              canceled: time.isCanceled,
+            })}
             key={`${time.id}-${time.name}-${time.scheduledDeparture}`}
           >
             <span>

--- a/app/component/timetable.scss
+++ b/app/component/timetable.scss
@@ -90,6 +90,10 @@
         padding-left: 1em;
         overflow: visible;
       }
+
+      .timetablerow-linetime.canceled {
+        @include canceled;
+      }
     }
     @media print {
       border-bottom: 1px dotted $black;

--- a/app/component/util.scss
+++ b/app/component/util.scss
@@ -365,13 +365,13 @@ $btn-heigth: 17px;
     .icon.close {
       width: 1.4em;
       height: 1.4em;
-      color: rgb(0,122,201);
+      color: rgb(0, 122, 201);
     }
   }
 
   &.no-bike-allowed-popup {
-
-    .popup-icon, .popup-text {
+    .popup-icon,
+    .popup-text {
       text-align: center;
     }
 
@@ -387,14 +387,14 @@ $btn-heigth: 17px;
 
     .close-popup {
       display: flex;
-     flex-direction: row-reverse;
+      flex-direction: row-reverse;
     }
 
     .icon {
       &.caution {
         width: 3.5em;
         height: 3.5em;
-        fill: rgb(220,4,81);
+        fill: rgb(220, 4, 81);
         color: #fff;
       }
     }
@@ -470,4 +470,15 @@ select {
   height: 100%;
   justify-content: center;
   align-items: center;
+}
+
+@mixin canceled {
+  color: $cancelation-red;
+  background: linear-gradient(
+    to bottom,
+    transparent calc(50% - 1px),
+    $cancelation-red calc(50% - 1px),
+    $cancelation-red calc(50% + 1px),
+    transparent calc(50% + 1px)
+  );
 }

--- a/app/constants.js
+++ b/app/constants.js
@@ -68,3 +68,19 @@ export const QuickOptionSetType = {
   PreferWalkingRoutes: 'prefer-walking-routes',
   SavedSettings: 'saved-settings',
 };
+
+/**
+ * RealtimeStateType depicts different types of a trip's information state.
+ */
+export const RealtimeStateType = {
+  /** The trip has been added using a real-time update, i.e. the trip was not present in the GTFS feed. */
+  Added: 'ADDED',
+  /** The trip has been canceled by a real-time update. */
+  Canceled: 'CANCELED',
+  /** The trip information has been updated and resulted in a different trip pattern compared to the trip pattern of the scheduled trip. */
+  Modified: 'MODIFIED',
+  /** The trip information comes from the GTFS feed, i.e. no real-time update has been applied. This is often the default state. */
+  Scheduled: 'SCHEDULED',
+  /** The trip information has been updated, but the trip pattern stayed the same as the trip pattern of the scheduled trip. */
+  Updated: 'UPDATED',
+};

--- a/build/schema.json
+++ b/build/schema.json
@@ -1581,6 +1581,16 @@
                                 "defaultValue": null
                             },
                             {
+                                "name": "omitCanceled",
+                                "description": "When false, return itineraries using canceled trips. Default value: true.",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                },
+                                "defaultValue": "true"
+                            },
+                            {
                                 "name": "ignoreRealtimeUpdates",
                                 "description": "When true, realtime updates are ignored during this search. Default value: false",
                                 "type": {
@@ -3081,6 +3091,16 @@
                                     "ofType": null
                                 },
                                 "defaultValue": "false"
+                            },
+                            {
+                                "name": "omitCanceled",
+                                "description": "If false, returns also canceled trips",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                },
+                                "defaultValue": "true"
                             }
                         ],
                         "type": {
@@ -3409,6 +3429,16 @@
                                     "ofType": null
                                 },
                                 "defaultValue": "false"
+                            },
+                            {
+                                "name": "omitCanceled",
+                                "description": "If false, returns also canceled trips",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                },
+                                "defaultValue": "true"
                             }
                         ],
                         "type": {
@@ -3466,6 +3496,16 @@
                                     "ofType": null
                                 },
                                 "defaultValue": "false"
+                            },
+                            {
+                                "name": "omitCanceled",
+                                "description": "If false, returns also canceled trips",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                },
+                                "defaultValue": "true"
                             }
                         ],
                         "type": {
@@ -3523,6 +3563,16 @@
                                     "ofType": null
                                 },
                                 "defaultValue": "false"
+                            },
+                            {
+                                "name": "omitCanceled",
+                                "description": "If false, returns also canceled trips",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                },
+                                "defaultValue": "true"
                             }
                         ],
                         "type": {
@@ -5101,6 +5151,16 @@
                                     "ofType": null
                                 },
                                 "defaultValue": "false"
+                            },
+                            {
+                                "name": "omitCanceled",
+                                "description": "If false, returns also canceled trips",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                },
+                                "defaultValue": "true"
                             }
                         ],
                         "type": {
@@ -6143,6 +6203,18 @@
                         "type": {
                             "kind": "SCALAR",
                             "name": "Boolean",
+                            "ofType": null
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "realtimeState",
+                        "description": "State of real-time data",
+                        "args": [],
+                        "type": {
+                            "kind": "ENUM",
+                            "name": "RealtimeState",
                             "ofType": null
                         },
                         "isDeprecated": false,

--- a/test/unit/TimetableRow.test.js
+++ b/test/unit/TimetableRow.test.js
@@ -26,4 +26,37 @@ describe('<TimetableRow />', () => {
       'none',
     );
   });
+
+  it('should apply className canceled if a stoptime has been canceled', () => {
+    const props = {
+      title: '09',
+      stoptimes: [
+        {
+          id: 'HSL:1070:1:01',
+          name: '70',
+          scheduledDeparture: 32460,
+          serviceDay: 1547071200,
+          headsign: 'Kamppi',
+          longName: 'Kamppi-Töölö-Pihlajamäki-Pukinmäki-Malmi',
+          isCanceled: true,
+          duplicate: false,
+        },
+        {
+          id: 'HSL:1070:1:01',
+          name: '70',
+          scheduledDeparture: 33000,
+          serviceDay: 1547071200,
+          headsign: 'Kamppi',
+          longName: 'Kamppi-Töölö-Pihlajamäki-Pukinmäki-Malmi',
+          isCanceled: false,
+          duplicate: false,
+        },
+      ],
+      showRoutes: [],
+      timerows: [],
+    };
+    const wrapper = shallowWithIntl(<TimetableRow {...props} />);
+    expect(wrapper.find('.timetablerow-linetime')).to.have.lengthOf(2);
+    expect(wrapper.find('.timetablerow-linetime.canceled')).to.have.lengthOf(1);
+  });
 });

--- a/test/unit/component/Timetable.test.js
+++ b/test/unit/component/Timetable.test.js
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import React from 'react';
+
+import Timetable from '../../../app/component/Timetable';
+import TimetableRow from '../../../app/component/TimetableRow';
+import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
+
+describe('<Timetable />', () => {
+  it('should set isCanceled to true for rows that have RealtimeState CANCELED', () => {
+    const props = {
+      propsForStopPageActionBar: {
+        printUrl: 'http://aikataulut.hsl.fi/pysakit/fi/1140199.html',
+        startDate: '20190110',
+        selectedDate: '20190110',
+        onDateChange: () => {},
+      },
+      stop: {
+        gtfsId: 'HSL:1140199',
+        locationType: 'STOP',
+        name: 'Ooppera',
+        stoptimesForServiceDate: [
+          {
+            pattern: {
+              code: 'HSL:1070:1:01',
+              headsign: 'Kamppi',
+              route: {
+                agency: {
+                  name: 'Helsingin seudun liikenne',
+                },
+                longName: 'Kamppi-Töölö-Pihlajamäki-Pukinmäki-Malmi',
+                mode: 'BUS',
+                shortName: '70',
+              },
+            },
+            stoptimes: [
+              {
+                headsign: 'Kamppi via Töölö',
+                pickupType: 'SCHEDULED',
+                realtimeState: 'CANCELED',
+                scheduledDeparture: 32460,
+                serviceDay: 1547071200,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const wrapper = shallowWithIntl(<Timetable {...props} />, {
+      context: {
+        config: {
+          URL: {},
+        },
+      },
+    });
+    expect(wrapper.find(TimetableRow)).to.have.lengthOf(1);
+    expect(wrapper.find(TimetableRow).prop('stoptimes')[0].isCanceled).to.equal(
+      true,
+    );
+  });
+});

--- a/test/unit/component/TimetableRow.test.js
+++ b/test/unit/component/TimetableRow.test.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { shallowWithIntl } from './helpers/mock-intl-enzyme';
-import TimetableRow from '../../app/component/TimetableRow';
+import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
+import TimetableRow from '../../../app/component/TimetableRow';
 
-import data from './test-data/dt2720';
+import data from '../test-data/dt2720';
 
 describe('<TimetableRow />', () => {
   it('should not show stoptimes whose routes have been filtered out', () => {


### PR DESCRIPTION
The purpose of this pull request is to show canceled departures in the timetable view for a selected date. Previously these would just be hidden altogether.

This pull request includes a required update to the graphql schema file.

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/50977487-10a36000-14fb-11e9-9fd8-b04bcfa9b830.png)
