### PR TITLE
DT-3027: fixed not being able to change the hour and minute values

### DIFF
--- a/app/component/ItineraryTimePicker.js
+++ b/app/component/ItineraryTimePicker.js
@@ -24,15 +24,19 @@ class ItineraryTimePicker extends React.Component {
     };
   }
 
-  componentWillReceiveProps({ initHours, initMin }) {
-    this.setState({
-      hour: this.padDigits(initHours),
-      minute: this.padDigits(initMin),
-    });
+  componentWillReceiveProps({ initHours: nextHours, initMin: nextMin }) {
+    const { initHours, initMin } = this.props;
+    if (initHours !== nextHours || initMin !== nextMin) {
+      this.setState({
+        hour: this.padDigits(nextHours),
+        minute: this.padDigits(nextMin),
+      });
+    }
   }
 
   onChangeHour = e => {
     let val = e.target.value;
+
     // allow clearing
     if (val === '') {
       this.setState({ hour: val });
@@ -182,4 +186,7 @@ class ItineraryTimePicker extends React.Component {
   }
 }
 
-export default onlyUpdateForKeys(['initMin', 'initHours'])(ItineraryTimePicker);
+const recomposed = onlyUpdateForKeys(['initMin', 'initHours'])(
+  ItineraryTimePicker,
+);
+export { recomposed as default, ItineraryTimePicker as Component };

--- a/test/unit/component/ItineraryTimePicker.test.js
+++ b/test/unit/component/ItineraryTimePicker.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { shallowWithIntl, mountWithIntl } from '../helpers/mock-intl-enzyme';
+import ItineraryTimePicker from '../../../app/component/ItineraryTimePicker';
+
+describe('<ItineraryTimePicker />', () => {
+  it('should render', () => {
+    const props = {
+      changeTime: () => {},
+      initHours: '12',
+      initMin: '30',
+    };
+    const wrapper = shallowWithIntl(<ItineraryTimePicker {...props} />).dive();
+    expect(wrapper.isEmptyRender()).to.equal(false);
+  });
+
+  it('should not change the existing state if the props have not been changed', () => {
+    const props = {
+      changeTime: () => {},
+      initHours: '15',
+      initMin: '45',
+    };
+    const wrapper = mountWithIntl(
+      shallowWithIntl(<ItineraryTimePicker {...props} />).get(0),
+    );
+    wrapper.find('#inputHours').simulate('change', { target: { value: '12' } });
+    wrapper.setProps({ initHours: '15', initMin: '45' });
+    expect(wrapper.state()).to.deep.equal({ hour: '12', minute: '45' });
+  });
+});


### PR DESCRIPTION
The purpose of this pull request is to fix a bug in the ItineraryTimePicker component that prevented users from easily changing the hour and minute values of the requested itinerary's start (or end) time.

The reason for this regression remained somewhat obscure: presumably the componentWillReceiveProps lifecycle method was not previously called but this has been changed unbeknownst to us.