### PR TITLE
DT-3037: show correct citybike network icon on the map layer multi-selection popup

### DIFF
--- a/app/component/map/tile-layer/SelectCityBikeRow.js
+++ b/app/component/map/tile-layer/SelectCityBikeRow.js
@@ -2,19 +2,25 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Icon from '../../Icon';
 import ComponentUsageExample from '../../ComponentUsageExample';
+import {
+  getCityBikeNetworkConfig,
+  getCityBikeNetworkIcon,
+  getCityBikeNetworkId,
+} from '../../../util/citybikes';
 
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-function SelectCityBikeRow(props) {
+function SelectCityBikeRow({ selectRow, name, networks }, { config }) {
+  const img = getCityBikeNetworkIcon(
+    getCityBikeNetworkConfig(getCityBikeNetworkId(networks), config),
+  );
   return (
     <div className="no-margin">
-      <div className="cursor-pointer select-row" onClick={props.selectRow}>
+      <div className="cursor-pointer select-row" onClick={selectRow}>
         <div className="padding-vertical-normal select-row-icon">
-          <Icon img="icon-icon_citybike" />
+          <Icon img={img} />
         </div>
         <div className="padding-vertical-normal select-row-text">
-          <span className="header-primary no-margin link-color">
-            {props.name} ›
-          </span>
+          <span className="header-primary no-margin link-color">{name} ›</span>
         </div>
         <div className="clear" />
       </div>
@@ -37,6 +43,14 @@ SelectCityBikeRow.description = (
 SelectCityBikeRow.propTypes = {
   selectRow: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
+  networks: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]).isRequired,
+};
+
+SelectCityBikeRow.contextTypes = {
+  config: PropTypes.object.isRequired,
 };
 
 export default SelectCityBikeRow;

--- a/app/util/citybikes.js
+++ b/app/util/citybikes.js
@@ -1,4 +1,6 @@
-import { isEmpty, without } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isString from 'lodash/isString';
+import without from 'lodash/without';
 import { toggleCitybikesAndNetworks } from './modeUtils';
 import { getCustomizedSettings } from '../store/localStorage';
 import { replaceQueryParams } from './queryUtils';
@@ -32,6 +34,9 @@ export const getCityBikeNetworkIcon = (networkConfig = defaultNetworkConfig) =>
   `icon-icon_${networkConfig.icon || 'citybike'}`;
 
 export const getCityBikeNetworkId = networks => {
+  if (isString(networks) && networks.length > 0) {
+    return networks;
+  }
   if (!Array.isArray(networks) || networks.length === 0) {
     return undefined;
   }

--- a/test/unit/component/map/tile-layer/MarkerSelectPopup.test.js
+++ b/test/unit/component/map/tile-layer/MarkerSelectPopup.test.js
@@ -27,7 +27,11 @@ describe('<MarkerSelectPopup />', () => {
           layer: 'citybike',
           feature: {
             geom: { x: 2948, y: 3452 },
-            properties: { id: '114', name: 'Ratapihantie' },
+            properties: {
+              id: '114',
+              name: 'Ratapihantie',
+              networks: ['foobar'],
+            },
           },
         },
       ],

--- a/test/unit/component/map/tile-layer/SelectCityBikeRow.test.js
+++ b/test/unit/component/map/tile-layer/SelectCityBikeRow.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import SelectCityBikeRow from '../../../../../app/component/map/tile-layer/SelectCityBikeRow';
+import { shallowWithIntl } from '../../../helpers/mock-intl-enzyme';
+import Icon from '../../../../../app/component/Icon';
+
+describe('<SelectCityBikeRow />', () => {
+  it('should use the citybike icon by default', () => {
+    const props = {
+      name: 'foobar',
+      networks: 'some_network',
+      selectRow: () => {},
+    };
+    const wrapper = shallowWithIntl(<SelectCityBikeRow {...props} />);
+    expect(wrapper.find(Icon).prop('img')).to.contain('citybike');
+  });
+
+  it('should use the configured icon for the network', () => {
+    const props = {
+      name: 'foobar',
+      networks: 'scooter_network',
+      selectRow: () => {},
+    };
+    const wrapper = shallowWithIntl(<SelectCityBikeRow {...props} />, {
+      context: {
+        config: {
+          cityBike: { networks: { scooter_network: { icon: 'scooter' } } },
+        },
+      },
+    });
+    expect(wrapper.find(Icon).prop('img')).to.contain('scooter');
+  });
+});

--- a/test/unit/util/citybikes.test.js
+++ b/test/unit/util/citybikes.test.js
@@ -19,6 +19,11 @@ describe('citybikes', () => {
       const networks = ['Samocat', 'Smoove'];
       expect(getCityBikeNetworkId(networks)).to.equal('Samocat');
     });
+
+    it('should also accept an input string', () => {
+      const networks = 'Samocat';
+      expect(getCityBikeNetworkId(networks)).to.equal('Samocat');
+    });
   });
 
   describe('getCityBikeNetworkConfig', () => {


### PR DESCRIPTION
The purpose of this pull request is to show the correct icon for a citybike station when there are multiple selection options listed in the popup. This can be reviewed using scooter network data currently available from the development api.

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/58017408-d41aed00-7b08-11e9-8265-177da341275b.png)
