### PR TITLE
Fix: regression when opening a route without a trip for today

### DIFF
--- a/app/component/RoutePatternSelect.js
+++ b/app/component/RoutePatternSelect.js
@@ -59,6 +59,10 @@ class RoutePatternSelect extends Component {
             p => Array.isArray(p.tripsForDate) && p.tripsForDate.length > 0,
           );
 
+    if (patterns.length === 0) {
+      return null;
+    }
+
     const options = sortBy(patterns, 'code').map(pattern => {
       if (patterns.length > 2) {
         return (

--- a/test/unit/component/RoutePatternSelect.test.js
+++ b/test/unit/component/RoutePatternSelect.test.js
@@ -120,4 +120,40 @@ describe('<RoutePatternSelect />', () => {
     expect(url).to.contain(props.gtfsId);
     expect(url).to.contain(props.route.patterns[0].code);
   });
+
+  it('should not crash if there are no patterns with trips available for the current date', () => {
+    const props = {
+      activeTab: 'pysakit',
+      gtfsId: 'HSL:3002U',
+      onSelectChange: () => {},
+      params: {
+        patternId: 'HSL:3002U:0:01',
+      },
+      relay: {
+        setVariables: () => {},
+      },
+      route: {
+        patterns: [
+          {
+            code: 'HSL:3002U:0:01',
+            headsign: 'Kauklahti',
+            stops: [{ name: 'Helsinki' }, { name: 'Kauklahti' }],
+            tripsForDate: [],
+          },
+          {
+            code: 'HSL:3002U:0:02',
+            headsign: 'Kirkkonummi',
+            stops: [{ name: 'Helsinki' }, { name: 'Kirkkonummi' }],
+            tripsForDate: [],
+          },
+        ],
+      },
+      serviceDay: '20190604',
+    };
+
+    const wrapper = shallowWithIntl(<RoutePatternSelect {...props} />, {
+      context: { ...mockContext },
+    });
+    expect(wrapper.isEmptyRender()).to.equal(false);
+  });
 });


### PR DESCRIPTION
The purpose of this pull request is to fix a regression introduced in a previous pull request related to handling routes with only two patterns. The problematic situation happens when there are no trips for any of the patterns that are driven today.

Example route: https://reittiopas.hsl.fi/linjat/HSL:6911X/pysakit/HSL:6911X:0:01