### PR TITLE
DT-3081: map is now centered correctly when selecting destination point

### DIFF
--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -400,16 +400,6 @@ class MapWithTrackingStateHandler extends React.Component {
       );
     }
 
-    if (destination && destination.ready === true && destination.gps !== true) {
-      leafletObjs.push(
-        <LazilyLoad modules={locationMarkerModules} key="to">
-          {({ LocationMarker }) => (
-            <LocationMarker position={destination} type="to" />
-          )}
-        </LazilyLoad>,
-      );
-    }
-
     if (geoJson) {
       const { bounds } = this.state;
       Object.keys(geoJson)

--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -139,6 +139,16 @@ class MapWithTrackingStateHandler extends React.Component {
     ) {
       this.usePosition(newProps.origin);
     } else if (
+      // "current position selected"
+      newProps.destination.lat !== null &&
+      newProps.destination.lon !== null &&
+      newProps.destination.gps === true &&
+      ((this.state.destination.ready === false &&
+        newProps.destination.ready === true) ||
+        !this.state.destination.gps) // current position selected
+    ) {
+      this.usePosition(newProps.destination);
+    } else if (
       // "poi selected"
       !newProps.origin.gps &&
       (newProps.origin.lat !== this.state.origin.lat ||

--- a/test/unit/component/map/MapWithTracking.test.js
+++ b/test/unit/component/map/MapWithTracking.test.js
@@ -9,6 +9,7 @@ const defaultProps = {
   getGeoJsonConfig: () => {},
   getGeoJsonData: () => {},
   origin: {},
+  destination: {},
   position: {
     hasLocation: false,
     isLocationingInProgress: false,


### PR DESCRIPTION
## Proposed Changes

  - Map is centered around the destination point when origin point is not selected and when destination point is selected from route or stop page.
  - [DT-3081](https://digitransit.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=DT&modal=detail&selectedIssue=DT-3081)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
