### PR TITLE
Added a small halo effect for the icons on map

### DIFF
--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -111,6 +111,9 @@ div.leaflet-marker-icon.via {
   > span {
     > svg.icon {
       height: auto;
+      paint-order: stroke;
+      stroke: white;
+      stroke-width: 1;
       width: auto;
     }
   }


### PR DESCRIPTION
The purpose of this pull request is to add a small halo effect to from/to/via etc. icons that are shown on the map. This makes them easier to see visually and it was part of the initial UI design.

Relevant JIRA ticket: https://digitransit.atlassian.net/browse/DT-2959

Before:
![image](https://user-images.githubusercontent.com/2669201/55631028-c52de480-57bf-11e9-9b67-75988cf565b0.png)

After:
![image](https://user-images.githubusercontent.com/2669201/55630999-b2b3ab00-57bf-11e9-9af7-42aba79ef559.png)

