### PR TITLE
DT-3033: display a url link for service alerts

### DIFF
--- a/app/component/AlertList.js
+++ b/app/component/AlertList.js
@@ -105,6 +105,7 @@ const AlertList = ({
                 expired,
                 route: { color, mode, shortName } = {},
                 severityLevel,
+                url,
                 validityPeriod: { startTime, endTime },
               },
               i,
@@ -121,6 +122,7 @@ const AlertList = ({
                 routeMode={mode && mode.toLowerCase()}
                 severityLevel={severityLevel}
                 startTime={startTime}
+                url={url}
               />
             ),
           )}
@@ -138,6 +140,7 @@ const alertShape = PropTypes.shape({
     shortName: PropTypes.string,
   }),
   severityLevel: PropTypes.string,
+  url: PropTypes.string,
   validityPeriod: PropTypes.shape({
     startTime: PropTypes.number.isRequired,
     endTime: PropTypes.number,

--- a/app/component/RouteAlertsRow.js
+++ b/app/component/RouteAlertsRow.js
@@ -6,6 +6,7 @@ import React from 'react';
 import { intlShape } from 'react-intl';
 
 import ComponentUsageExample from './ComponentUsageExample';
+import ExternalLink from './ExternalLink';
 import RouteNumber from './RouteNumber';
 import ServiceAlertIcon from './ServiceAlertIcon';
 import { AlertSeverityLevelType } from '../constants';
@@ -44,6 +45,7 @@ export default function RouteAlertsRow(
     startTime,
     endTime,
     currentTime,
+    url,
   },
   { intl },
 ) {
@@ -63,7 +65,16 @@ export default function RouteAlertsRow(
         </div>
       )}
       <div className="route-alert-contents">
-        {routeLine && <div className={routeMode}>{routeLine}</div>}
+        {(routeLine || url) && (
+          <div className="route-alert-top-row">
+            {routeLine && <div className={routeMode}>{routeLine}</div>}
+            {url && (
+              <ExternalLink className="route-alert-url" href={url}>
+                {intl.formatMessage({ id: 'extra-info' })}
+              </ExternalLink>
+            )}
+          </div>
+        )}
         {showTime && (
           <div className="route-alert-time-period">
             {getTimePeriod({
@@ -92,6 +103,7 @@ RouteAlertsRow.propTypes = {
   startTime: PropTypes.number,
   endTime: PropTypes.number,
   currentTime: PropTypes.number,
+  url: PropTypes.string,
 };
 
 RouteAlertsRow.contextTypes = {
@@ -209,6 +221,16 @@ RouteAlertsRow.description = () => (
           routeLine="Y, S, U, L, E, A"
           routeMode="rail"
           severityLevel="WARNING"
+        />
+      </ComponentUsageExample>
+      <ComponentUsageExample description="with alert url">
+        <RouteAlertsRow
+          header="Pysäkki H4461 siirtyy"
+          description="Leikkikujan pysäkki H4461 siirtyy tilapäisesti kulkusuunnassa 100 metriä taaksepäin."
+          routeLine="97N"
+          routeMode="bus"
+          severityLevel="INFO"
+          url="https://www.hsl.fi"
         />
       </ComponentUsageExample>
     </div>

--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -756,7 +756,8 @@ div.route-tabs {
     cursor: pointer;
   }
 
-  button.toggle-direction, button.toggle-direction:hover {
+  button.toggle-direction,
+  button.toggle-direction:hover {
     background: $white;
     padding: 0;
     position: absolute;
@@ -790,7 +791,8 @@ div.route-tabs {
     overflow: hidden;
   }
 
-  select, .route-option {
+  select,
+  .route-option {
     padding: 0 35px 0 10px;
     -webkit-padding-end: 35px;
     -webkit-padding-start: 10px;
@@ -836,7 +838,8 @@ div.route-tabs {
       margin-top: 0.5em;
     }
 
-    select, .route-option {
+    select,
+    .route-option {
       height: 40px;
       font-size: 18px;
       padding: 0 48px 0 20px;
@@ -870,6 +873,19 @@ div.route-tabs {
 
     .route-alert-contents {
       vertical-align: bottom;
+
+      .route-alert-top-row {
+        display: flex;
+
+        .route-alert-url {
+          color: $primary-color;
+          margin-left: auto;
+
+          .external-link {
+            color: $primary-color;
+          }
+        }
+      }
     }
 
     .route-number {

--- a/app/util/alertQueries.js
+++ b/app/util/alertQueries.js
@@ -10,6 +10,7 @@ export const AlertContentQuery = Relay.QL`
     alertHash
     alertHeaderText
     alertSeverityLevel
+    alertUrl
     effectiveEndDate
     effectiveStartDate
     alertDescriptionTextTranslations {
@@ -17,6 +18,10 @@ export const AlertContentQuery = Relay.QL`
       text
     }
     alertHeaderTextTranslations {
+      language
+      text
+    }
+    alertUrlTranslations {
       language
       text
     }

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -245,6 +245,15 @@ export const getServiceAlertDescription = (alert, locale = 'en') =>
     locale,
   );
 
+/**
+ * Attempts to find alert's url in the given language.
+ *
+ * @param {*} alert the alert object to look into.
+ * @param {*} locale the locale to use, default to 'en'.
+ */
+export const getServiceAlertUrl = (alert, locale = 'en') =>
+  getTranslation(alert.alertUrlTranslations, alert.alertUrl || '', locale);
+
 const getServiceAlerts = (
   { alerts } = {},
   { color, mode, shortName } = {},
@@ -261,6 +270,7 @@ const getServiceAlerts = (
           shortName,
         },
         severityLevel: alert.alertSeverityLevel,
+        url: getServiceAlertUrl(alert, locale),
         validityPeriod: {
           startTime: alert.effectiveStartDate,
           endTime: alert.effectiveEndDate,

--- a/build/schema.json
+++ b/build/schema.json
@@ -4237,6 +4237,30 @@
                         "deprecationReason": null
                     },
                     {
+                        "name": "alertUrlTranslations",
+                        "description": "Url with more information in all different available languages",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "TranslatedString",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
                         "name": "alertEffect",
                         "description": "Alert effect",
                         "args": [],
@@ -4507,25 +4531,25 @@
                 "enumValues": [
                     {
                         "name": "UNKNOWN_SEVERITY",
-                        "description": "UNKNOWN_SEVERITY",
+                        "description": "Severity of alert is unknown",
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
                         "name": "INFO",
-                        "description": "INFO",
+                        "description": "Info alerts are used for informational messages that should not have a significant effect on user's journey, for example: A single entrance to a metro station is temporarily closed.",
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
                         "name": "WARNING",
-                        "description": "WARNING",
+                        "description": "Warning alerts are used when a single stop or route has a disruption that can affect user's journey, for example: All trams on a specific route are running with irregular schedules.",
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
                         "name": "SEVERE",
-                        "description": "SEVERE",
+                        "description": "Severe alerts are used when a significant part of public transport services is affected, for example: All train services are cancelled due to technical problems.",
                         "isDeprecated": false,
                         "deprecationReason": null
                     }

--- a/test/unit/component/RouteAlertsRow.test.js
+++ b/test/unit/component/RouteAlertsRow.test.js
@@ -71,4 +71,20 @@ describe('<RouteAlertsRow />', () => {
     const wrapper = shallowWithIntl(<RouteAlertsRow {...props} />);
     expect(wrapper.find('.route-alert-time-period')).to.have.lengthOf(0);
   });
+
+  it('should render the routeLine', () => {
+    const props = {
+      routeLine: '97N',
+    };
+    const wrapper = shallowWithIntl(<RouteAlertsRow {...props} />);
+    expect(wrapper.find('.route-alert-top-row').text()).to.equal('97N');
+  });
+
+  it('should render the url', () => {
+    const props = {
+      url: 'https://www.hsl.fi',
+    };
+    const wrapper = shallowWithIntl(<RouteAlertsRow {...props} />);
+    expect(wrapper.find('.route-alert-url')).to.have.lengthOf(1);
+  });
 });

--- a/test/unit/util/alertUtils.test.js
+++ b/test/unit/util/alertUtils.test.js
@@ -404,6 +404,32 @@ describe('alertUtils', () => {
     });
   });
 
+  describe('getServiceAlertUrl', () => {
+    it('should return an empty string if there are no translations and no alertUrl', () => {
+      const alert = {};
+      expect(utils.getServiceAlertUrl(alert)).to.equal('');
+    });
+
+    it('should return alertUrl if there are no translations', () => {
+      const alert = {
+        alertUrl: 'foo',
+      };
+      expect(utils.getServiceAlertUrl(alert)).to.equal('foo');
+    });
+
+    it('should return the localized alertUrl', () => {
+      const alert = {
+        alertUrlTranslations: [
+          {
+            text: 'bar',
+            language: 'en',
+          },
+        ],
+      };
+      expect(utils.getServiceAlertUrl(alert)).to.equal('bar');
+    });
+  });
+
   describe('getServiceAlertsForRoute', () => {
     it('should return an empty array if the route does not exist', () => {
       expect(utils.getServiceAlertsForRoute(undefined)).to.deep.equal([]);
@@ -447,6 +473,17 @@ describe('alertUtils', () => {
               },
             ],
             alertSeverityLevel: 'foo',
+            alertUrl: 'https://www.hsl.fi',
+            alertUrlTranslations: [
+              {
+                language: 'fi',
+                text: 'https://www.hsl.fi',
+              },
+              {
+                language: 'en',
+                text: 'https://www.hsl.fi/en',
+              },
+            ],
             effectiveEndDate: 1577829548,
             effectiveStartDate: 1543183208,
           },
@@ -467,6 +504,7 @@ describe('alertUtils', () => {
             shortName: 'foobar',
           },
           severityLevel: 'foo',
+          url: 'https://www.hsl.fi/en',
           validityPeriod: {
             endTime: 1577829548,
             startTime: 1543183208,


### PR DESCRIPTION
The purpose of this pull request is to show a link to an external resource for service alerts if the url is available. This can be previewed using the style guide page for the component RouteAlertsRow.

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/58004421-dc186400-7aeb-11e9-9748-cdcdbdba9603.png)
