### PR TITLE
DT-2992: Indicate no bikes available with a zero value

### DIFF
--- a/app/component/map/tile-layer/CityBikes.js
+++ b/app/component/map/tile-layer/CityBikes.js
@@ -148,25 +148,14 @@ class CityBikes {
               geom,
               this.citybikeImageSize,
             ).then(() => {
-              if (result.bikesAvailable === 0) {
-                drawAvailabilityBadge(
-                  'no',
-                  this.tile,
-                  geom,
-                  this.citybikeImageSize,
-                  this.availabilityImageSize,
-                  this.scaleratio,
-                );
-              } else {
-                drawAvailabilityValue(
-                  this.tile,
-                  geom,
-                  result.bikesAvailable,
-                  this.citybikeImageSize,
-                  this.availabilityImageSize,
-                  this.scaleratio,
-                );
-              }
+              drawAvailabilityValue(
+                this.tile,
+                geom,
+                result.bikesAvailable,
+                this.citybikeImageSize,
+                this.availabilityImageSize,
+                this.scaleratio,
+              );
             });
           }
         }

--- a/app/util/mapIconUtils.js
+++ b/app/util/mapIconUtils.js
@@ -329,7 +329,8 @@ export function drawAvailabilityValue(
     calculateIconBadgePosition(geom.y, tile, imageSize, radius, scaleratio) + 1;
 
   tile.ctx.beginPath();
-  tile.ctx.fillStyle = value > 3 ? '#4EA700' : '#FF6319';
+  tile.ctx.fillStyle =
+    (value > 3 && '#4EA700') || (value > 0 && '#FF6319') || '#DC0451';
   tile.ctx.arc(x, y, radius, 0, FULL_CIRCLE);
   tile.ctx.fill();
 


### PR DESCRIPTION
The purpose of this pull request is to change the way it is shown that there are no bikes available at a citybike station.

Relevant JIRA ticket: https://digitransit.atlassian.net/browse/DT-2992

Previous:
![image](https://user-images.githubusercontent.com/2669201/56720662-fc9f0980-674b-11e9-9d86-9dbd3eeba71e.png)

Next:
![image](https://user-images.githubusercontent.com/2669201/56720606-e3965880-674b-11e9-99e9-5df6037fc8d6.png)
