### PR TITLE
DT-3057: add service alert icon to "from" stops in the itinerary overview

### DIFF
--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -5,21 +5,23 @@ import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
 import { Link } from 'react-router';
 
-import RouteNumber from './RouteNumber';
-import Icon from './Icon';
-import { durationToString } from '../util/timeUtils';
-import StopCode from './StopCode';
+import ExternalLink from './ExternalLink';
 import LegAgencyInfo from './LegAgencyInfo';
+import Icon from './Icon';
 import IntermediateLeg from './IntermediateLeg';
-import PlatformNumber from './PlatformNumber';
 import ItineraryCircleLine from './ItineraryCircleLine';
-import { PREFIX_ROUTES } from '../util/path';
+import PlatformNumber from './PlatformNumber';
+import RouteNumber from './RouteNumber';
+import ServiceAlertIcon from './ServiceAlertIcon';
+import StopCode from './StopCode';
 import {
+  getActiveAlertSeverityLevel,
   getActiveLegAlertSeverityLevel,
   legHasCancelation,
   tripHasCancelationForStop,
 } from '../util/alertUtils';
-import ExternalLink from './ExternalLink';
+import { PREFIX_ROUTES } from '../util/path';
+import { durationToString } from '../util/timeUtils';
 
 class TransitLeg extends React.Component {
   constructor(props) {
@@ -205,6 +207,13 @@ class TransitLeg extends React.Component {
           <div className="itinerary-leg-first-row">
             <div>
               {leg.from.name}
+              <ServiceAlertIcon
+                className="inline-icon"
+                severityLevel={getActiveAlertSeverityLevel(
+                  leg.from.stop && leg.from.stop.alerts,
+                  leg.startTime / 1000,
+                )}
+              />
               {this.stopCode(leg.from.stop && leg.from.stop.code)}
               <PlatformNumber
                 number={leg.from.stop.platformCode}

--- a/app/component/WalkLeg.js
+++ b/app/component/WalkLeg.js
@@ -1,19 +1,21 @@
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
 import { FormattedMessage } from 'react-intl';
 
-import RouteNumber from './RouteNumber';
-import Icon from './Icon';
 import ComponentUsageExample from './ComponentUsageExample';
-import { displayDistance } from '../util/geo-utils';
-import { durationToString } from '../util/timeUtils';
+import Icon from './Icon';
 import ItineraryCircleLine from './ItineraryCircleLine';
+import RouteNumber from './RouteNumber';
+import ServiceAlertIcon from './ServiceAlertIcon';
+import { getActiveAlertSeverityLevel } from '../util/alertUtils';
 import {
+  CityBikeNetworkType,
   getCityBikeNetworkId,
   getCityBikeNetworkConfig,
-  CityBikeNetworkType,
 } from '../util/citybikes';
+import { displayDistance } from '../util/geo-utils';
+import { durationToString } from '../util/timeUtils';
 
 function WalkLeg(
   { children, focusAction, index, leg, previousLeg },
@@ -62,6 +64,13 @@ function WalkLeg(
             ) : (
               leg.from.name
             )}
+            <ServiceAlertIcon
+              className="inline-icon"
+              severityLevel={getActiveAlertSeverityLevel(
+                leg.from.stop && leg.from.stop.alerts,
+                leg.startTime / 1000,
+              )}
+            />
             {children}
           </div>
           <Icon img="icon-icon_search-plus" className="itinerary-search-icon" />

--- a/test/unit/WalkLeg.test.js
+++ b/test/unit/WalkLeg.test.js
@@ -4,6 +4,8 @@ import { FormattedMessage } from 'react-intl';
 import { shallowWithIntl } from './helpers/mock-intl-enzyme';
 import WalkLeg from '../../app/component/WalkLeg';
 import { CityBikeNetworkType } from '../../app/util/citybikes';
+import ServiceAlertIcon from '../../app/component/ServiceAlertIcon';
+import { AlertSeverityLevelType } from '../../app/constants';
 
 describe('<WalkLeg />', () => {
   it('should show the leg starting point name', () => {
@@ -29,7 +31,7 @@ describe('<WalkLeg />', () => {
       },
     });
 
-    expect(wrapper.find('.itinerary-leg-first-row>div').text()).to.equal(
+    expect(wrapper.find('.itinerary-leg-first-row>div').text()).to.contain(
       'Veturitori',
     );
   });
@@ -123,5 +125,40 @@ describe('<WalkLeg />', () => {
         .at(0)
         .prop('id'),
     ).to.equal('return-scooter-to');
+  });
+
+  it('should show a service alert icon if there is one at the "from" stop', () => {
+    const startTime = 1529589709000;
+    const props = {
+      focusAction: () => {},
+      index: 2,
+      leg: {
+        distance: 284.787,
+        duration: 289,
+        from: {
+          name: 'Veturitori',
+          stop: {
+            alerts: [
+              {
+                alertSeverityLevel: AlertSeverityLevelType.Info,
+                effectiveEndDate: startTime / 1000 + 1,
+                effectiveStartDate: startTime / 1000 - 1,
+              },
+            ],
+          },
+        },
+        mode: 'WALK',
+        rentedBike: false,
+        startTime,
+      },
+    };
+
+    const wrapper = shallowWithIntl(<WalkLeg {...props} />, {
+      context: { config: {} },
+    });
+
+    expect(wrapper.find(ServiceAlertIcon).prop('severityLevel')).to.equal(
+      AlertSeverityLevelType.Info,
+    );
   });
 });

--- a/test/unit/component/TransitLeg.test.js
+++ b/test/unit/component/TransitLeg.test.js
@@ -10,6 +10,7 @@ import {
   AlertSeverityLevelType,
 } from '../../../app/constants';
 import RouteNumber from '../../../app/component/RouteNumber';
+import ServiceAlertIcon from '../../../app/component/ServiceAlertIcon';
 
 const defaultProps = {
   children: <div />,
@@ -609,5 +610,47 @@ describe('<TransitLeg />', () => {
     });
     expect(wrapper.find('.disclaimer-container')).to.have.lengthOf(1);
     expect(wrapper.find('.agency-link')).to.have.lengthOf(1);
+  });
+
+  it('should show a service alert icon if there is one at the "from" stop', () => {
+    const startTime = 123456789;
+    const props = {
+      ...defaultProps,
+      leg: {
+        from: {
+          name: 'Test',
+          stop: {
+            alerts: [
+              {
+                alertSeverityLevel: AlertSeverityLevelType.Info,
+                effectiveEndDate: startTime + 1,
+                effectiveStartDate: startTime - 1,
+              },
+            ],
+          },
+        },
+        intermediatePlaces: [],
+        route: {
+          gtfsId: 'A1234',
+        },
+        startTime: startTime * 1000,
+        to: {
+          stop: {},
+        },
+        trip: {
+          gtfsId: 'A1234:01',
+          pattern: {
+            code: 'A',
+          },
+        },
+      },
+      mode: 'BUS',
+    };
+    const wrapper = shallowWithIntl(<TransitLeg {...props} />, {
+      context: { config: { itinerary: {} }, focusFunction: () => {} },
+    });
+    expect(wrapper.find(ServiceAlertIcon).prop('severityLevel')).to.equal(
+      AlertSeverityLevelType.Info,
+    );
   });
 });


### PR DESCRIPTION
The purpose of this pull request is to show a service alert icon at the "from" stops in the itinerary overview. This will be shown if there is an active service alert at the stop specified, it is independent of the route that passes by that stop.

Screenshot (TransitLeg):
![image](https://user-images.githubusercontent.com/2669201/59109281-70d0ed80-8945-11e9-90c3-62191c55ee83.png)

Screenshot (WalkLeg):
![image](https://user-images.githubusercontent.com/2669201/59109313-7f1f0980-8945-11e9-9373-7488b5de0476.png)
