### PR TITLE
DT-2885: changed Kuopio's app bar link address

### DIFF
--- a/app/configurations/config.kuopio.js
+++ b/app/configurations/config.kuopio.js
@@ -9,7 +9,7 @@ const walttiConfig = require('./waltti').default;
 export default configMerger(walttiConfig, {
   CONFIG,
 
-  appBarLink: { name: 'Kuopio', href: 'http://joukkoliikenne.kuopio.fi/' },
+  appBarLink: { name: 'Kuopio', href: 'https://vilkku.kuopio.fi/' },
 
   colors: {
     primary: '#0ab1c8',


### PR DESCRIPTION
The purpose of this pull request is to update the app bar link address for Kuopio. The previous link points to a non-existent url.

JIRA link: https://digitransit.atlassian.net/browse/DT-2885