### PR TITLE
Support for auto-scaling custom geojson icons

### DIFF
--- a/app/component/map/GeoJSON.js
+++ b/app/component/map/GeoJSON.js
@@ -27,13 +27,6 @@ const getIcons = features => {
     return {};
   }
 
-  const CustomIcon = L.Icon.extend({
-    options: {
-      iconSize: [30, 30],
-      iconAnchor: [15, 15],
-    },
-  });
-
   return features
     .filter(
       feature =>
@@ -51,7 +44,7 @@ const getIcons = features => {
       const url = `data:image/svg+xml;charset=utf-8,${encodeURI(
         icon.svg,
       ).replace(/#/g, '%23')}`;
-      icons[icon.id] = new CustomIcon({ iconUrl: url }); // eslint-disable-line no-param-reassign
+      icons[icon.id] = url; // eslint-disable-line no-param-reassign
       return icons;
     }, {});
 };

--- a/app/component/map/PointFeatureMarker.js
+++ b/app/component/map/PointFeatureMarker.js
@@ -13,6 +13,7 @@ import {
   getCaseRadius,
   getStopRadius,
   getHubRadius,
+  getMapIconScale,
 } from '../../util/mapIconUtils';
 
 /**
@@ -30,7 +31,12 @@ const isRoundIconVisible = zoom => getCaseRadius(zoom) >= ROUND_ICON_MIN_RADIUS;
 /**
  * The minimum zoom level at which a custom icon is visible.
  */
-const CUSTOM_ICON_MIN_ZOOM = 10;
+export const CUSTOM_ICON_MIN_ZOOM = 15;
+
+/**
+ * The custom icon's width and height (before scaling).
+ */
+export const CUSTOM_ICON_SIZE = 20;
 
 /**
  * Checks if the custom icon is visible.
@@ -61,6 +67,21 @@ export const getRoundIcon = zoom => {
     `,
     iconSize: [radius * 2, radius * 2],
     className: `cursor-pointer`,
+  });
+};
+
+/**
+ * Generates a custom icon at the given zoom level.
+ *
+ * @param {number} zoom the current zoom level.
+ * @param {string} iconUrl the url-encoded svg for the icon.
+ */
+export const getCustomIcon = (zoom, iconUrl) => {
+  const iconSize = CUSTOM_ICON_SIZE * getMapIconScale(zoom);
+  return L.icon({
+    iconAnchor: [1 / 2 * iconSize, 1 / 2 * iconSize],
+    iconSize: [iconSize, iconSize],
+    iconUrl,
   });
 };
 
@@ -104,13 +125,17 @@ const PointFeatureMarker = ({ feature, icons, language }) => {
 
   return (
     <GenericMarker
-      getIcon={zoom => (hasCustomIcon ? icons[icon.id] : getRoundIcon(zoom))}
+      getIcon={zoom =>
+        hasCustomIcon && isCustomIconVisible(zoom)
+          ? getCustomIcon(zoom, icons[icon.id])
+          : getRoundIcon(zoom)
+      }
       position={{
         lat,
         lon,
       }}
       shouldRender={zoom =>
-        hasCustomIcon ? isCustomIconVisible(zoom) : isRoundIconVisible(zoom)
+        isCustomIconVisible(zoom) || isRoundIconVisible(zoom)
       }
     >
       <Card>

--- a/app/component/map/tile-layer/CityBikes.js
+++ b/app/component/map/tile-layer/CityBikes.js
@@ -10,19 +10,14 @@ import {
   drawCitybikeOffIcon,
   drawAvailabilityBadge,
   drawAvailabilityValue,
+  getMapIconScale,
 } from '../../../util/mapIconUtils';
-import glfun from '../../../util/glfun';
 
 import {
   BIKESTATION_ON,
   BIKESTATION_OFF,
   BIKESTATION_CLOSED,
 } from '../../../util/citybikes';
-
-const getScale = glfun({
-  base: 1,
-  stops: [[13, 0.8], [20, 1.6]],
-});
 
 const timeOfLastFetch = {};
 
@@ -33,9 +28,9 @@ class CityBikes {
 
     this.scaleratio = (isBrowser && window.devicePixelRatio) || 1;
     this.citybikeImageSize =
-      20 * this.scaleratio * getScale(this.tile.coords.z);
+      20 * this.scaleratio * getMapIconScale(this.tile.coords.z);
     this.availabilityImageSize =
-      14 * this.scaleratio * getScale(this.tile.coords.z);
+      14 * this.scaleratio * getMapIconScale(this.tile.coords.z);
 
     this.promise = this.fetchWithAction(this.fetchAndDrawStatus);
   }

--- a/app/util/mapIconUtils.js
+++ b/app/util/mapIconUtils.js
@@ -31,6 +31,13 @@ export const getHubRadius = memoize(
   }),
 );
 
+export const getMapIconScale = memoize(
+  glfun({
+    base: 1,
+    stops: [[13, 0.8], [20, 1.6]],
+  }),
+);
+
 const getStyleOrDefault = (selector, defaultValue = {}) => {
   const cssRule = selector && getSelector(selector.toLowerCase());
   return (cssRule && cssRule.style) || defaultValue;

--- a/test/unit/component/map/GeoJSON.test.js
+++ b/test/unit/component/map/GeoJSON.test.js
@@ -79,7 +79,7 @@ describe('<GeoJSON />', () => {
       ];
 
       const icons = getIcons(features);
-      expect(icons.test.options.iconUrl).to.equal(
+      expect(icons.test).to.equal(
         'data:image/svg+xml;charset=utf-8,%23%3Cfoobar%3E%23',
       );
     });

--- a/test/unit/component/map/PointFeatureMarker.test.js
+++ b/test/unit/component/map/PointFeatureMarker.test.js
@@ -4,6 +4,9 @@ import { shallowWithIntl } from '../../helpers/mock-intl-enzyme';
 import CardHeader from '../../../../app/component/CardHeader';
 import {
   Component as PointFeatureMarker,
+  CUSTOM_ICON_MIN_ZOOM,
+  CUSTOM_ICON_SIZE,
+  getCustomIcon,
   getPropertyValueOrDefault,
   getRoundIcon,
 } from '../../../../app/component/map/PointFeatureMarker';
@@ -135,6 +138,19 @@ describe('<PointFeatureMarker />', () => {
       const icon = getRoundIcon(12);
       expect(icon.options.html).to.contain('svg');
       expect(icon.options.iconSize).to.deep.equal([3, 3]);
+    });
+  });
+
+  describe('getCustomIcon', () => {
+    it('should return a scaled custom icon', () => {
+      const icon = getCustomIcon(CUSTOM_ICON_MIN_ZOOM, 'foobar');
+      expect(icon.options.iconAnchor[0]).to.equal(
+        icon.options.iconSize[0] * 1 / 2,
+      );
+      expect(icon.options.iconAnchor[0]).to.equal(icon.options.iconAnchor[1]);
+      expect(icon.options.iconSize[0]).to.be.at.least(CUSTOM_ICON_SIZE);
+      expect(icon.options.iconSize[0]).to.equal(icon.options.iconSize[1]);
+      expect(icon.options.iconUrl).to.equal('foobar');
     });
   });
 });


### PR DESCRIPTION
The purpose of this pull request is to enable scaling of custom icons included in geojson. The scaling functionality mimics that of city bike stations, with the two icon sets being fairly equal in size at a given zoom level.

This can be tested using Turku's configuration.

Screenshots:
![image](https://user-images.githubusercontent.com/2669201/54593366-0fc90600-4a37-11e9-9d27-c9ee14659a8f.png)
![image](https://user-images.githubusercontent.com/2669201/54593386-1a839b00-4a37-11e9-9d18-11d8cdb9b5ea.png)
![image](https://user-images.githubusercontent.com/2669201/54593397-240d0300-4a37-11e9-9ea0-52b8ec41c07b.png)
