### PR TITLE
DT-2995: Show alert or notification icon for disruptions tab when not empty (stop and route views)

### DIFF
--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -23,6 +23,7 @@ import {
   getServiceAlertsForRoute,
   getServiceAlertsForRouteStops,
   isAlertActive,
+  getActiveAlertSeverityLevel,
 } from '../util/alertUtils';
 import { PREFIX_ROUTES } from '../util/path';
 import withBreakpoint from '../util/withBreakpoint';
@@ -185,10 +186,10 @@ class RoutePage extends React.Component {
       ],
       currentTime,
     );
-
-    const hasActiveServiceAlerts =
-      isAlertActive(getServiceAlertsForRoute(route, patternId)) &&
-      getServiceAlertsForRoute(route, patternId).length > 0;
+    const hasActiveServiceAlerts = getActiveAlertSeverityLevel(
+      getServiceAlertsForRoute(route, patternId),
+      currentTime,
+    );
 
     const disruptionClassName =
       (hasActiveAlert && 'active-disruption-alert') ||

--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -186,6 +186,13 @@ class RoutePage extends React.Component {
       currentTime,
     );
 
+    const hasActiveServiceAlerts =
+      getServiceAlertsForRoute(route, patternId).length > 0;
+
+    const disruptionClassName =
+      (hasActiveAlert && 'active-disruption-alert') ||
+      (hasActiveServiceAlerts && 'active-service-alert');
+
     return (
       <div>
         <div className="header-for-printing">
@@ -244,8 +251,13 @@ class RoutePage extends React.Component {
                 this.changeTab(Tab.Disruptions);
               }}
             >
-              <div>
+              <div
+                className={`tab-route-disruption ${disruptionClassName ||
+                  `no-alerts`}`}
+              >
                 <Icon
+                  className={`route-page-tab_icon ${disruptionClassName ||
+                    `no-alerts`}`}
                   img={hasActiveAlert ? 'icon-icon_caution' : 'icon-icon_info'}
                 />
                 <FormattedMessage

--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -187,6 +187,7 @@ class RoutePage extends React.Component {
     );
 
     const hasActiveServiceAlerts =
+      isAlertActive(getServiceAlertsForRoute(route, patternId)) &&
       getServiceAlertsForRoute(route, patternId).length > 0;
 
     const disruptionClassName =

--- a/app/component/StopPageTabContainer.js
+++ b/app/component/StopPageTabContainer.js
@@ -2,13 +2,18 @@ import cx from 'classnames';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape } from 'react-intl';
 import Relay from 'react-relay/classic';
 import { Link } from 'react-router';
 import some from 'lodash/some';
 
 import Icon from './Icon';
-import { RouteAlertsQuery, StopAlertsQuery } from '../util/alertQueries';
+import {
+  RouteAlertsQuery,
+  StopAlertsQuery,
+  RouteAlertsWithContentQuery,
+  StopAlertsWithContentQuery,
+} from '../util/alertQueries';
 import {
   getCancelationsForStop,
   getServiceAlertsForStop,
@@ -37,14 +42,10 @@ const getActiveTab = pathname => {
   return Tab.RightNow;
 };
 
-function StopPageTabContainer({
-  children,
-  params,
-  routes,
-  breakpoint,
-  location: { pathname },
-  stop,
-}) {
+function StopPageTabContainer(
+  { children, params, routes, breakpoint, location: { pathname }, stop },
+  { intl },
+) {
   if (!stop || (some(routes, 'fullscreenMap') && breakpoint !== 'large')) {
     return null;
   }
@@ -201,6 +202,10 @@ StopPageTabContainer.defaultProps = {
   stop: undefined,
 };
 
+StopPageTabContainer.contextTypes = {
+  intl: intlShape.isRequired,
+};
+
 const containerComponent = Relay.createContainer(
   withBreakpoint(StopPageTabContainer),
   {
@@ -208,6 +213,7 @@ const containerComponent = Relay.createContainer(
       stop: () => Relay.QL`
         fragment on Stop {
           ${StopAlertsQuery}
+          ${StopAlertsWithContentQuery}
           stoptimes: stoptimesWithoutPatterns(
             startTime:$startTime,
             timeRange:$timeRange,
@@ -221,6 +227,7 @@ const containerComponent = Relay.createContainer(
               }
               route {
                 ${RouteAlertsQuery}
+                ${RouteAlertsWithContentQuery}
               }
             }
           }

--- a/app/component/StopPageTabContainer.js
+++ b/app/component/StopPageTabContainer.js
@@ -19,6 +19,7 @@ import {
   getServiceAlertsForStop,
   getServiceAlertsForStopRoutes,
   isAlertActive,
+  getActiveAlertSeverityLevel,
 } from '../util/alertUtils';
 import withBreakpoint from '../util/withBreakpoint';
 
@@ -66,10 +67,15 @@ function StopPageTabContainer(
   );
 
   const hasActiveServiceAlerts =
-    (isAlertActive(getServiceAlertsForStop(stop, intl)) &&
-      getServiceAlertsForStop(stop, intl).length > 0) ||
-    (isAlertActive(getServiceAlertsForStopRoutes(stop, intl)) &&
-      getServiceAlertsForStopRoutes(stop, intl).length > 0);
+    getActiveAlertSeverityLevel(
+      getServiceAlertsForStop(stop, intl),
+      currentTime,
+    ) ||
+    getActiveAlertSeverityLevel(
+      getServiceAlertsForStopRoutes(stop, intl),
+      currentTime,
+    );
+
   const disruptionClassName =
     (hasActiveAlert && 'active-disruption-alert') ||
     (hasActiveServiceAlerts && 'active-service-alert');

--- a/app/component/StopPageTabContainer.js
+++ b/app/component/StopPageTabContainer.js
@@ -64,6 +64,13 @@ function StopPageTabContainer({
     currentTime,
   );
 
+  const hasActiveServiceAlerts =
+    getServiceAlertsForStop(stop).length > 0 ||
+    getServiceAlertsForStopRoutes(stop).length > 0;
+  const disruptionClassName =
+    (hasActiveAlert && 'active-disruption-alert') ||
+    (hasActiveServiceAlerts && 'active-service-alert');
+
   return (
     <div className="stop-page-content-wrapper">
       <div>
@@ -124,16 +131,18 @@ function StopPageTabContainer({
             className={cx('stop-tab-singletab', {
               active: activeTab === Tab.Disruptions,
               'alert-active': hasActiveAlert,
+              'service-alert-active': hasActiveServiceAlerts,
             })}
           >
             <div className="stop-tab-singletab-container">
               <div>
                 <Icon
-                  className="stop-page-tab_icon"
+                  className={`stop-page-tab_icon ${disruptionClassName ||
+                    `no-alerts`}`}
                   img={hasActiveAlert ? 'icon-icon_caution' : 'icon-icon_info'}
                 />
               </div>
-              <div>
+              <div className={`${disruptionClassName || `no-alerts`}`}>
                 <FormattedMessage id="disruptions" />
               </div>
             </div>

--- a/app/component/StopPageTabContainer.js
+++ b/app/component/StopPageTabContainer.js
@@ -66,8 +66,10 @@ function StopPageTabContainer(
   );
 
   const hasActiveServiceAlerts =
-    getServiceAlertsForStop(stop).length > 0 ||
-    getServiceAlertsForStopRoutes(stop).length > 0;
+    (isAlertActive(getServiceAlertsForStop(stop, intl)) &&
+      getServiceAlertsForStop(stop, intl).length > 0) ||
+    (isAlertActive(getServiceAlertsForStopRoutes(stop, intl)) &&
+      getServiceAlertsForStopRoutes(stop, intl).length > 0);
   const disruptionClassName =
     (hasActiveAlert && 'active-disruption-alert') ||
     (hasActiveServiceAlerts && 'active-service-alert');

--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -676,12 +676,12 @@ div.route-tabs {
       }
 
       .no-alerts span {
-        color: #78909c;
+        color:rgb(183, 183, 183);
       }
 
       .route-page-tab_icon {
         &.no-alerts.icon {
-          fill: #78909c;
+          fill: rgb(183, 183, 183);
         }
         &.active-disruption-alert.icon {
           fill: $cancelation-red;

--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -703,7 +703,7 @@ div.route-tabs {
       }
     }
     .tab-route-disruption {
-      &:hover .icon, &:hover span {
+      &:hover span {
         fill: lighten($black, 20%);
         color: lighten($black, 20%);
       }

--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -675,6 +675,40 @@ div.route-tabs {
         display: none;
       }
 
+      .no-alerts span {
+        color: #78909c;
+      }
+
+      .route-page-tab_icon {
+        &.no-alerts.icon {
+          fill: #78909c;
+        }
+        &.active-disruption-alert.icon {
+          fill: $cancelation-red;
+        }
+        &.active-service-alert {
+          &.icon {
+            stroke: $primary-color;
+            fill: $primary-color;
+          }
+      }
+    }
+
+      .active-service-alert {
+        &:hover {
+          .icon {
+          stroke: lighten($black, 20%);
+          fill: lighten($black, 20%);
+        }
+      }
+    }
+    .tab-route-disruption {
+      &:hover .icon, &:hover span {
+        fill: lighten($black, 20%);
+        color: lighten($black, 20%);
+      }
+    }
+
       &.activeAlert,
       &.activeAlert.is-active,
       &.activeAlert:hover {
@@ -689,6 +723,31 @@ div.route-tabs {
 
         .icon {
           fill: $black;
+        }
+        .no-alerts span {
+          color: $black;
+        }
+        .route-page-tab_icon {
+          &.no-alerts.icon {
+            fill: $black;
+          }
+          &.active-disruption-alert.icon {
+            fill: $black;
+          }
+          &.active-service-alert {
+            &.icon {
+            stroke: $black;
+            fill: $black;
+            }
+        }
+      }
+        .active-service-alert {
+            &:hover {
+              .icon {
+              stroke: lighten($black, 20%);
+              fill: lighten($black, 20%);
+            }
+          }
         }
       }
 

--- a/app/component/stop.scss
+++ b/app/component/stop.scss
@@ -174,12 +174,39 @@
       stroke: $black;
       fill: $black;
     }
+    .no-alerts span {
+      color: $black;
+    }
+    .no-alerts.icon {
+      fill: $black;
+    }
+    .active-disruption-alert.icon {
+      fill: $black;
+    }
+    .active-service-alert.icon {
+      stroke: $black;
+      fill: $black;
+    }
   }
 
   &.alert-active {
     .icon {
       fill: $cancelation-red;
     }
+  }
+
+  .no-alerts span {
+    color: #78909c;
+  }
+  .no-alerts.icon {
+    fill: #78909c;
+  }
+  .active-disruption-alert.icon {
+    fill: $cancelation-red
+  }
+  .active-service-alert.icon {
+    stroke: $primary-color;
+    fill: $primary-color;
   }
 
   @media print {

--- a/app/component/stop.scss
+++ b/app/component/stop.scss
@@ -196,10 +196,10 @@
   }
 
   .no-alerts span {
-    color: #78909c;
+    color: rgb(183, 183, 183);
   }
   .no-alerts.icon {
-    fill: #78909c;
+    fill: rgb(183, 183, 183);
   }
   .active-disruption-alert.icon {
     fill: $cancelation-red


### PR DESCRIPTION
## Proposed Changes

  - When there's an active disruption, the icon in the Route and Stop views will be shown as a red disruption icon
  - When there's an active service alert, the icon in the Route and Stop views will be shown as a blue info icon
  - When there are no active alerts at all, the icon will be a grey info icon
  - JIRA Link: https://digitransit.atlassian.net/browse/DT-2995

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
