### PR TITLE
DT-2833: add a "no departures" indicator for stops

### DIFF
--- a/app/component/RouteScheduleContainer.js
+++ b/app/component/RouteScheduleContainer.js
@@ -13,8 +13,15 @@ import DateSelect from './DateSelect';
 import SecondaryButton from './SecondaryButton';
 import Loading from './Loading';
 import Icon from './Icon';
+import { RealtimeStateType } from '../constants';
 
 const DATE_FORMAT = 'YYYYMMDD';
+
+const isTripCanceled = trip =>
+  trip.stoptimes &&
+  Object.keys(trip.stoptimes)
+    .map(key => trip.stoptimes[key])
+    .every(st => st.realtimeState === RealtimeStateType.Canceled);
 
 class RouteScheduleContainer extends Component {
   static propTypes = {
@@ -104,6 +111,7 @@ class RouteScheduleContainer extends Component {
           key={trip.id}
           departureTime={departureTime}
           arrivalTime={arrivalTime}
+          isCanceled={isTripCanceled(trip)}
         />
       );
     });
@@ -191,7 +199,7 @@ class RouteScheduleContainer extends Component {
   }
 }
 
-export default connectToStores(
+const connectedComponent = connectToStores(
   Relay.createContainer(RouteScheduleContainer, {
     initialVariables: {
       serviceDay: moment().format(DATE_FORMAT),
@@ -209,6 +217,7 @@ export default connectToStores(
           tripsForDate(serviceDay: $serviceDay) {
             id
             stoptimes: stoptimesForDate(serviceDay: $serviceDay) {
+              realtimeState
               scheduledArrival
               scheduledDeparture
               serviceDay
@@ -229,3 +238,5 @@ export default connectToStores(
       .format(DATE_FORMAT),
   }),
 );
+
+export { connectedComponent as default, RouteScheduleContainer as Component };

--- a/app/component/RouteScheduleTripRow.js
+++ b/app/component/RouteScheduleTripRow.js
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ComponentUsageExample from './ComponentUsageExample';
@@ -6,9 +7,21 @@ function RouteScheduleTripRow(props) {
   return (
     <div className="row">
       <div className="trip-column">
-        <div className="trip-from trip-label">{props.departureTime}</div>
+        <div
+          className={cx('trip-from', 'trip-label', {
+            canceled: props.isCanceled,
+          })}
+        >
+          {props.departureTime}
+        </div>
         <div className="trip-separator" />
-        <div className="trip-to trip-label">{props.arrivalTime}</div>
+        <div
+          className={cx('trip-to', 'trip-label', {
+            canceled: props.isCanceled,
+          })}
+        >
+          {props.arrivalTime}
+        </div>
       </div>
     </div>
   );
@@ -16,6 +29,11 @@ function RouteScheduleTripRow(props) {
 RouteScheduleTripRow.propTypes = {
   departureTime: PropTypes.string.isRequired,
   arrivalTime: PropTypes.string.isRequired,
+  isCanceled: PropTypes.bool,
+};
+
+RouteScheduleTripRow.defaultProps = {
+  isCanceled: false,
 };
 
 RouteScheduleTripRow.displayName = 'RouteScheduleTripRow';

--- a/app/component/RoutesAndPlatformsForStops.js
+++ b/app/component/RoutesAndPlatformsForStops.js
@@ -1,15 +1,17 @@
+import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import Relay from 'react-relay/classic';
-import cx from 'classnames';
 import { Link } from 'react-router';
 import orderBy from 'lodash/orderBy';
 import uniqBy from 'lodash/uniqBy';
-import { routeNameCompare } from '../util/searchUtils';
 
 import Departure from './Departure';
-import { PREFIX_ROUTES } from '../util/path';
 import DepartureListHeader from './DepartureListHeader';
+import Icon from './Icon';
+import { PREFIX_ROUTES } from '../util/path';
+import { routeNameCompare } from '../util/searchUtils';
 
 export const mapRoutes = (stopFromProps, stopType) => {
   const stopRoutes = [];
@@ -76,6 +78,15 @@ const RoutesAndPlatformsForStops = props => {
     props.stop,
     props.params.terminalId ? 'terminal' : 'stop',
   ).sort((x, y) => routeNameCompare(x.pattern.route, y.pattern.route));
+
+  if (mappedRoutes.length === 0) {
+    return (
+      <div className="stop-no-departures-container">
+        <Icon img="icon-icon_station" />
+        <FormattedMessage id="no-departures" defaultMessage="No departures" />
+      </div>
+    );
+  }
 
   const timeTableRows = mappedRoutes.map(route => (
     <Link

--- a/app/component/StopAlertsContainer.js
+++ b/app/component/StopAlertsContainer.js
@@ -12,10 +12,10 @@ const StopAlertsContainer = ({ stop }) => {
     .filter(pattern => pattern.route.alerts.length > 0);
   if (patternsWithAlerts.length === 0) {
     return (
-      <div className="no-stop-alerts-message">
+      <div className="stop-no-alerts-container">
         <FormattedMessage
-          id="disruption-info-route-no-alerts"
-          defaultMessage="No known disruptions or diversions for route."
+          id="disruption-info-no-alerts"
+          defaultMessage="No known disruptions or diversions."
         />
       </div>
     );

--- a/app/component/StopPageContentContainer.js
+++ b/app/component/StopPageContentContainer.js
@@ -70,7 +70,7 @@ class StopPageContent extends React.Component {
   }
 }
 
-export default Relay.createContainer(
+const connectedComponent = Relay.createContainer(
   connectToStores(StopPageContent, ['TimeStore'], ({ getStore }) => ({
     currentTime: getStore('TimeStore')
       .getCurrentTime()
@@ -100,3 +100,5 @@ export default Relay.createContainer(
     },
   },
 );
+
+export { connectedComponent as default, StopPageContent as Component };

--- a/app/component/StopPageContentContainer.js
+++ b/app/component/StopPageContentContainer.js
@@ -2,10 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Relay from 'react-relay/classic';
 import connectToStores from 'fluxible-addons-react/connectToStores';
+import { FormattedMessage } from 'react-intl';
 
 import DepartureListHeader from './DepartureListHeader';
 import DepartureListContainer from './DepartureListContainer';
 import Error404 from './404';
+import Icon from './Icon';
 
 class StopPageContent extends React.Component {
   static propTypes = {
@@ -37,12 +39,22 @@ class StopPageContent extends React.Component {
       return <Error404 />;
     }
 
+    const { stoptimes } = this.props.stop;
+    if (!stoptimes || stoptimes.length === 0) {
+      return (
+        <div className="stop-no-departures-container">
+          <Icon img="icon-icon_station" />
+          <FormattedMessage id="no-departures" defaultMessage="No departures" />
+        </div>
+      );
+    }
+
     return (
       <React.Fragment>
         <DepartureListHeader />
         <div className="stop-scroll-container momentum-scroll">
           <DepartureListContainer
-            stoptimes={this.props.stop.stoptimes}
+            stoptimes={stoptimes}
             key="departures"
             className="stop-page momentum-scroll"
             routeLinks

--- a/app/component/stop.scss
+++ b/app/component/stop.scss
@@ -41,6 +41,10 @@
   justify-content: center;
   text-align: center;
 
+  @media print {
+    display: none;
+  }
+
   .icon {
     font-size: 2.5em;
   }

--- a/app/component/stop.scss
+++ b/app/component/stop.scss
@@ -30,6 +30,22 @@
   }
 }
 
+.stop-no-alerts-container,
+.stop-no-departures-container {
+  align-items: center;
+  background-color: white;
+  color: $gray;
+  display: flex;
+  flex: 1 0 6em;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+
+  .icon {
+    font-size: 2.5em;
+  }
+}
+
 .stop-scroll-container {
   flex-basis: 0px;
   flex-grow: 1;
@@ -593,10 +609,4 @@ hr.action-bar {
   .showroutes-header {
     width: 41%;
   }
-}
-
-.no-stop-alerts-message {
-  background-color: white;
-  padding: 2em 1em;
-  text-align: center;
 }

--- a/app/translations.js
+++ b/app/translations.js
@@ -2323,6 +2323,7 @@ const translations = {
     next: 'Nästa',
     'no-bike-allowed-popup':
       'Cyklar är inte tillåtna i bussar eller spårvagnar. Om du använder dessa fordon på din färd, lämna cykeln vid hållplatsen eller vid infartsparkeringen.',
+    'no-departures': 'Inga avgående resor',
     'no-favourite-locations':
       'Lägg till dina oftast använda platser här. Knapparna för dig rakt till reseplanen.',
     'no-favourites':

--- a/app/translations.js
+++ b/app/translations.js
@@ -676,6 +676,7 @@ const translations = {
     next: 'Next',
     'no-bike-allowed-popup':
       'Bicycles are not allowed on buses or trams. If you are using these vehicles on your route, leave the bicycle at the stop or at a Park-and-Ride. ',
+    'no-departures': 'No departures',
     'no-favourite-locations':
       'Add your most used locations here. The buttons will plan your route straight away.',
     'no-favourites':
@@ -1345,6 +1346,7 @@ const translations = {
     next: 'Seuraava',
     'no-bike-allowed-popup':
       'Pyörää ei voi ottaa bussiin tai raitiovaunuun. Jos käytät reitilläsi näitä kulkuvälineitä, jätä pyörä pysäkille tai liityntäpysäköintiin.',
+    'no-departures': 'Ei lähteviä vuoroja',
     'no-favourite-locations':
       'Lisää tähän usein käyttämäsi paikat. Painikkeet toimivat suorina linkkeinä reititykseen.',
     'no-favourites':

--- a/test/unit/component/RouteScheduleContainer.test.js
+++ b/test/unit/component/RouteScheduleContainer.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
+import { Component as RouteScheduleContainer } from '../../../app/component/RouteScheduleContainer';
+import RouteScheduleTripRow from '../../../app/component/RouteScheduleTripRow';
+
+describe('<RouteScheduleContainer />', () => {
+  it('should identify canceled departures from incoming data', () => {
+    const props = {
+      pattern: {
+        stops: [
+          {
+            name: 'Koskela',
+          },
+          {
+            name: 'Rautatientori',
+          },
+        ],
+        tripsForDate: [
+          {
+            id: 'trip-1',
+            stoptimes: [
+              {
+                realtimeState: 'CANCELED',
+                scheduledArrival: 28080,
+                scheduledDeparture: 28080,
+                serviceDay: 1547503200,
+              },
+              {
+                realtimeState: 'CANCELED',
+                scheduledArrival: 30060,
+                scheduledDeparture: 30060,
+                serviceDay: 1547503200,
+              },
+            ],
+          },
+        ],
+      },
+      relay: {
+        setVariables: () => {},
+        variables: {
+          serviceDay: '20190115',
+        },
+      },
+      serviceDay: '20190115',
+    };
+    const wrapper = shallowWithIntl(<RouteScheduleContainer {...props} />);
+    expect(wrapper.find(RouteScheduleTripRow)).to.have.lengthOf(1);
+    expect(
+      wrapper
+        .find(RouteScheduleTripRow)
+        .at(0)
+        .props().isCanceled,
+    ).to.equal(true);
+  });
+});

--- a/test/unit/component/RouteScheduleTripRow.test.js
+++ b/test/unit/component/RouteScheduleTripRow.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
+import RouteScheduleTripRow from '../../../app/component/RouteScheduleTripRow';
+
+describe('<RouteScheduleTripRow />', () => {
+  it('should highlight a canceled departure', () => {
+    const props = {
+      isCanceled: true,
+      departureTime: '10.50',
+      arrivalTime: '11.55',
+    };
+    const wrapper = shallowWithIntl(<RouteScheduleTripRow {...props} />);
+    expect(wrapper.find('.trip-from.canceled')).to.have.lengthOf(1);
+    expect(wrapper.find('.trip-to.canceled')).to.have.lengthOf(1);
+  });
+});

--- a/test/unit/component/RoutesAndPlatformsForStops.test.js
+++ b/test/unit/component/RoutesAndPlatformsForStops.test.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { shallowWithIntl } from './helpers/mock-intl-enzyme';
+import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
 
-import dt2715a from './test-data/dt2715a';
-import dt2715b from './test-data/dt2715b';
+import dt2715a from '../test-data/dt2715a';
+import dt2715b from '../test-data/dt2715b';
 import {
   mapRoutes,
   Component as RoutesAndPlatformsForStops,
-} from '../../app/component/RoutesAndPlatformsForStops';
+} from '../../../app/component/RoutesAndPlatformsForStops';
 
 describe('<RoutesAndPlatformsForStops />', () => {
   it('should render a container successfully', () => {
@@ -20,6 +20,7 @@ describe('<RoutesAndPlatformsForStops />', () => {
 
     expect(wrapper.find('.departure-list')).to.have.lengthOf(1);
   });
+
   it('should calculate the correct amount of unique departures', () => {
     const props = {
       stop: dt2715a,
@@ -29,6 +30,7 @@ describe('<RoutesAndPlatformsForStops />', () => {
 
     expect(sortedProps.length).to.equal(28);
   });
+
   it('should render as many departures as it receives for a terminal', () => {
     const props = {
       stop: dt2715a,
@@ -40,6 +42,7 @@ describe('<RoutesAndPlatformsForStops />', () => {
       mapRoutes(props.stop, 'terminal').length,
     );
   });
+
   it('should render as many departures as it receives for a stop', () => {
     const props = {
       stop: dt2715b,
@@ -50,5 +53,17 @@ describe('<RoutesAndPlatformsForStops />', () => {
     expect(wrapper.find('.departure')).to.have.lengthOf(
       mapRoutes(props.stop, 'stop').length,
     );
+  });
+
+  it("should show a 'no departures' indicator", () => {
+    const props = {
+      params: { stopId: 'HSL:1173105' },
+      stop: {
+        stops: [],
+        stoptimesForPatterns: [],
+      },
+    };
+    const wrapper = shallowWithIntl(<RoutesAndPlatformsForStops {...props} />);
+    expect(wrapper.find('.stop-no-departures-container')).to.have.lengthOf(1);
   });
 });

--- a/test/unit/component/StopAlertsContainer.test.js
+++ b/test/unit/component/StopAlertsContainer.test.js
@@ -14,7 +14,7 @@ describe('<StopAlertsContainer />', () => {
       ...data.withoutAlerts,
     };
     const wrapper = shallowWithIntl(<StopAlertsContainer {...props} />);
-    expect(wrapper.find('.no-stop-alerts-message')).to.have.lengthOf(1);
+    expect(wrapper.find('.stop-no-alerts-container')).to.have.lengthOf(1);
   });
 
   it('should show all the alerts', () => {

--- a/test/unit/component/StopPageContentContainer.test.js
+++ b/test/unit/component/StopPageContentContainer.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
+import { Component as StopPageContentContainer } from '../../../app/component/StopPageContentContainer';
+
+describe('<StopPageContentContainer />', () => {
+  it("should show a 'no departures' indicator", () => {
+    const props = {
+      currentTime: 0,
+      params: {
+        stopId: '1234',
+      },
+      relay: {
+        setVariables: () => {},
+        variables: {
+          startTime: '1234',
+        },
+      },
+      stop: {},
+    };
+    const wrapper = shallowWithIntl(<StopPageContentContainer {...props} />);
+    expect(wrapper.find('.stop-no-departures-container')).to.have.lengthOf(1);
+  });
+});


### PR DESCRIPTION
The purpose of this pull request is to add a "no departures" indicator for stops. This indicator is shown on the "right now" and "routes, platforms" tabs.

In addition, the route timetable view will now also highlight canceled departures.

Screenshots:
![image](https://user-images.githubusercontent.com/2669201/51252517-b5fb7f80-19a4-11e9-9634-3a3d9d0bf5f7.png)
![image](https://user-images.githubusercontent.com/2669201/51252648-0d015480-19a5-11e9-8a71-f8a879b07e8f.png)

