### PR TITLE
write Google Tag Manager script tag only if GTMid is set in the config

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -283,16 +283,18 @@ export default function(req, res, next) {
 
     // Write preload hints before doing anything else
     if (process.env.NODE_ENV !== 'development') {
-      // Google Tag Manager script
-      res.write(
-        `<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-          })(window,document,'script','dataLayer','${
-            config.GTMid
-          }');</script>\n`,
-      );
+      if (!!config.GTMid) {
+        // Google Tag Manager script
+        res.write(
+          `<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','${
+              config.GTMid
+            }');</script>\n`,
+        );
+      }
 
       const preloads = [
         { as: 'style', href: config.URL.FONT },


### PR DESCRIPTION
DT-2872 (PR #2673) (commit a7d88b98cf120b5279d2a2aec406d59391187f27) replaced Piwik with Google Tag Manager.

One regression to the piwik embed is, that if piwik was not configured it wouldn't be included in the page. Now, Google Tag Manager Code is always included, even when the `GTMid` is overridden in a specific configuration file with `''` or `null`.

This PR reintroduces the previous functionality for GTM: only if `GTMid` is set, the tag manager code is included. 