### PR TITLE
DT-3045: do not display future service alerts

### DIFF
--- a/app/component/AlertList.js
+++ b/app/component/AlertList.js
@@ -7,7 +7,7 @@ import { FormattedMessage } from 'react-intl';
 
 import ComponentUsageExample from './ComponentUsageExample';
 import RouteAlertsRow from './RouteAlertsRow';
-import { alertHasExpired } from '../util/alertUtils';
+import { isAlertValid } from '../util/alertUtils';
 import { routeNameCompare } from '../util/searchUtils';
 import { AlertSeverityLevelType } from '../constants';
 
@@ -62,7 +62,7 @@ const AlertList = ({
   )
     .map(alert => ({
       ...alert,
-      expired: alertHasExpired(alert, currentTimeUnix),
+      expired: !isAlertValid(alert, currentTimeUnix),
     }))
     .filter(alert => (showExpired ? true : !alert.expired));
 

--- a/app/component/AlertList.js
+++ b/app/component/AlertList.js
@@ -62,7 +62,7 @@ const AlertList = ({
   )
     .map(alert => ({
       ...alert,
-      expired: alertHasExpired(alert.validityPeriod, currentTimeUnix),
+      expired: alertHasExpired(alert, currentTimeUnix),
     }))
     .filter(alert => (showExpired ? true : !alert.expired));
 

--- a/app/component/RouteStop.js
+++ b/app/component/RouteStop.js
@@ -13,7 +13,7 @@ import StopCode from './StopCode';
 import { fromStopTime } from './DepartureTime';
 import ComponentUsageExample from './ComponentUsageExample';
 import { AlertSeverityLevelType, RealtimeStateType } from '../constants';
-import { getMaximumAlertSeverityLevel } from '../util/alertUtils';
+import { getActiveAlertSeverityLevel } from '../util/alertUtils';
 import { PREFIX_STOPS } from '../util/path';
 
 const exampleStop = {
@@ -185,7 +185,10 @@ class RouteStop extends React.PureComponent {
                 <span>{stop.name}</span>
                 <ServiceAlertIcon
                   className="inline-icon"
-                  severityLevel={getMaximumAlertSeverityLevel(stop.alerts)}
+                  severityLevel={getActiveAlertSeverityLevel(
+                    stop.alerts,
+                    currentTime,
+                  )}
                 />
                 {patternExists &&
                   stop.stopTimesForPattern[0].pickupType === 'NONE' &&

--- a/app/component/StopCardHeader.js
+++ b/app/component/StopCardHeader.js
@@ -7,7 +7,7 @@ import ComponentUsageExample from './ComponentUsageExample';
 import Icon from './Icon';
 import ServiceAlertIcon from './ServiceAlertIcon';
 import ZoneIcon from './ZoneIcon';
-import { getMaximumAlertSeverityLevel } from '../util/alertUtils';
+import { getActiveAlertSeverityLevel } from '../util/alertUtils';
 
 class StopCardHeader extends React.Component {
   get headerConfig() {
@@ -29,7 +29,7 @@ class StopCardHeader extends React.Component {
   }
 
   render() {
-    const { className, headingStyle, icons, stop } = this.props;
+    const { className, currentTime, headingStyle, icons, stop } = this.props;
     if (!stop) {
       return false;
     }
@@ -40,7 +40,10 @@ class StopCardHeader extends React.Component {
         headerIcon={
           <ServiceAlertIcon
             className="inline-icon"
-            severityLevel={getMaximumAlertSeverityLevel(stop.alerts)}
+            severityLevel={getActiveAlertSeverityLevel(
+              stop.alerts,
+              currentTime,
+            )}
           />
         }
         headingStyle={headingStyle}
@@ -57,6 +60,7 @@ class StopCardHeader extends React.Component {
 }
 
 StopCardHeader.propTypes = {
+  currentTime: PropTypes.number,
   stop: PropTypes.shape({
     gtfsId: PropTypes.string,
     name: PropTypes.string,
@@ -64,7 +68,11 @@ StopCardHeader.propTypes = {
     desc: PropTypes.string,
     zoneId: PropTypes.string,
     alerts: PropTypes.arrayOf(
-      PropTypes.shape({ alertSeverityLevel: PropTypes.string }),
+      PropTypes.shape({
+        alertSeverityLevel: PropTypes.string,
+        effectiveEndDate: PropTypes.number,
+        effectiveStartDate: PropTypes.number,
+      }),
     ),
   }),
   distance: PropTypes.number,

--- a/app/component/StopCardHeaderContainer.js
+++ b/app/component/StopCardHeaderContainer.js
@@ -1,19 +1,28 @@
+import connectToStores from 'fluxible-addons-react/connectToStores';
 import Relay from 'react-relay/classic';
-import StopCardHeader from './StopCardHeader';
 
-export default Relay.createContainer(StopCardHeader, {
-  fragments: {
-    stop: () => Relay.QL`
+import StopCardHeader from './StopCardHeader';
+import { StopAlertsQuery } from '../util/alertQueries';
+
+export default Relay.createContainer(
+  connectToStores(StopCardHeader, ['TimeStore'], context => ({
+    currentTime: context
+      .getStore('TimeStore')
+      .getCurrentTime()
+      .unix(),
+  })),
+  {
+    fragments: {
+      stop: () => Relay.QL`
       fragment on Stop {
         gtfsId
         name
         code
         desc
         zoneId
-        alerts {
-          alertSeverityLevel
-        }
+        ${StopAlertsQuery}
       }
     `,
+    },
   },
-});
+);

--- a/app/component/TripRouteStop.js
+++ b/app/component/TripRouteStop.js
@@ -17,9 +17,20 @@ import {
   realtimeDeparture as exampleRealtimeDeparture,
   vehicle as exampleVehicle,
 } from './ExampleData';
-import { getMaximumAlertSeverityLevel } from '../util/alertUtils';
+import { getActiveAlertSeverityLevel } from '../util/alertUtils';
 
 const TripRouteStop = props => {
+  const {
+    className,
+    color,
+    currentTime,
+    distance,
+    mode,
+    stop,
+    stopPassed,
+    stoptime,
+  } = props;
+
   const vehicles =
     props.vehicles &&
     props.vehicles.map(vehicle => (
@@ -38,56 +49,58 @@ const TripRouteStop = props => {
     <div
       className={cx(
         'route-stop location-details_container',
-        { passed: props.stopPassed },
-        props.className,
+        { passed: stopPassed },
+        className,
       )}
     >
       <div className=" route-stop-now">{vehicles}</div>
-      <div className={cx('route-stop-now_circleline', props.mode)}>
+      <div className={cx('route-stop-now_circleline', mode)}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width={15}
           height={30}
-          style={{ fill: props.color, stroke: props.color }}
+          style={{ fill: color, stroke: color }}
         >
           <circle
             strokeWidth="2"
-            stroke={props.color || 'currentColor'}
+            stroke={color || 'currentColor'}
             fill="white"
             cx="6"
             cy="13"
             r="5"
           />
         </svg>
-        <div className={cx('route-stop-now_line', props.mode)} />
+        <div className={cx('route-stop-now_line', mode)} />
       </div>
       <div className="route-stop-row_content-container">
-        <Link to={`/${PREFIX_STOPS}/${encodeURIComponent(props.stop.gtfsId)}`}>
-          <div className={`route-details_container ${props.mode}`}>
+        <Link to={`/${PREFIX_STOPS}/${encodeURIComponent(stop.gtfsId)}`}>
+          <div className={`route-details_container ${mode}`}>
             <div>
-              <span>{props.stop.name}</span>
+              <span>{stop.name}</span>
               <ServiceAlertIcon
                 className="inline-icon"
-                severityLevel={getMaximumAlertSeverityLevel(props.stop.alerts)}
+                severityLevel={getActiveAlertSeverityLevel(
+                  stop.alerts,
+                  currentTime,
+                )}
               />
             </div>
             <div>
-              {props.stop.code && <StopCode code={props.stop.code} />}
-              <span className="route-stop-address">{props.stop.desc}</span>
+              {stop.code && <StopCode code={stop.code} />}
+              <span className="route-stop-address">{stop.desc}</span>
               {'\u2002'}
-              {props.distance && (
+              {distance && (
                 <WalkDistance
                   className="nearest-route-stop"
                   icon="icon_location-with-user"
-                  walkDistance={props.distance}
+                  walkDistance={distance}
                 />
               )}
             </div>
           </div>
           <div className="departure-times-container">
             <div className="route-stop-time">
-              {props.stoptime &&
-                fromStopTime(props.stoptime, props.currentTime)}
+              {stoptime && fromStopTime(stoptime, currentTime)}
             </div>
           </div>
         </Link>

--- a/app/component/TripStopListContainer.js
+++ b/app/component/TripStopListContainer.js
@@ -8,6 +8,7 @@ import groupBy from 'lodash/groupBy';
 import values from 'lodash/values';
 
 import TripRouteStop from './TripRouteStop';
+import { StopAlertsQuery } from '../util/alertQueries';
 import { getDistanceToNearestStop } from '../util/geo-utils';
 import withBreakpoint from '../util/withBreakpoint';
 
@@ -202,9 +203,7 @@ const connectedComponent = Relay.createContainer(
             code
             lat
             lon
-            alerts {
-              alertSeverityLevel
-            }
+            ${StopAlertsQuery}
           }
           realtimeDeparture
           realtime

--- a/app/component/map/tile-layer/Stops.js
+++ b/app/component/map/tile-layer/Stops.js
@@ -4,7 +4,7 @@ import pick from 'lodash/pick';
 import Relay from 'react-relay/classic';
 
 import { StopAlertsQuery } from '../../../util/alertQueries';
-import { getMaximumAlertSeverityLevel } from '../../../util/alertUtils';
+import { getActiveAlertSeverityLevel } from '../../../util/alertUtils';
 import {
   drawRoundIcon,
   drawTerminalIcon,
@@ -102,7 +102,10 @@ class Stops {
         return;
       }
       cache[gtfsId] = currentTime;
-      this.drawStop(stopFeature, getMaximumAlertSeverityLevel(result.alerts));
+      this.drawStop(
+        stopFeature,
+        getActiveAlertSeverityLevel(result.alerts, currentTime / 1000),
+      );
     };
 
     const latestFetchTime = cache[gtfsId];

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -1,5 +1,5 @@
 import find from 'lodash/find';
-import isInteger from 'lodash/isInteger';
+import isNumber from 'lodash/isNumber';
 import uniqBy from 'lodash/uniqBy';
 import PropTypes from 'prop-types';
 
@@ -147,7 +147,7 @@ export const isAlertValid = (
   referenceUnixTime,
   defaultValidity = DEFAULT_VALIDITY,
 ) => {
-  if (!validityPeriod || !isInteger(referenceUnixTime)) {
+  if (!validityPeriod || !isNumber(referenceUnixTime)) {
     return true;
   }
   const { startTime, endTime } = validityPeriod;

--- a/test/unit/component/AlertList.test.js
+++ b/test/unit/component/AlertList.test.js
@@ -20,7 +20,7 @@ describe('<AlertList />', () => {
 
   it('should order the cancelations and service alerts by route shortName', () => {
     const props = {
-      currentTime: 1547464412,
+      currentTime: 1547464414,
       cancelations: [
         {
           header: 'second',
@@ -95,7 +95,7 @@ describe('<AlertList />', () => {
 
   it('should indicate that an alert has not expired', () => {
     const props = {
-      currentTime: moment.unix(1547464412),
+      currentTime: moment.unix(1547464413),
       cancelations: [
         {
           header: 'foo',

--- a/test/unit/component/MessageBar.test.js
+++ b/test/unit/component/MessageBar.test.js
@@ -8,11 +8,13 @@ import {
 import { mockContext } from '../helpers/mock-context';
 import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
 import { setReadMessageIds } from '../../../app/store/localStorage';
+import { AlertSeverityLevelType } from '../../../app/constants';
 
 const defaultProps = {
   getServiceAlertsAsync: async () => [],
   lang: 'fi',
   messages: [],
+  currentTime: 1558610379,
 };
 
 describe('<MessageBar />', () => {
@@ -31,6 +33,7 @@ describe('<MessageBar />', () => {
         {
           alertDescriptionText: 'bar',
           alertHeaderText: 'foo',
+          alertSeverityLevel: AlertSeverityLevelType.Severe,
         },
       ],
     };
@@ -42,10 +45,20 @@ describe('<MessageBar />', () => {
   });
 
   it('should not show a closed service alert tab again', async () => {
-    const alertId = -1792393699;
+    const alertId = 926603079;
     const alerts = [
-      { alertDescriptionText: 'bar', alertHash: 1, alertHeaderText: 'foo' },
-      { alertDescriptionText: 'text', alertHash: 2, alertHeaderText: 'header' },
+      {
+        alertDescriptionText: 'bar',
+        alertHash: 1,
+        alertHeaderText: 'foo',
+        alertSeverityLevel: AlertSeverityLevelType.Severe,
+      },
+      {
+        alertDescriptionText: 'text',
+        alertHash: 2,
+        alertHeaderText: 'header',
+        alertSeverityLevel: AlertSeverityLevelType.Severe,
+      },
     ];
 
     expect(getServiceAlertId(alerts[0])).to.equal(alertId);
@@ -62,5 +75,27 @@ describe('<MessageBar />', () => {
     await wrapper.instance().componentDidMount();
     expect(wrapper.instance().validMessages()[0].id).to.not.equal(alertId);
     expect(wrapper.find(Tab)).to.have.lengthOf(1);
+  });
+
+  it('should not render service alerts that are expired', async () => {
+    const alerts = [
+      {
+        alertDescriptionText: 'bar',
+        alertHeaderText: 'foo',
+        alertSeverityLevel: AlertSeverityLevelType.Severe,
+        effectiveEndDate: 1558610381,
+        effectiveStartDate: 1558610380,
+      },
+    ];
+    const props = {
+      ...defaultProps,
+      getServiceAlertsAsync: async () => alerts,
+    };
+    const wrapper = shallowWithIntl(<MessageBar {...props} />, {
+      context: mockContext,
+    });
+
+    await wrapper.instance().componentDidMount();
+    expect(wrapper.find(Tab)).to.have.lengthOf(0);
   });
 });

--- a/test/unit/component/RouteStop.test.js
+++ b/test/unit/component/RouteStop.test.js
@@ -31,4 +31,20 @@ describe('<RouteStop />', () => {
     const wrapper = mountWithIntl(<RouteStop {...props} />);
     expect(wrapper.find(ServiceAlertIcon).isEmptyRender()).to.equal(false);
   });
+
+  it('should not render a service alert icon for the stop if the alert is not active', () => {
+    const props = {
+      currentTime: 1471515614,
+      stop: {
+        alerts: [
+          {
+            alertSeverityLevel: AlertSeverityLevelType.Warning,
+            effectiveStartDate: 1471515615,
+          },
+        ],
+      },
+    };
+    const wrapper = mountWithIntl(<RouteStop {...props} />);
+    expect(wrapper.find(ServiceAlertIcon).isEmptyRender()).to.equal(true);
+  });
 });

--- a/test/unit/component/StopCardHeader.test.js
+++ b/test/unit/component/StopCardHeader.test.js
@@ -142,4 +142,26 @@ describe('<StopCardHeader />', () => {
     });
     expect(wrapper.find(ServiceAlertIcon).isEmptyRender()).to.equal(true);
   });
+
+  it('should not use a header icon when the stop has alerts but the alerts are not active', () => {
+    const props = {
+      currentTime: 500,
+      stop: {
+        code: '1270',
+        desc: 'Hietaniemenkatu',
+        gtfsId: 'HSL:1130181',
+        name: 'Hietaniemi',
+        alerts: [
+          {
+            alertSeverityLevel: AlertSeverityLevelType.Info,
+            effectiveStartDate: 501,
+          },
+        ],
+      },
+    };
+    const wrapper = mountWithIntl(<StopCardHeader {...props} />, {
+      context: { config: { stopCard: { header: {} } } },
+    });
+    expect(wrapper.find(ServiceAlertIcon).isEmptyRender()).to.equal(true);
+  });
 });

--- a/test/unit/component/TripRouteStop.test.js
+++ b/test/unit/component/TripRouteStop.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { mountWithIntl } from '../helpers/mock-intl-enzyme';
+import TripRouteStop from '../../../app/component/TripRouteStop';
+import ServiceAlertIcon from '../../../app/component/ServiceAlertIcon';
+import { AlertSeverityLevelType } from '../../../app/constants';
+
+describe('<TripRouteStop />', () => {
+  it('should not render a service alert icon for the trip route stop if the alert is not active', () => {
+    const props = {
+      currentTime: 1471515614,
+      distance: false,
+      mode: 'bus',
+      pattern: 'HSL:4444T:0:02',
+      route: 'HSL:4444T',
+      selectedVehicle: {},
+      stop: {
+        alerts: [
+          {
+            alertSeverityLevel: AlertSeverityLevelType.Warning,
+            effectiveStartDate: 1471515615,
+          },
+        ],
+      },
+      stoptime: {},
+    };
+    const wrapper = mountWithIntl(<TripRouteStop {...props} />, {
+      context: { config: {} },
+      childContextTypes: { config: PropTypes.object },
+    });
+    expect(wrapper.find(ServiceAlertIcon).isEmptyRender()).to.equal(true);
+  });
+});

--- a/test/unit/util/alertUtils.test.js
+++ b/test/unit/util/alertUtils.test.js
@@ -660,34 +660,66 @@ describe('alertUtils', () => {
   });
 
   describe('alertHasExpired', () => {
+    it('should not mark an alert missing its validity period as expired', () => {
+      expect(utils.alertHasExpired({ validityPeriod: undefined }, 1)).to.equal(
+        false,
+      );
+    });
+
+    it('should not mark an alert missing its validity start and end times as expired', () => {
+      expect(
+        utils.alertHasExpired(
+          { validityPeriod: { startTime: null, endTime: null } },
+          1000,
+        ),
+      ).to.equal(false);
+    });
+
     it('should mark an alert in the past as expired', () => {
       expect(
-        utils.alertHasExpired({ startTime: 1000, endTime: 2000 }, 2500),
+        utils.alertHasExpired(
+          { validityPeriod: { startTime: 1000, endTime: 2000 } },
+          2500,
+        ),
       ).to.equal(true);
     });
 
     it('should not mark a current alert as expired', () => {
       expect(
-        utils.alertHasExpired({ startTime: 1000, endTime: 2000 }, 1500),
+        utils.alertHasExpired(
+          { validityPeriod: { startTime: 1000, endTime: 2000 } },
+          1500,
+        ),
       ).to.equal(false);
     });
 
     it('should not mark a current alert within DEFAULT_VALIDITY period as expired', () => {
-      expect(utils.alertHasExpired({ startTime: 1000 }, 1100, 200)).to.equal(
-        false,
-      );
+      expect(
+        utils.alertHasExpired(
+          { validityPeriod: { startTime: 1000 } },
+          1100,
+          200,
+        ),
+      ).to.equal(false);
     });
 
     it('should mark an alert after the DEFAULT_VALIDITY period as expired', () => {
-      expect(utils.alertHasExpired({ startTime: 1000 }, 1300, 200)).to.equal(
-        true,
-      );
+      expect(
+        utils.alertHasExpired(
+          { validityPeriod: { startTime: 1000 } },
+          1300,
+          200,
+        ),
+      ).to.equal(true);
     });
 
-    it('should not mark an alert in the future as expired', () => {
+    it('should mark an alert in the future as expired', () => {
       expect(
-        utils.alertHasExpired({ startTime: 1000, endTime: 2000 }, 500),
-      ).to.equal(false);
+        utils.alertHasExpired(
+          { validityPeriod: { startTime: 1000, endTime: 2000 } },
+          500,
+        ),
+      ).to.equal(true);
     });
   });
 
@@ -1067,6 +1099,36 @@ describe('alertUtils', () => {
         startTime: 1553769600000,
       };
       expect(utils.legHasActiveAlert(leg)).to.equal(true);
+    });
+  });
+
+  describe('getActiveAlertSeverityLevel', () => {
+    it('should return undefined if there are no current alerts', () => {
+      const alerts = [
+        {
+          alertSeverityLevel: AlertSeverityLevelType.Info,
+          effectiveEndDate: 1559941140,
+          effectiveStartDate: 1558904400,
+        },
+      ];
+      const currentTime = 1558599526;
+      expect(utils.getActiveAlertSeverityLevel(alerts, currentTime)).to.equal(
+        undefined,
+      );
+    });
+
+    it('should return the severity level if there are no effective dates available', () => {
+      const alerts = [
+        {
+          alertSeverityLevel: AlertSeverityLevelType.Info,
+          effectiveEndDate: null,
+          effectiveStartDate: null,
+        },
+      ];
+      const currentTime = 1558599526;
+      expect(utils.getActiveAlertSeverityLevel(alerts, currentTime)).to.equal(
+        AlertSeverityLevelType.Info,
+      );
     });
   });
 });

--- a/test/unit/util/alertUtils.test.js
+++ b/test/unit/util/alertUtils.test.js
@@ -714,13 +714,27 @@ describe('alertUtils', () => {
       ).to.equal(false);
     });
 
-    it('should mark an alert as valid if the given reference time is not an integer', () => {
+    it('should mark an alert as valid if the given reference time is not a number', () => {
       expect(
         utils.isAlertValid(
           { validityPeriod: { startTime: 0, endTime: 1000 } },
           undefined,
         ),
       ).to.equal(true);
+    });
+
+    it('should accept non-integer numbers', () => {
+      expect(
+        utils.isAlertValid(
+          {
+            validityPeriod: {
+              endTime: 1559941140,
+              startTime: 1558904400,
+            },
+          },
+          1558678507424 / 1000,
+        ),
+      ).to.equal(false);
     });
   });
 


### PR DESCRIPTION
The purpose of this pull request is to prevent any service alerts from showing if they are currently not active. In addition, the same filtering logic was included to the top banner as it was previously missing.