### PR TITLE
DT-2886: changed the priority of configured static messages

### DIFF
--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -439,6 +439,7 @@ export default {
   staticMessages: [
     {
       id: '2',
+      priority: -1,
       content: {
         fi: [
           {

--- a/test/unit/store/MessageStore.test.js
+++ b/test/unit/store/MessageStore.test.js
@@ -1,0 +1,167 @@
+import { expect } from 'chai';
+import fetchMock from 'fetch-mock';
+import { describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import MessageStore, {
+  processStaticMessages,
+} from '../../../app/store/MessageStore';
+
+describe('MessageStore', () => {
+  describe('getMessages', () => {
+    it('should show higher priority first', async () => {
+      const staticMessagesUrl = '/staticMessages';
+      const mock = fetchMock.sandbox().mock(staticMessagesUrl, {
+        staticMessages: [
+          {
+            id: '2',
+            content: {
+              en: [
+                {
+                  type: 'text',
+                  content: 'foo',
+                },
+              ],
+            },
+          },
+        ],
+      });
+      global.fetch = mock;
+      const store = new MessageStore();
+      const config = {
+        staticMessages: [
+          {
+            id: '1',
+            content: {
+              en: [
+                {
+                  type: 'text',
+                  content: 'bar',
+                },
+              ],
+            },
+            priority: -1,
+          },
+        ],
+        staticMessagesUrl,
+      };
+
+      await store.addConfigMessages(config);
+      expect(mock.called(staticMessagesUrl)).to.equal(true);
+      expect(store.getMessages()).to.deep.equal([
+        {
+          content: {
+            en: [{ type: 'text', content: 'foo' }],
+          },
+          id: '2',
+        },
+        {
+          content: {
+            en: [{ type: 'text', content: 'bar' }],
+          },
+          id: '1',
+          priority: -1,
+        },
+      ]);
+
+      global.fetch = undefined;
+    });
+  });
+
+  describe('processStaticMessages', () => {
+    it('should process a message with content', () => {
+      const staticMessages = [
+        {
+          id: '03022019_203257_08',
+          content: {
+            fi: [
+              {
+                type: 'text',
+                content:
+                  'Maanantaina 4.2. Leppävaaran A-junat ja Keravan K -junat liikennöivät 20 minuutin välein klo 14 saakka ',
+              },
+            ],
+            en: [
+              {
+                type: 'text',
+                content:
+                  'On Monday 4 February, A and K trains run every 20 minutes until 2pm',
+              },
+            ],
+            sv: [
+              {
+                type: 'text',
+                content:
+                  'A- och K-tågen går med 20 minuters mellanrum tills kl 14 ',
+              },
+            ],
+          },
+        },
+      ];
+      const callback = sinon.spy();
+      processStaticMessages({ staticMessages }, callback);
+      expect(callback.called).to.equal(true);
+    });
+
+    it('should ignore messages that have no content in any language', () => {
+      const staticMessages = [
+        {
+          id: '03022019_203559_96',
+          content: {
+            fi: [],
+            en: [],
+            sv: [],
+          },
+        },
+        {
+          id: '03022019_203612_18',
+          content: {
+            fi: [],
+            en: [],
+            sv: [],
+          },
+        },
+        {
+          id: '03022019_203612_86',
+          content: {
+            fi: [],
+            en: [],
+            sv: [],
+          },
+        },
+        {
+          id: '04022019_060821_65',
+          content: {
+            fi: [],
+            en: [],
+            sv: [],
+          },
+        },
+      ];
+      const callback = sinon.spy();
+      processStaticMessages({ staticMessages }, callback);
+      expect(callback.called).to.equal(false);
+    });
+
+    it('should process messages that have content in some language', () => {
+      const staticMessages = [
+        {
+          id: '03022019_203559_96',
+          content: {
+            fi: [],
+            en: [
+              {
+                type: 'text',
+                content: 'Foo',
+              },
+            ],
+            sv: [],
+          },
+        },
+      ];
+      const callback = sinon.spy();
+      processStaticMessages({ staticMessages }, callback);
+      expect(callback.called).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
The purpose of this pull request is to make the configured HSL static messages show after other messages in the carousel. Added filtering for empty static messages (these will cause a lot of error logging for no good reason). Added unit tests.