### PR TITLE
DT-3082: With a long route name, agency_fare_url link is not usable

### DIFF
--- a/app/component/itinerary.scss
+++ b/app/component/itinerary.scss
@@ -107,7 +107,7 @@ $itinerary-tab-switch-height: 48px;
 
   div {
     flex-grow: 1;
-    flex-shrink: 0;
+    flex-shrink: 1;
   }
 
   .disclaimer-container {

--- a/app/component/itinerary.scss
+++ b/app/component/itinerary.scss
@@ -107,7 +107,7 @@ $itinerary-tab-switch-height: 48px;
 
   div {
     flex-grow: 1;
-    flex-shrink: 1;
+    flex-shrink: 0;
   }
 
   .disclaimer-container {
@@ -372,11 +372,13 @@ $itinerary-tab-switch-height: 48px;
         padding-top: $padding-medium;
       }
 
-      .ticket-identifier {
-        @include font-medium;
-        color: $black;
+      div {
+        flex-shrink: 1;
+        .ticket-identifier {
+          @include font-medium;
+          color: $black;
+        }
       }
-
       .ticket-type-agency-link {
         flex-grow: 0;
       }


### PR DESCRIPTION
## Proposed Changes

  - Agency_fare_url is now usable with long route names
  - https://digitransit.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=DT&modal=detail&selectedIssue=DT-3082

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
