### PR TITLE
Unpreferred routes penalty

### DIFF
--- a/app/component/CustomizeSearchNew.js
+++ b/app/component/CustomizeSearchNew.js
@@ -39,12 +39,7 @@ class CustomizeSearch extends React.Component {
   };
 
   static propTypes = {
-    isOpen: PropTypes.bool,
     onToggleClick: PropTypes.func.isRequired,
-  };
-
-  static defaultProps = {
-    isOpen: false,
   };
 
   defaultSettings = getDefaultSettings(this.context.config);
@@ -81,131 +76,122 @@ class CustomizeSearch extends React.Component {
     const {
       config: { accessibilityOptions },
     } = this.context;
-    const { isOpen, onToggleClick } = this.props;
+    const { onToggleClick } = this.props;
     const currentSettings = getCurrentSettings(config, query);
     const isUsingBicycle = currentSettings.modes.includes(StreetMode.Bicycle);
 
     return (
-      <div
-        style={{ visibility: isOpen ? 'visible' : 'hidden' }}
-        className="customize-search-wrapper"
-      >
-        <div className="customize-search">
-          <button className="close-offcanvas" onClick={onToggleClick}>
-            <Icon className="close-icon" img="icon-icon_close" />
-          </button>
-          <div className="settings-option-container">
-            <StreetModeSelectorPanel
-              className="customized-settings"
-              selectedStreetMode={ModeUtils.getStreetMode(
-                router.location,
-                config,
-              )}
-              selectStreetMode={(streetMode, isExclusive) =>
-                ModeUtils.setStreetMode(streetMode, config, router, isExclusive)
-              }
-              showButtonTitles
-              streetModeConfigs={ModeUtils.getAvailableStreetModeConfigs(
-                config,
-              )}
-            />
-          </div>
-          {isUsingBicycle && (
-            <div className="settings-option-container">
-              <BikeTransportOptionsSection
-                currentModes={currentSettings.modes}
-              />
-            </div>
-          )}
-          <div className="settings-option-container">
-            <TransportModesSection
-              config={config}
-              currentModes={currentSettings.modes}
-            />
-          </div>
-          <div className="settings-option-container">
-            {isUsingBicycle ? (
-              <BikingOptionsSection
-                walkReluctance={currentSettings.walkReluctance}
-                walkReluctanceOptions={config.defaultOptions.walkReluctance}
-                bikeSpeed={currentSettings.bikeSpeed}
-                defaultSettings={this.defaultSettings}
-              />
-            ) : (
-              <WalkingOptionsSection
-                walkReluctance={currentSettings.walkReluctance}
-                walkReluctanceOptions={config.defaultOptions.walkReluctance}
-                walkSpeed={currentSettings.walkSpeed}
-                defaultSettings={this.defaultSettings}
-              />
+      <div className="customize-search">
+        <button className="close-offcanvas" onClick={onToggleClick}>
+          <Icon className="close-icon" img="icon-icon_close" />
+        </button>
+        <div className="settings-option-container">
+          <StreetModeSelectorPanel
+            className="customized-settings"
+            selectedStreetMode={ModeUtils.getStreetMode(
+              router.location,
+              config,
             )}
-          </div>
+            selectStreetMode={(streetMode, isExclusive) =>
+              ModeUtils.setStreetMode(streetMode, config, router, isExclusive)
+            }
+            showButtonTitles
+            streetModeConfigs={ModeUtils.getAvailableStreetModeConfigs(config)}
+          />
+        </div>
+        {isUsingBicycle && (
           <div className="settings-option-container">
-            <TransferOptionsSection
-              walkBoardCost={currentSettings.walkBoardCost}
-              walkBoardCostOptions={config.defaultOptions.walkBoardCost}
-              minTransferTime={currentSettings.minTransferTime}
+            <BikeTransportOptionsSection currentModes={currentSettings.modes} />
+          </div>
+        )}
+        <div className="settings-option-container">
+          <TransportModesSection
+            config={config}
+            currentModes={currentSettings.modes}
+          />
+        </div>
+        <div className="settings-option-container">
+          {isUsingBicycle ? (
+            <BikingOptionsSection
+              walkReluctance={currentSettings.walkReluctance}
+              walkReluctanceOptions={config.defaultOptions.walkReluctance}
+              bikeSpeed={currentSettings.bikeSpeed}
               defaultSettings={this.defaultSettings}
             />
-          </div>
-          {config.showTicketSelector && (
-            <FareZoneSelector
-              headerText={intl.formatMessage({
-                id: 'zones',
-                defaultMessage: 'Fare zones',
-              })}
-              options={config.fares}
-              currentOption={currentSettings.ticketTypes || 'none'}
-              updateValue={value =>
-                replaceQueryParams(router, { ticketTypes: value })
-              }
+          ) : (
+            <WalkingOptionsSection
+              walkReluctance={currentSettings.walkReluctance}
+              walkReluctanceOptions={config.defaultOptions.walkReluctance}
+              walkSpeed={currentSettings.walkSpeed}
+              defaultSettings={this.defaultSettings}
             />
           )}
-          <PreferredRoutes
-            onRouteSelected={this.onRouteSelected}
-            preferredRoutes={currentSettings.preferredRoutes}
-            unPreferredRoutes={currentSettings.unpreferredRoutes}
-            removeRoute={this.removeRoute}
+        </div>
+        <div className="settings-option-container">
+          <TransferOptionsSection
+            walkBoardCost={currentSettings.walkBoardCost}
+            walkBoardCostOptions={config.defaultOptions.walkBoardCost}
+            minTransferTime={currentSettings.minTransferTime}
+            defaultSettings={this.defaultSettings}
           />
-          <div className="settings-option-container">
-            <RoutePreferencesSection
-              optimize={currentSettings.optimize}
-              triangleFactors={{
-                safetyFactor: currentSettings.safetyFactor,
-                slopeFactor: currentSettings.slopeFactor,
-                timeFactor: currentSettings.timeFactor,
-              }}
-              defaultSettings={this.defaultSettings}
+        </div>
+        {config.showTicketSelector && (
+          <FareZoneSelector
+            headerText={intl.formatMessage({
+              id: 'zones',
+              defaultMessage: 'Fare zones',
+            })}
+            options={config.fares}
+            currentOption={currentSettings.ticketTypes || 'none'}
+            updateValue={value =>
+              replaceQueryParams(router, { ticketTypes: value })
+            }
+          />
+        )}
+        <PreferredRoutes
+          onRouteSelected={this.onRouteSelected}
+          preferredRoutes={currentSettings.preferredRoutes}
+          unPreferredRoutes={currentSettings.unpreferredRoutes}
+          removeRoute={this.removeRoute}
+        />
+        <div className="settings-option-container">
+          <RoutePreferencesSection
+            optimize={currentSettings.optimize}
+            triangleFactors={{
+              safetyFactor: currentSettings.safetyFactor,
+              slopeFactor: currentSettings.slopeFactor,
+              timeFactor: currentSettings.timeFactor,
+            }}
+            defaultSettings={this.defaultSettings}
+          />
+        </div>
+        <div className="settings-option-container">
+          <SelectOptionContainer
+            currentSelection={currentSettings.accessibilityOption}
+            defaultValue={this.defaultSettings.accessibilityOption}
+            options={accessibilityOptions.map((o, i) => ({
+              title: accessibilityOptions[i].messageId,
+              value: accessibilityOptions[i].value,
+            }))}
+            onOptionSelected={value =>
+              replaceQueryParams(router, {
+                accessibilityOption: value,
+              })
+            }
+            title="accessibility"
+          />
+        </div>
+        <div className="settings-option-container save-controls-container">
+          <div style={{ display: 'flex' }}>
+            <SaveCustomizedSettingsButton
+              noSettingsFound={this.resetParameters}
+            />
+            <LoadCustomizedSettingsButton
+              noSettingsFound={this.resetParameters}
             />
           </div>
-          <div className="settings-option-container">
-            <SelectOptionContainer
-              currentSelection={currentSettings.accessibilityOption}
-              defaultValue={this.defaultSettings.accessibilityOption}
-              options={accessibilityOptions.map((o, i) => ({
-                title: accessibilityOptions[i].messageId,
-                value: accessibilityOptions[i].value,
-              }))}
-              onOptionSelected={value =>
-                replaceQueryParams(router, {
-                  accessibilityOption: value,
-                })
-              }
-              title="accessibility"
-            />
-          </div>
-          <div className="settings-option-container save-controls-container">
-            <div style={{ display: 'flex' }}>
-              <SaveCustomizedSettingsButton
-                noSettingsFound={this.resetParameters}
-              />
-              <LoadCustomizedSettingsButton
-                noSettingsFound={this.resetParameters}
-              />
-            </div>
-            <div>
-              <ResetCustomizedSettingsButton onReset={this.resetParameters} />
-            </div>
+          <div>
+            <ResetCustomizedSettingsButton onReset={this.resetParameters} />
           </div>
         </div>
       </div>

--- a/app/component/SaveCustomizedSettingsButton.js
+++ b/app/component/SaveCustomizedSettingsButton.js
@@ -97,7 +97,12 @@ class SaveCustomizedSettingsButton extends React.Component {
           }
           autoHideDuration={this.state.autoHideDuration}
           onRequestClose={this.handleRequestClose}
-          style={{ width: drawerWidth }}
+          style={{
+            width: drawerWidth,
+            transform: 'none',
+            left: 'auto',
+            right: '0px',
+          }}
           bodyStyle={{
             backgroundColor: '#585a5b',
             color: '#fff',

--- a/app/component/SaveCustomizedSettingsButton.js
+++ b/app/component/SaveCustomizedSettingsButton.js
@@ -53,6 +53,9 @@ class SaveCustomizedSettingsButton extends React.Component {
       isEqual(currentSettings, defaultSettings)
     ) {
       this.props.noSettingsFound();
+      this.setState({
+        open: true,
+      });
     } else {
       setCustomizedSettings(querySettings);
       this.setState({

--- a/app/component/SummaryNavigation.js
+++ b/app/component/SummaryNavigation.js
@@ -153,7 +153,7 @@ class SummaryNavigation extends React.Component {
               containerStyle={{
                 background: 'transparent',
                 boxShadow: 'none',
-                ...(isOpen && { MozTransform: 'none' }), // needed to prevent showing an extra scrollbar in FF
+                transform: 'none', // needed to prevent showing an extra scrollbar on FF & Chrome
               }}
               width={getDrawerWidth(window)}
             >

--- a/app/component/SummaryNavigation.js
+++ b/app/component/SummaryNavigation.js
@@ -153,12 +153,11 @@ class SummaryNavigation extends React.Component {
               containerStyle={{
                 background: 'transparent',
                 boxShadow: 'none',
-                transform: 'none', // needed to prevent showing an extra scrollbar on FF & Chrome
+                overflow: 'visible',
               }}
               width={getDrawerWidth(window)}
             >
               <CustomizeSearch
-                isOpen={isOpen}
                 params={this.props.params}
                 onToggleClick={this.toggleCustomizeSearchOffcanvas}
               />

--- a/app/component/customize-search.scss
+++ b/app/component/customize-search.scss
@@ -1,7 +1,3 @@
-.customize-search-wrapper {
-  height: 100%;
-}
-
 .customize-search {
   background: #f4f4f5;
   color: $black;

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -159,7 +159,7 @@ export default {
   maxWalkDistance: 10000,
   maxBikingDistance: 100000,
   itineraryFiltering: 1.5, // drops 66% worse routes
-  useUnpreferredRoutesPenalty: 420, // adds 7 minute (weight) penalty to routes that are unpreferred
+  useUnpreferredRoutesPenalty: 600, // adds 10 minute (weight) penalty to routes that are unpreferred
   availableLanguages: ['fi', 'sv', 'en', 'fr', 'nb', 'de'],
   defaultLanguage: 'en',
   // This timezone data will expire on 31.12.2020

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -159,7 +159,7 @@ export default {
   maxWalkDistance: 10000,
   maxBikingDistance: 100000,
   itineraryFiltering: 1.5, // drops 66% worse routes
-  useUnpreferredRoutesPenalty: 600, // adds 10 minute (weight) penalty to routes that are unpreferred
+  useUnpreferredRoutesPenalty: 1200, // adds 10 minute (weight) penalty to routes that are unpreferred
   availableLanguages: ['fi', 'sv', 'en', 'fr', 'nb', 'de'],
   defaultLanguage: 'en',
   // This timezone data will expire on 31.12.2020

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -159,6 +159,7 @@ export default {
   maxWalkDistance: 10000,
   maxBikingDistance: 100000,
   itineraryFiltering: 1.5, // drops 66% worse routes
+  useUnpreferredRoutesPenalty: 420, // adds 7 minute (weight) penalty to routes that are unpreferred
   availableLanguages: ['fi', 'sv', 'en', 'fr', 'nb', 'de'],
   defaultLanguage: 'en',
   // This timezone data will expire on 31.12.2020

--- a/app/store/localStorage.js
+++ b/app/store/localStorage.js
@@ -149,6 +149,18 @@ export function setCustomizedSettings(data) {
     delete newSettings.slopeFactor;
     delete newSettings.timeFactor;
   }
+  if (
+    newSettings.preferredRoutes !== undefined &&
+    newSettings.preferredRoutes.length === 0
+  ) {
+    delete newSettings.preferredRoutes;
+  }
+  if (
+    newSettings.unpreferredRoutes !== undefined &&
+    newSettings.unpreferredRoutes.length === 0
+  ) {
+    delete newSettings.unpreferredRoutes;
+  }
 
   setItem('customizedSettings', newSettings);
 }

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -124,22 +124,24 @@ function getPreferredorUnpreferredRoutes(
   unpreferredPenalty,
 ) {
   const preferenceObject = {};
-  // queryRoutes is undefined if query params dont contain routes and empty string if user has removed all routes
-  if (queryRoutes !== undefined && queryRoutes !== '') {
-    // queryRoutes contains routes found in query params
-    preferenceObject.routes = queryRoutes;
-  } else if (isPreferred) {
-    // default or localstorage preferredRoutes
-    preferenceObject.routes = settings.preferredRoutes;
-  } else {
-    // default or localstorage unpreferredRoutes
-    preferenceObject.routes = settings.unpreferredRoutes;
-  }
   if (!isPreferred) {
     // adds penalty weight to unpreferred routes, there might be default unpreferred routes even if user has not defined any
     preferenceObject.useUnpreferredRoutesPenalty = unpreferredPenalty;
   }
-  return preferenceObject;
+  // queryRoutes is undefined if query params dont contain routes and empty string if user has removed all routes
+  if (queryRoutes === '') {
+    return preferenceObject;
+  }
+  if (queryRoutes !== undefined && queryRoutes !== '') {
+    // queryRoutes contains routes found in query params
+    return { ...preferenceObject, routes: queryRoutes };
+  }
+  if (isPreferred) {
+    // default or localstorage preferredRoutes
+    return { ...preferenceObject, routes: settings.preferredRoutes };
+  }
+  // default or localstorage unpreferredRoutes
+  return { ...preferenceObject, routes: settings.unpreferredRoutes };
 }
 
 const getNumberValueOrDefault = (value, defaultValue = undefined) =>

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -8,7 +8,6 @@ import {
   getCustomizedSettings,
   getRoutingSettings,
 } from '../store/localStorage';
-import { isEmpty } from 'lodash';
 
 /**
  * Retrieves the default settings from the configuration.
@@ -118,19 +117,23 @@ function getDisableRemainingWeightHeuristic(
   return disableRemainingWeightHeuristic;
 }
 
-function getPreferredorUnpreferredRoutes(queryRoutes, isPreferred, settings, unpreferredPenalty) {
+function getPreferredorUnpreferredRoutes(
+  queryRoutes,
+  isPreferred,
+  settings,
+  unpreferredPenalty,
+) {
   const preferenceObject = {};
   // queryRoutes is undefined if query params dont contain routes and empty string if user has removed all routes
   if (queryRoutes !== undefined && queryRoutes !== '') {
     // queryRoutes contains routes found in query params
     preferenceObject.routes = queryRoutes;
+  } else if (isPreferred) {
+    // default or localstorage preferredRoutes
+    preferenceObject.routes = settings.preferredRoutes;
   } else {
-    // default or localstorage routes
-    if (isPreferred) {
-      preferenceObject.routes = settings.preferredRoutes
-    } else {
-      preferenceObject.routes = settings.unpreferredRoutes
-    }
+    // default or localstorage unpreferredRoutes
+    preferenceObject.routes = settings.unpreferredRoutes;
   }
   if (!isPreferred) {
     // adds penalty weight to unpreferred routes, there might be default unpreferred routes even if user has not defined any

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -117,6 +117,20 @@ function getDisableRemainingWeightHeuristic(
   return disableRemainingWeightHeuristic;
 }
 
+function getPreferredorUnpreferredRoutes(queryRoutes, settingsRoutes) {
+  // queryRoutes is undefined if user has not touched settings
+  if (queryRoutes !== undefined) {
+    // queryRoutes is an empty string if user has removed all the routes
+    if (queryRoutes === '') {
+      return {};
+    }
+    // queryRoutes contains routes found in query params
+    return { routes: queryRoutes };
+  }
+  // default or localstorage routes
+  return { routes: settingsRoutes };
+}
+
 const getNumberValueOrDefault = (value, defaultValue = undefined) =>
   value !== undefined ? Number(value) : defaultValue;
 const getBooleanValueOrDefault = (value, defaultValue = undefined) =>
@@ -334,12 +348,14 @@ export const preparePlanParams = config => (
                 nullOrUndefined,
               )
             : null,
-        preferred: {
-          routes: preferredRoutes || settings.preferredRoutes,
-        },
-        unpreferred: {
-          routes: unpreferredRoutes || settings.unpreferredRoutes,
-        },
+        preferred: getPreferredorUnpreferredRoutes(
+          preferredRoutes,
+          settings.preferredRoutes,
+        ),
+        unpreferred: getPreferredorUnpreferredRoutes(
+          unpreferredRoutes,
+          settings.unpreferredRoutes,
+        ),
         disableRemainingWeightHeuristic: getDisableRemainingWeightHeuristic(
           modesOrDefault,
           settings,

--- a/build/schema.json
+++ b/build/schema.json
@@ -88,7 +88,7 @@
                     },
                     {
                         "name": "agency",
-                        "description": "Get a single agency based on agency ID",
+                        "description": "Get a single agency based on agency ID, i.e. value of field `gtfsId` (ID format is `FeedId:StopId`)",
                         "args": [
                             {
                                 "name": "id",
@@ -1849,7 +1849,7 @@
                     },
                     {
                         "name": "gtfsId",
-                        "description": "Agency id",
+                        "description": "Agency feed and id",
                         "args": [],
                         "type": {
                             "kind": "NON_NULL",
@@ -7148,6 +7148,16 @@
                         "type": {
                             "kind": "SCALAR",
                             "name": "String",
+                            "ofType": null
+                        },
+                        "defaultValue": null
+                    },
+                    {
+                        "name": "useUnpreferredRoutesPenalty",
+                        "description": "Penalty added for using route that is unpreferred, i.e. number of seconds that we are willing to wait for route that is unpreferred.",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "Int",
                             "ofType": null
                         },
                         "defaultValue": null

--- a/test/unit/localStorage.test.js
+++ b/test/unit/localStorage.test.js
@@ -82,7 +82,13 @@ describe('localStorage', () => {
     it('should save all default settings', () => {
       const defaultSettings = { ...defaultConfig.defaultSettings };
       setCustomizedSettings(defaultSettings);
-      expect(getCustomizedSettings()).to.deep.equal(defaultSettings);
+      // empty unpreferredRoutes and preferredRoutes should not be stored
+      const {
+        unpreferredRoutes,
+        preferredRoutes,
+        ...resultSettings
+      } = defaultSettings;
+      expect(getCustomizedSettings()).to.deep.equal(resultSettings);
     });
 
     it('should remove triangle factors if optimize is no longer "TRIANGLE"', () => {
@@ -142,8 +148,10 @@ describe('localStorage', () => {
       setCustomizedSettings(updatedSettings);
 
       settings = getCustomizedSettings();
-      expect(settings.preferredRoutes.length).to.equal(0);
-      expect(settings.unpreferredRoutes.length).to.equal(0);
+      // eslint-disable-next-line no-unused-expressions
+      expect(settings.preferredRoutes).to.be.undefined;
+      // eslint-disable-next-line no-unused-expressions
+      expect(settings.unpreferredRoutes).to.be.undefined;
     });
   });
 

--- a/test/unit/localStorage.test.js
+++ b/test/unit/localStorage.test.js
@@ -119,6 +119,32 @@ describe('localStorage', () => {
       expect(settings.slopeFactor).to.equal(undefined);
       expect(settings.timeFactor).to.equal(undefined);
     });
+
+    it('should remove unpreferredRoutes and preferredRoutes if there are none', () => {
+      const initialSettings = {
+        preferredRoutes: ['HSL__1050'],
+        unpreferredRoutes: ['HSL__4555'],
+      };
+      setCustomizedSettings(initialSettings);
+
+      let settings = getCustomizedSettings();
+      expect(settings.preferredRoutes).to.deep.equal(
+        initialSettings.preferredRoutes,
+      );
+      expect(settings.unpreferredRoutes).to.deep.equal(
+        initialSettings.unpreferredRoutes,
+      );
+
+      const updatedSettings = {
+        preferredRoutes: [],
+        unpreferredRoutes: [],
+      };
+      setCustomizedSettings(updatedSettings);
+
+      settings = getCustomizedSettings();
+      expect(settings.preferredRoutes.length).to.equal(0);
+      expect(settings.unpreferredRoutes.length).to.equal(0);
+    });
   });
 
   describe('getLocalStorage', () => {

--- a/test/unit/util/planParamUtil.test.js
+++ b/test/unit/util/planParamUtil.test.js
@@ -97,7 +97,7 @@ describe('planParamUtil', () => {
       const { unpreferred } = params;
       expect(unpreferred).to.deep.equal({
         routes: 'HSL__7480',
-        useUnpreferredRoutesPenalty: 600,
+        useUnpreferredRoutesPenalty: 1200,
       });
     });
 
@@ -114,7 +114,7 @@ describe('planParamUtil', () => {
       const { unpreferred } = params;
       expect(unpreferred).to.deep.equal({
         routes: 'HSL__7480',
-        useUnpreferredRoutesPenalty: 600,
+        useUnpreferredRoutesPenalty: 1200,
       });
     });
 
@@ -153,7 +153,7 @@ describe('planParamUtil', () => {
         },
       );
       const { unpreferred } = params;
-      expect(unpreferred).to.deep.equal({ useUnpreferredRoutesPenalty: 600 });
+      expect(unpreferred).to.deep.equal({ useUnpreferredRoutesPenalty: 1200 });
     });
 
     it('should use bikeSpeed from query', () => {

--- a/test/unit/util/planParamUtil.test.js
+++ b/test/unit/util/planParamUtil.test.js
@@ -95,7 +95,10 @@ describe('planParamUtil', () => {
         },
       );
       const { unpreferred } = params;
-      expect(unpreferred).to.deep.equal({ routes: 'HSL__7480' });
+      expect(unpreferred).to.deep.equal({
+        routes: 'HSL__7480',
+        useUnpreferredRoutesPenalty: 600,
+      });
     });
 
     it('should use the preferred routes from localStorage', () => {
@@ -105,11 +108,52 @@ describe('planParamUtil', () => {
       expect(preferred).to.deep.equal({ routes: 'HSL__1052' });
     });
 
-    it('should use the preferred routes from localStorage', () => {
+    it('should use the unpreferred routes from localStorage', () => {
       setCustomizedSettings({ unpreferredRoutes: 'HSL__7480' });
       const params = utils.preparePlanParams(defaultConfig)(...defaultProps);
       const { unpreferred } = params;
-      expect(unpreferred).to.deep.equal({ routes: 'HSL__7480' });
+      expect(unpreferred).to.deep.equal({
+        routes: 'HSL__7480',
+        useUnpreferredRoutesPenalty: 600,
+      });
+    });
+
+    it('should ignore the preferred routes from localstorage when query contains empty string', () => {
+      setCustomizedSettings({ preferredRoutes: 'HSL__1052' });
+      const params = utils.preparePlanParams(defaultConfig)(
+        {
+          from,
+          to,
+        },
+        {
+          location: {
+            query: {
+              preferredRoutes: '',
+            },
+          },
+        },
+      );
+      const { preferred } = params;
+      expect(preferred).to.deep.equal({});
+    });
+
+    it('should ignore the unpreferred routes from localstorage when query contains empty string', () => {
+      setCustomizedSettings({ unpreferredRoutes: 'HSL__7480' });
+      const params = utils.preparePlanParams(defaultConfig)(
+        {
+          from,
+          to,
+        },
+        {
+          location: {
+            query: {
+              unpreferredRoutes: '',
+            },
+          },
+        },
+      );
+      const { unpreferred } = params;
+      expect(unpreferred).to.deep.equal({ useUnpreferredRoutesPenalty: 600 });
     });
 
     it('should use bikeSpeed from query', () => {

--- a/test/unit/util/queryUtils.test.js
+++ b/test/unit/util/queryUtils.test.js
@@ -268,7 +268,9 @@ describe('queryUtils', () => {
       const router = createMemoryHistory();
       utils.addPreferredRoute(router, 'HSL__1052');
       utils.removePreferredRoute(router, 'HSL__1052');
-      expect(router.getCurrentLocation().query).to.deep.equal({});
+      expect(router.getCurrentLocation().query).to.deep.equal({
+        preferredRoutes: '',
+      });
     });
 
     it('should ignore a missing preferred route', () => {
@@ -286,7 +288,9 @@ describe('queryUtils', () => {
       const router = createMemoryHistory();
       utils.addUnpreferredRoute(router, 'HSL__1052');
       utils.removeUnpreferredRoute(router, 'HSL__1052');
-      expect(router.getCurrentLocation().query).to.deep.equal({});
+      expect(router.getCurrentLocation().query).to.deep.equal({
+        unpreferredRoutes: '',
+      });
     });
 
     it('should ignore a missing Unpreferred route', () => {


### PR DESCRIPTION
## Proposed Changes

  - Fix removal of preferred and unpreferred routes from settings after they have been saved to localstorage
  - Add useUnpreferredRoutesPenalty GraphQL parameter for giving higher penalty to unpreferred routes than OTP's default value as currently using unpreferred routes did not seem very effective

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
