### PR TITLE
DT-2966: Message bar layout fix for Firefox

### DIFF
--- a/app/component/MessageBar.js
+++ b/app/component/MessageBar.js
@@ -139,7 +139,7 @@ class MessageBar extends Component {
         >
           <div className="banner-container">
             <Icon img={iconName} className="message-icon" />
-            <div className={`flex-grow message-bar-${type}`}>
+            <div className={`message-bar-content message-bar-${type}`}>
               <SwipeableViews
                 index={index}
                 onChangeIndex={this.handleChange}

--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -354,7 +354,9 @@ section.content {
     display: flex;
     max-height: 100%;
 
-    .message-bar-info {
+    .message-bar-content {
+      flex-basis: auto;
+      flex-grow: 1;
       width: 60%;
     }
   }


### PR DESCRIPTION
The purpose of this pull request is to fix the layout under (mobile) Firefox. The message bar would overflow the viewport causing unnecessary horizontal scrolling. This problem manifested itself when the zones message was shown in Finnish.

Relevant JIRA ticket: https://digitransit.atlassian.net/browse/DT-2966

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/54979092-e9611880-4faa-11e9-95a6-ee1bbe58f7e2.png)
