### PR TITLE
DT-3038: Increased the size of platform numbers

### DIFF
--- a/app/util/mapIconUtils.js
+++ b/app/util/mapIconUtils.js
@@ -166,7 +166,9 @@ export function drawRoundIcon(tile, geom, type, large, platformNumber) {
 
       // The text requires 14 pixels in width, so we draw if the hub radius is at least half of that
       if (platformNumber && hubRadius > 7) {
-        tile.ctx.font = `${1.6 *
+        const { length } = `${platformNumber}`;
+        const multiplier = (length > 3 && 1.2) || (length === 3 && 1.4) || 1.6;
+        tile.ctx.font = `${multiplier *
           hubRadius *
           tile.scaleratio}px Gotham XNarrow SSm A, Gotham XNarrow SSm B, Arial, sans-serif`;
         tile.ctx.fillStyle = '#333';

--- a/app/util/mapIconUtils.js
+++ b/app/util/mapIconUtils.js
@@ -166,7 +166,7 @@ export function drawRoundIcon(tile, geom, type, large, platformNumber) {
 
       // The text requires 14 pixels in width, so we draw if the hub radius is at least half of that
       if (platformNumber && hubRadius > 7) {
-        tile.ctx.font = `${1.2 *
+        tile.ctx.font = `${1.6 *
           hubRadius *
           tile.scaleratio}px Gotham XNarrow SSm A, Gotham XNarrow SSm B, Arial, sans-serif`;
         tile.ctx.fillStyle = '#333';

--- a/test/unit/util/mapIconUtils.test.js
+++ b/test/unit/util/mapIconUtils.test.js
@@ -13,6 +13,7 @@ describe('mapIconUtils', () => {
         arc: sinon.stub(),
         beginPath: sinon.stub(),
         fill: sinon.stub(),
+        fillText: sinon.stub(),
       },
       ratio: 1,
       scaleratio: 1,
@@ -43,6 +44,27 @@ describe('mapIconUtils', () => {
         undefined,
       );
       expect(iconRadius).to.equal(2);
+    });
+
+    it('should use different font sizes depending on the platformNumber length', () => {
+      const getFontSize = font => Number(font.split('px')[0]);
+      const platformTile = {
+        ...tile,
+        coords: {
+          z: 18,
+        },
+      };
+
+      utils.drawRoundIcon(platformTile, geometry, 'BUS', false, '12');
+      const large = getFontSize(platformTile.ctx.font);
+
+      utils.drawRoundIcon(platformTile, geometry, 'BUS', false, '123');
+      const medium = getFontSize(platformTile.ctx.font);
+
+      utils.drawRoundIcon(platformTile, geometry, 'BUS', false, '1234');
+      const small = getFontSize(platformTile.ctx.font);
+
+      expect(large > medium && medium > small).to.equal(true);
     });
   });
 


### PR DESCRIPTION
The purpose of this pull request is to increase the size of platform numbers shown in the stop markers on the map. This size works best with platform codes consisting of one and two letters. Provided that the font and letters are narrow, three letters may work as well.

Single letter:
![image](https://user-images.githubusercontent.com/2669201/58953772-15192f80-87a0-11e9-8ece-d846997b5d4f.png)

Two letters:
![image](https://user-images.githubusercontent.com/2669201/58953714-f31fad00-879f-11e9-9acd-41e79fa1cc15.png)

Longer text:
![image](https://user-images.githubusercontent.com/2669201/58953726-fd41ab80-879f-11e9-8026-a21cb13ea8f1.png)
