### PR TITLE
Stop popup shows canceled departures on the map

### DIFF
--- a/app/component/StopCardContainer.js
+++ b/app/component/StopCardContainer.js
@@ -38,7 +38,8 @@ export default Relay.createContainer(StopCardContainer, {
         stoptimes: stoptimesWithoutPatterns(
           startTime: $startTime,
           timeRange: $timeRange,
-          numberOfDepartures: $numberOfDepartures
+          numberOfDepartures: $numberOfDepartures,
+          omitCanceled: false
         ) {
           ${DepartureListContainer.getFragment('stoptimes')}
         }


### PR DESCRIPTION
The purpose of this pull request is to enable showing canceled departures in the stop popup on the map. This is part of ticket DT-2833 (https://digitransit.atlassian.net/browse/DT-2833).

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/51107797-96bfef00-17f8-11e9-8e16-12227db5a68d.png)
