### PR TITLE
Fixes: severity level duplicates, pattern selection

### DIFF
--- a/app/component/AlertList.js
+++ b/app/component/AlertList.js
@@ -48,7 +48,9 @@ const AlertList = ({
   const getMode = alert => getRoute(alert).mode;
   const getShortName = alert => getRoute(alert).shortName;
   const getGroupKey = alert =>
-    `${getMode(alert)}${alert.header}${alert.description}`;
+    `${alert.severityLevel}${getMode(alert)}${alert.header}${
+      alert.description
+    }`;
   const getUniqueId = alert => `${getShortName(alert)}${getGroupKey(alert)}`;
 
   const uniqueAlerts = uniqBy(

--- a/app/component/AlertList.js
+++ b/app/component/AlertList.js
@@ -56,23 +56,27 @@ const AlertList = ({
   const uniqueAlerts = uniqBy(
     [
       ...(Array.isArray(cancelations)
-        ? cancelations.map(cancelation => ({
-            ...cancelation,
-            severityLevel: AlertSeverityLevelType.Warning,
-            expired: !isAlertValid(cancelation, currentTime, {
-              isFutureValid: true,
-            }),
-          }))
+        ? cancelations
+            .map(cancelation => ({
+              ...cancelation,
+              severityLevel: AlertSeverityLevelType.Warning,
+              expired: !isAlertValid(cancelation, currentTime, {
+                isFutureValid: true,
+              }),
+            }))
+            .filter(alert => (showExpired ? true : !alert.expired))
         : []),
       ...(Array.isArray(serviceAlerts)
-        ? serviceAlerts.map(alert => ({
-            ...alert,
-            expired: !isAlertValid(alert, currentTime),
-          }))
+        ? serviceAlerts
+            .map(alert => ({
+              ...alert,
+              expired: !isAlertValid(alert, currentTime),
+            }))
+            .filter(alert => (showExpired ? true : !alert.expired))
         : []),
     ],
     getUniqueId,
-  ).filter(alert => (showExpired ? true : !alert.expired));
+  );
 
   if (uniqueAlerts.length === 0) {
     return (

--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -69,33 +69,42 @@ class RoutePage extends React.Component {
 
   // gets called if pattern has not been visited before
   componentDidMount() {
-    const { realTime } = this.context.config;
-    if (!realTime || this.props.route == null) {
+    const { params, route } = this.props;
+    const { config, executeAction } = this.context;
+    const { realTime } = config;
+    if (!realTime || route == null) {
       return;
     }
-    const route = this.props.route.gtfsId.split(':');
-    const agency = route[0];
+
+    const routeParts = route.gtfsId.split(':');
+    const agency = routeParts[0];
     const source = realTime[agency];
-    if (source && source.active) {
-      const { headsign } = this.props.route.patterns.find(
-        pattern => pattern.code === this.props.params.patternId,
-      );
-      const id = source.routeSelector(this.props);
-      this.context.executeAction(startRealTimeClient, {
-        ...source,
-        agency,
-        options: [
-          {
-            route: id,
-            // add some information from the context
-            // to compensate potentially missing feed data
-            mode: this.props.route.mode.toLowerCase(),
-            gtfsId: route[1],
-            headsign,
-          },
-        ],
-      });
+    if (!source || !source.active) {
+      return;
     }
+
+    const pattern = route.patterns.find(
+      ({ code }) => code === params.patternId,
+    );
+    if (!pattern) {
+      return;
+    }
+
+    const id = source.routeSelector(this.props);
+    executeAction(startRealTimeClient, {
+      ...source,
+      agency,
+      options: [
+        {
+          route: id,
+          // add some information from the context
+          // to compensate potentially missing feed data
+          mode: route.mode.toLowerCase(),
+          gtfsId: routeParts[1],
+          headsign: pattern.headsign,
+        },
+      ],
+    });
   }
 
   componentWillUnmount() {
@@ -106,35 +115,38 @@ class RoutePage extends React.Component {
   }
 
   onPatternChange = newPattern => {
-    const { client, topics } = this.context.getStore(
-      'RealTimeInformationStore',
-    );
+    const { location, params, route } = this.props;
+    const { config, executeAction, getStore, router } = this.context;
+    const { client, topics } = getStore('RealTimeInformationStore');
+
     // if config contains mqtt feed and old client has not been removed
     if (client) {
-      const { realTime } = this.context.config;
-      const route = this.props.route.gtfsId.split(':');
-      const agency = route[0];
+      const { realTime } = config;
+      const routeParts = route.gtfsId.split(':');
+      const agency = routeParts[0];
       const source = realTime[agency];
-      const { headsign } = this.props.route.patterns.find(
-        pattern => pattern.code === newPattern,
-      );
-      const id = source.routeSelector(this.props);
-      this.context.executeAction(changeRealTimeClientTopics, {
-        ...source,
-        agency,
-        options: {
-          route: id,
-          mode: this.props.route.mode.toLowerCase(),
-          gtfsId: route[1],
-          headsign,
-        },
-        oldTopics: topics,
-        client,
-      });
+
+      const pattern = route.patterns.find(({ code }) => code === newPattern);
+      if (pattern) {
+        const id = source.routeSelector(this.props);
+        executeAction(changeRealTimeClientTopics, {
+          ...source,
+          agency,
+          options: {
+            route: id,
+            mode: route.mode.toLowerCase(),
+            gtfsId: routeParts[1],
+            headsign: pattern.headsign,
+          },
+          oldTopics: topics,
+          client,
+        });
+      }
     }
-    this.context.router.replace(
-      decodeURIComponent(this.props.location.pathname).replace(
-        new RegExp(`${this.props.params.patternId}(.*)`),
+
+    router.replace(
+      decodeURIComponent(location.pathname).replace(
+        new RegExp(`${params.patternId}(.*)`),
         newPattern,
       ),
     );

--- a/app/component/RoutePatternSelect.js
+++ b/app/component/RoutePatternSelect.js
@@ -49,47 +49,38 @@ class RoutePatternSelect extends Component {
   };
 
   getOptions = () => {
-    const options =
-      this.props.route.patterns.find(
-        o => o.tripsForDate && o.tripsForDate.length > 0,
-      ) !== undefined ||
-      (this.props.route.patterns.find(
-        o => o.tripsForDate && o.tripsForDate.length > 0,
-      ) === undefined &&
-        this.props.activeTab === 'aikataulu')
-        ? sortBy(this.props.route.patterns, 'code')
-            .filter(
-              o =>
-                this.props.activeTab !== 'aikataulu'
-                  ? o.tripsForDate && o.tripsForDate.length > 0
-                  : o,
-            )
-            .map(pattern => {
-              if (this.props.route.patterns.length > 2) {
-                return (
-                  <option key={pattern.code} value={pattern.code}>
-                    {pattern.stops[0].name} ➔ {pattern.headsign}
-                  </option>
-                );
-              }
-              return (
-                <div
-                  key={pattern.code}
-                  value={pattern.code}
-                  className="route-option-togglable"
-                >
-                  {pattern.stops[0].name} ➔ {pattern.headsign}
-                </div>
-              );
-            })
-        : null;
-    const patternDepartures =
-      options && options.filter(o => o.key === this.props.params.patternId);
-    if (patternDepartures && patternDepartures.length === 0) {
-      this.context.router.replace(
-        `/${PREFIX_ROUTES}/${this.props.gtfsId}/pysakit/${options[0].key}`,
+    const { activeTab, gtfsId, params, route } = this.props;
+    const { router } = this.context;
+
+    const patterns =
+      activeTab === 'aikataulu'
+        ? route.patterns
+        : route.patterns.filter(
+            p => Array.isArray(p.tripsForDate) && p.tripsForDate.length > 0,
+          );
+
+    const options = sortBy(patterns, 'code').map(pattern => {
+      if (patterns.length > 2) {
+        return (
+          <option key={pattern.code} value={pattern.code}>
+            {pattern.stops[0].name} ➔ {pattern.headsign}
+          </option>
+        );
+      }
+      return (
+        <div
+          key={pattern.code}
+          value={pattern.code}
+          className="route-option-togglable"
+        >
+          {pattern.stops[0].name} ➔ {pattern.headsign}
+        </div>
       );
-    } else if (options !== null && this.state.loading === true) {
+    });
+
+    if (options.every(o => o.key !== params.patternId)) {
+      router.replace(`/${PREFIX_ROUTES}/${gtfsId}/pysakit/${options[0].key}`);
+    } else if (options.length > 0 && this.state.loading === true) {
       this.setState({ loading: false });
     }
     return options;

--- a/test/unit/component/AlertList.test.js
+++ b/test/unit/component/AlertList.test.js
@@ -326,4 +326,52 @@ describe('<AlertList />', () => {
       AlertSeverityLevelType.Warning,
     );
   });
+
+  it('should not remove a valid service alert due to duplicates', () => {
+    const props = {
+      cancelations: [],
+      serviceAlerts: [
+        {
+          severityLevel: 'WARNING',
+          validityPeriod: {
+            startTime: 1559919600,
+            endTime: 1560130200,
+          },
+          description:
+            'Bussit ajavat poikkeusreittejä Suutarilassa perjantaista 7.6. klo 18 alkaen maanantaiaamuun saakka. Revontulentiellä ja Kiertotähdentiellä ei ole liikennettä ja pysäkeissä on muutoksia. Info: hsl.fi',
+          hash: 460136547,
+          header: 'Bussit poikkeusreitillä Suutarilassa viikonloppuna 7.–9.6.',
+          route: {
+            color: null,
+            mode: 'BUS',
+            shortName: '79',
+          },
+          url:
+            'https://www.hsl.fi/liikennetiedotteet/2019/bussit-poikkeusreitilla-suutarilassa-viikonloppuna-7-96-17505',
+        },
+        {
+          severityLevel: 'INFO',
+          validityPeriod: {
+            startTime: 1559621580,
+            endTime: 1559919600,
+          },
+          description:
+            'Bussit ajavat poikkeusreittejä Suutarilassa perjantaista 7.6. klo 18 alkaen maanantaiaamuun saakka. Revontulentiellä ja Kiertotähdentiellä ei ole liikennettä ja pysäkeissä on muutoksia. Info: hsl.fi',
+          hash: 654282542,
+          header: 'Bussit poikkeusreitillä Suutarilassa viikonloppuna 7.–9.6.',
+          route: {
+            color: null,
+            mode: 'BUS',
+            shortName: '79',
+          },
+          url:
+            'https://www.hsl.fi/liikennetiedotteet/2019/bussit-poikkeusreitilla-suutarilassa-viikonloppuna-7-96-17505',
+        },
+      ],
+      currentTime: 1559654135,
+      showExpired: false,
+    };
+    const wrapper = shallowWithIntl(<AlertList {...props} />);
+    expect(wrapper.find(RouteAlertsRow)).to.have.lengthOf(1);
+  });
 });

--- a/test/unit/component/RoutePage.test.js
+++ b/test/unit/component/RoutePage.test.js
@@ -268,4 +268,69 @@ describe('<RoutePage />', () => {
     });
     expect(wrapper.find('.activeAlert')).to.have.lengthOf(1);
   });
+
+  describe('componentDidMount', () => {
+    it('should ignore a missing pattern', () => {
+      const props = {
+        breakpoint: 'large',
+        location: {
+          pathname: '/linjat/HSL:1063/pysakit/HSL:1063:0:02',
+        },
+        params: {
+          routeId: 'HSL:1063',
+          patternId: 'HSL:1063:0:02',
+        },
+        route: {
+          gtfsId: 'HSL:1063',
+          mode: 'BUS',
+          patterns: [
+            {
+              code: 'HSL:1063:0:01',
+            },
+          ],
+        },
+      };
+      const wrapper = shallowWithIntl(<RoutePage {...props} />, {
+        context: {
+          ...mockContext,
+          config: { realTime: { HSL: { active: true } } },
+        },
+      });
+      wrapper.instance().componentDidMount();
+    });
+  });
+
+  describe('onPatternChange', () => {
+    it('should ignore a missing pattern', () => {
+      const props = {
+        breakpoint: 'large',
+        location: {
+          pathname: '/linjat/HSL:1063/pysakit/HSL:1063:0:02',
+        },
+        params: {
+          routeId: 'HSL:1063',
+          patternId: 'HSL:1063:0:01',
+        },
+        route: {
+          gtfsId: 'HSL:1063',
+          mode: 'BUS',
+          patterns: [
+            {
+              code: 'HSL:1063:0:01',
+            },
+          ],
+        },
+      };
+      const wrapper = shallowWithIntl(<RoutePage {...props} />, {
+        context: {
+          ...mockContext,
+          config: {
+            realTime: { HSL: { active: true, routeSelector: () => '63' } },
+          },
+          getStore: () => ({ client: {} }),
+        },
+      });
+      wrapper.instance().onPatternChange('foobar');
+    });
+  });
 });

--- a/test/unit/component/RoutePatternSelect.test.js
+++ b/test/unit/component/RoutePatternSelect.test.js
@@ -33,4 +33,91 @@ describe('<RoutePatternSelect />', () => {
     });
     expect(wrapper.find('#select-route-pattern > option')).to.have.lengthOf(3);
   });
+
+  it('should render a toggle element with divs if there are only 2 patterns with trips', () => {
+    const props = {
+      activeTab: 'pysakit',
+      gtfsId: 'HSL:3002U',
+      onSelectChange: () => {},
+      params: {
+        patternId: 'HSL:3002U:0:02',
+      },
+      relay: {
+        setVariables: () => {},
+      },
+      route: {
+        patterns: [
+          {
+            code: 'HSL:3002U:0:01',
+            headsign: 'Kauklahti',
+            stops: [{ name: 'Helsinki' }, { name: 'Kauklahti' }],
+            tripsForDate: [{}],
+          },
+          {
+            code: 'HSL:3002U:0:02',
+            headsign: 'Kirkkonummi',
+            stops: [{ name: 'Helsinki' }, { name: 'Kirkkonummi' }],
+            tripsForDate: [{}],
+          },
+          {
+            code: 'HSL:3002U:0:03',
+            stops: [{ name: 'Helsinki' }, { name: 'Siuntio' }],
+            tripsForDate: [],
+          },
+        ],
+      },
+      serviceDay: '20190604',
+    };
+    const wrapper = shallowWithIntl(<RoutePatternSelect {...props} />, {
+      context: { ...mockContext },
+    });
+    expect(wrapper.find('option')).to.have.lengthOf(0);
+    expect(wrapper.find('div.route-option-togglable')).to.have.lengthOf(1);
+  });
+
+  it('should redirect to the first existing pattern if there is no matching pattern available', () => {
+    const props = {
+      activeTab: 'pysakit',
+      gtfsId: 'HSL:3002U',
+      onSelectChange: () => {},
+      params: {
+        patternId: 'foobar',
+      },
+      relay: {
+        setVariables: () => {},
+      },
+      route: {
+        patterns: [
+          {
+            code: 'HSL:3002U:0:01',
+            headsign: 'Kauklahti',
+            stops: [{ name: 'Helsinki' }, { name: 'Kauklahti' }],
+            tripsForDate: [{}],
+          },
+          {
+            code: 'HSL:3002U:0:02',
+            headsign: 'Kirkkonummi',
+            stops: [{ name: 'Helsinki' }, { name: 'Kirkkonummi' }],
+            tripsForDate: [{}],
+          },
+        ],
+      },
+      serviceDay: '20190604',
+    };
+
+    let url;
+    shallowWithIntl(<RoutePatternSelect {...props} />, {
+      context: {
+        ...mockContext,
+        router: {
+          ...mockContext.router,
+          replace: args => {
+            url = args;
+          },
+        },
+      },
+    });
+    expect(url).to.contain(props.gtfsId);
+    expect(url).to.contain(props.route.patterns[0].code);
+  });
 });


### PR DESCRIPTION
The purpose of this pull request is to enable showing service alerts that are otherwise duplicates but have different severity levels. This case may happen if there is an informational service alert before an actual service alert (e.g. a notification of a planned outage of some sort).

This pull request also fixes a problem with the route pattern selection not showing up in Safari for some routes. In addition, a problem with invalid route pattern ids crashing the UI was fixed.

Screenshot:
![image](https://user-images.githubusercontent.com/2669201/58892069-42a99e80-86f6-11e9-99be-d80d427bbe71.png)
