### PR TITLE
DT-2884: changed Jyväskylä's feedback link address

### DIFF
--- a/app/configurations/config.jyvaskyla.js
+++ b/app/configurations/config.jyvaskyla.js
@@ -85,7 +85,7 @@ export default configMerger(walttiConfig, {
       {
         name: 'footer-feedback',
         nameEn: 'Submit feedback',
-        href: 'https://s-asiointi.jkl.fi/eFeedback/fi/Feedback/24/113',
+        href: 'https://s-asiointi.jkl.fi/eFeedback/fi/Feedback/38',
         icon: 'icon-icon_speech-bubble',
       },
       {


### PR DESCRIPTION
The purpose of this pull request is to change the feedback link address for Jyväskylä.

JIRA link: https://digitransit.atlassian.net/browse/DT-2884