### PR TITLE
DT-3085: Display origin icon on top of the user location icon when selecting own location as origin

### DIFF
--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -57,7 +57,7 @@ class MapWithTrackingStateHandler extends React.Component {
       lon: PropTypes.number.isRequired,
     }).isRequired,
     config: PropTypes.shape({
-      defaultMapCenter: dtLocationShape,
+      defaultM2Center: dtLocationShape,
       defaultEndpoint: dtLocationShape.isRequired,
       realTime: PropTypes.object.isRequired,
       feedIds: PropTypes.array.isRequired,
@@ -346,7 +346,7 @@ class MapWithTrackingStateHandler extends React.Component {
       );
     }
 
-    if (origin && origin.ready === true && origin.gps !== true) {
+    if (origin && origin.ready === true) {
       leafletObjs.push(
         <LazilyLoad modules={locationMarkerModules} key="from">
           {({ LocationMarker }) => (

--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -57,7 +57,7 @@ class MapWithTrackingStateHandler extends React.Component {
       lon: PropTypes.number.isRequired,
     }).isRequired,
     config: PropTypes.shape({
-      defaultM2Center: dtLocationShape,
+      defaultMapCenter: dtLocationShape,
       defaultEndpoint: dtLocationShape.isRequired,
       realTime: PropTypes.object.isRequired,
       feedIds: PropTypes.array.isRequired,


### PR DESCRIPTION
## Proposed Changes

  - JIRA Link: https://digitransit.atlassian.net/browse/DT-3085
   - Enabled location icon even when the user's origin point is the same as their location. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
