### PR TITLE
DT-3086: use correct html format for a single pattern

### DIFF
--- a/app/component/RoutePatternSelect.js
+++ b/app/component/RoutePatternSelect.js
@@ -64,21 +64,22 @@ class RoutePatternSelect extends Component {
     }
 
     const options = sortBy(patterns, 'code').map(pattern => {
-      if (patterns.length > 2) {
+      if (patterns.length === 2) {
         return (
-          <option key={pattern.code} value={pattern.code}>
+          <div
+            key={pattern.code}
+            value={pattern.code}
+            className="route-option-togglable"
+          >
             {pattern.stops[0].name} ➔ {pattern.headsign}
-          </option>
+          </div>
         );
       }
+
       return (
-        <div
-          key={pattern.code}
-          value={pattern.code}
-          className="route-option-togglable"
-        >
+        <option key={pattern.code} value={pattern.code}>
           {pattern.stops[0].name} ➔ {pattern.headsign}
-        </div>
+        </option>
       );
     });
 

--- a/test/unit/component/RoutePatternSelect.test.js
+++ b/test/unit/component/RoutePatternSelect.test.js
@@ -156,4 +156,55 @@ describe('<RoutePatternSelect />', () => {
     });
     expect(wrapper.isEmptyRender()).to.equal(false);
   });
+
+  it('should not display a single pattern as a div inside a select element', () => {
+    const props = {
+      activeTab: 'pysakit',
+      gtfsId: 'LINKKI:9422',
+      onSelectChange: () => {},
+      params: {
+        patternId: 'LINKKI:9422:1:01',
+      },
+      relay: {
+        setVariables: () => {},
+      },
+      route: {
+        id: 'Um91dGU6TElOS0tJOjk0MjI=',
+        gtfsId: 'LINKKI:9422',
+        color: '00662B',
+        shortName: '42',
+        longName: 'JYVÄSKYLÄ-LIEVESTUORE',
+        mode: 'BUS',
+        type: 3,
+        agency: {
+          phone: null,
+          id: 'QWdlbmN5OjY3MTQ=',
+          name: 'Jyväskylän Liikenne Oy',
+          url: 'http://www.jyvaskylanliikenne.fi',
+          fareUrl: null,
+        },
+        patterns: [
+          {
+            headsign: 'LIEVESTUORE',
+            code: 'LINKKI:9422:1:01',
+            stops: [
+              {
+                name: 'Keskussairaala 1',
+              },
+              {
+                name: 'Liepeentie E',
+              },
+            ],
+            tripsForDate: [{}],
+          },
+        ],
+      },
+      serviceDay: '20190626',
+    };
+
+    const wrapper = shallowWithIntl(<RoutePatternSelect {...props} />, {
+      context: { ...mockContext },
+    });
+    expect(wrapper.find('select > div')).to.have.lengthOf(0);
+  });
 });


### PR DESCRIPTION
The purpose of this pull request is to enable rendering correct html content when there is just a single pattern available for selection.

Example route: https://jyvaskyla.digitransit.fi/linjat/LINKKI:9422/pysakit/LINKKI:9422:1:01

Related ticket: https://digitransit.atlassian.net/browse/DT-3086