### PR TITLE
Dt 3001: Stop and Route pages display wrong header in mobile

### DIFF
--- a/app/component/AppBarContainer.js
+++ b/app/component/AppBarContainer.js
@@ -16,7 +16,7 @@ const AppBarContainer = ({ router, location, homeUrl, logo, ...args }) => (
       mobile={() => (
         <AppBarSmall
           {...args}
-          showLogo={location.pathname.indexOf(homeUrl) === 0}
+          showLogo={location.pathname === homeUrl}
           logo={logo}
           homeUrl={homeUrl}
         />

--- a/app/component/RouteNumber.js
+++ b/app/component/RouteNumber.js
@@ -6,6 +6,7 @@ import IconWithBigCaution from './IconWithBigCaution';
 import IconWithIcon from './IconWithIcon';
 import ComponentUsageExample from './ComponentUsageExample';
 import { realtimeDeparture as exampleRealtimeDeparture } from './ExampleData';
+import { isMobile } from '../util/browser';
 
 const LONG_ROUTE_NUMBER_LENGTH = 6;
 
@@ -64,6 +65,7 @@ function RouteNumber(props, context) {
   // props.vertical is TRUE in itinerary view
   return (
     <span
+      style={{ display: longText && isMobile ? 'block' : null }}
       className={cx('route-number', {
         'overflow-fade': longText && props.fadeLong,
         vertical: props.vertical,
@@ -107,7 +109,10 @@ function RouteNumber(props, context) {
       {props.text &&
         (props.vertical === false ? (
           <span
-            style={{ color: props.color ? props.color : null }}
+            style={{
+              color: props.color ? props.color : null,
+              fontSize: longText && isMobile ? '17px' : null,
+            }}
             className={cx('vehicle-number', mode, {
               'overflow-fade': longText && props.fadeLong,
               long: longText,


### PR DESCRIPTION
## Proposed Changes

  - Route and stop pages display now correct header after refresh in mobile.
  - [DT-3001](https://digitransit.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=DT&modal=detail&selectedIssue=DT-3001)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
