### PR TITLE
Fix: added support for tile scaleratio on hi-dpi screens

### DIFF
--- a/app/util/mapIconUtils.js
+++ b/app/util/mapIconUtils.js
@@ -175,7 +175,7 @@ export function drawRoundIcon(tile, geom, type, large, platformNumber) {
   }
 
   return {
-    iconRadius: stopRadius,
+    iconRadius: stopRadius * tile.scaleratio,
   };
 }
 

--- a/test/unit/util/mapIconUtils.test.js
+++ b/test/unit/util/mapIconUtils.test.js
@@ -5,22 +5,25 @@ import { AlertSeverityLevelType } from '../../../app/constants';
 
 describe('mapIconUtils', () => {
   describe('drawRoundIcon', () => {
+    const tile = {
+      coords: {
+        z: 12,
+      },
+      ctx: {
+        arc: sinon.stub(),
+        beginPath: sinon.stub(),
+        fill: sinon.stub(),
+      },
+      ratio: 1,
+      scaleratio: 1,
+    };
+
+    const geometry = {
+      x: 1,
+      y: 1,
+    };
+
     it('should return the icon radius', () => {
-      const tile = {
-        coords: {
-          z: 12,
-        },
-        ctx: {
-          arc: sinon.stub(),
-          beginPath: sinon.stub(),
-          fill: sinon.stub(),
-        },
-        ratio: 1,
-      };
-      const geometry = {
-        x: 1,
-        y: 1,
-      };
       const { iconRadius } = utils.drawRoundIcon(
         tile,
         geometry,
@@ -29,6 +32,17 @@ describe('mapIconUtils', () => {
         undefined,
       );
       expect(iconRadius).to.equal(1);
+    });
+
+    it('should take the scaleratio into account', () => {
+      const { iconRadius } = utils.drawRoundIcon(
+        { ...tile, scaleratio: 2 },
+        geometry,
+        'BUS',
+        false,
+        undefined,
+      );
+      expect(iconRadius).to.equal(2);
     });
   });
 


### PR DESCRIPTION
The purpose of this pull request is to fix the alert badge size shown on hi-dpi screens.

Screenshot (before):
![image](https://user-images.githubusercontent.com/2669201/53647517-67e5c700-3c46-11e9-8ea3-701830bb365f.png)

Screenshot (after):
![image](https://user-images.githubusercontent.com/2669201/53647456-471d7180-3c46-11e9-9941-63150aa6f30c.png)
