### PR TITLE
Regression: fixed a bug related to the map popups not reopening when clicked.

### DIFF
--- a/app/component/map/tile-layer/TileLayerContainer.js
+++ b/app/component/map/tile-layer/TileLayerContainer.js
@@ -64,7 +64,7 @@ class TileLayerContainer extends GridLayer {
     autoPanPaddingTopLeft: [5, 125],
     className: 'popup',
     ref: 'popup',
-    onClose: this.onPopupclose,
+    onClose: () => this.setState(initialState),
     autoPan: false,
   };
 
@@ -148,8 +148,6 @@ class TileLayerContainer extends GridLayer {
       );
     /* eslint-enable no-underscore-dangle */
   };
-
-  onPopupclose = () => this.setState(initialState);
 
   createTile = (tileCoords, done) => {
     const tile = new TileContainer(
@@ -328,8 +326,10 @@ class TileLayerContainer extends GridLayer {
   }
 }
 
-export default withLeaflet(
+const connectedComponent = withLeaflet(
   connectToStores(TileLayerContainer, [MapLayerStore], context => ({
     mapLayers: context.getStore(MapLayerStore).getMapLayers(),
   })),
 );
+
+export { connectedComponent as default, TileLayerContainer as Component };

--- a/test/unit/component/map/tile-layer/TileLayerContainer.test.js
+++ b/test/unit/component/map/tile-layer/TileLayerContainer.test.js
@@ -1,0 +1,91 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { LeafletProvider } from 'react-leaflet/es/context';
+
+import { mountWithIntl } from '../../../helpers/mock-intl-enzyme';
+import {
+  mockChildContextTypes,
+  mockContext,
+} from '../../../helpers/mock-context';
+import TileLayerContainer, {
+  Component,
+} from '../../../../../app/component/map/tile-layer/TileLayerContainer';
+
+describe('<TileLayerContainer />', () => {
+  it('should have an onClose handler defined for the popup', () => {
+    const props = {
+      tileSize: 512,
+      zoomOffset: -1,
+    };
+    const wrapper = mountWithIntl(
+      <LeafletProvider
+        value={{
+          map: {
+            addEventParent: () => {},
+            addLayer: () => {},
+            on: () => {},
+            openPopup: () => {},
+            options: {
+              maxZoom: 16,
+              minZoom: 10,
+            },
+            removeEventParent: () => {},
+          },
+        }}
+      >
+        <TileLayerContainer {...props} />
+      </LeafletProvider>,
+      {
+        context: {
+          ...mockContext,
+          getStore: () => ({
+            addChangeListener: () => {},
+            getCurrentTime: () => ({ unix: () => 123457890 }),
+            getMapLayers: () => ({
+              stop: {},
+              terminal: {},
+              ticketSales: {},
+            }),
+            on: () => {},
+          }),
+        },
+        childContextTypes: {
+          ...mockChildContextTypes,
+          leaflet: PropTypes.func,
+        },
+      },
+    );
+    wrapper.find(Component).setState({
+      selectableTargets: [
+        {
+          feature: {
+            geom: { x: 1899, y: 2945 },
+            layer: 'stop',
+            properties: {
+              code: '1409',
+              gtfsId: 'HSL:1301214',
+              name: 'Saunalahti',
+              parentStation: 'null',
+              patterns:
+                '"[{"headsign":"Otaniemi","type":"BUS","shortName":"552"}]"',
+              platform: 'null',
+              type: 'BUS',
+            },
+          },
+          coords: {
+            lat: 60.192229421528765,
+            lng: 24.87814038991928,
+          },
+          showSpinner: true,
+        },
+      ],
+    });
+
+    expect(
+      wrapper
+        .find('.popup')
+        .at(0)
+        .prop('onClose'),
+    ).to.not.equal(undefined);
+  });
+});


### PR DESCRIPTION
The purpose of this pull request is to fix a bug that prevented a popup from showing on the map when clicking at the same location again after showing the popup once. This was related to reordering the class members and the handler becoming undefined.