### PR TITLE
Regression: fix for the selected vehicle not being properly highlighted

### DIFF
--- a/app/component/TripStopListContainer.js
+++ b/app/component/TripStopListContainer.js
@@ -98,8 +98,8 @@ class TripStopListContainer extends React.PureComponent {
       vehicle => `HSL:${vehicle.next_stop}`,
     );
 
-    const vehiclesWithCorrectStartTime = Object.keys(vehicles)
-      .map(key => vehicles[key])
+    const vehiclesWithCorrectStartTime = Object.keys(propVehicles)
+      .map(key => propVehicles[key])
       .filter(vehicle => vehicle.direction === trip.pattern.directionId)
       .filter(vehicle => vehicle.tripStartTime === tripStart);
 

--- a/test/unit/component/TripStopListContainer.test.js
+++ b/test/unit/component/TripStopListContainer.test.js
@@ -65,4 +65,82 @@ describe('<TripStopListContainer />', () => {
         .prop('stopPassed'),
     ).to.equal(false);
   });
+
+  it('should find the selected vehicle', () => {
+    const props = {
+      currentTime: moment.unix(1554882006),
+      locationState: {},
+      relay: {
+        forceFetch: () => {},
+      },
+      trip: {
+        pattern: {
+          code: 'HSL:6172:0:01',
+          directionId: 0,
+        },
+        route: {
+          mode: 'BUS',
+          gtfsId: 'HSL:6172',
+          color: null,
+        },
+        stoptimesForDate: [
+          {
+            stop: {
+              gtfsId: 'HSL:2314219',
+              name: 'Matinkylä (M)',
+              desc: 'Matinkylän term.',
+              code: 'E3155',
+              lat: 60.160171,
+              lon: 24.738517,
+              alerts: [],
+            },
+            realtimeDeparture: 36300,
+            realtime: true,
+            scheduledDeparture: 36300,
+            serviceDay: 1554843600,
+            realtimeState: 'UPDATED',
+          },
+        ],
+      },
+      tripStart: '1005',
+      vehicles: {
+        HSL_00225: {
+          id: 'HSL_00225',
+          route: 'HSL:6172',
+          direction: 1,
+          tripStartTime: '1016',
+          operatingDay: '2019-04-10',
+          mode: 'bus',
+          next_stop: '6040278',
+          timestamp: 1554881821,
+          lat: 60.1305,
+          long: 24.42246,
+          heading: 89,
+        },
+        HSL_00875: {
+          id: 'HSL_00875',
+          route: 'HSL:6172',
+          direction: 0,
+          tripStartTime: '1005',
+          operatingDay: '2019-04-10',
+          mode: 'bus',
+          next_stop: '6040231',
+          timestamp: 1554881822,
+          lat: 60.12307,
+          long: 24.41071,
+          heading: 140,
+        },
+      },
+    };
+    const wrapper = shallowWithIntl(<TripStopListContainer {...props} />, {
+      context: {
+        config: {
+          nearestStopDistance: {},
+        },
+      },
+    });
+    expect(wrapper.find(TripRouteStop).prop('selectedVehicle').id).to.equal(
+      'HSL_00875',
+    );
+  });
 });


### PR DESCRIPTION
The purpose of this pull request is to fix a regression in the trip route view. The selected vehicle was not properly highlighted due to an error in handling the component's properties.

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/55866855-e4df5700-5b89-11e9-98c6-d552b6172364.png)
