### PR TITLE
DT-2986: routing requests use now time query when using input fields

### DIFF
--- a/app/component/DTAutosuggestPanel.js
+++ b/app/component/DTAutosuggestPanel.js
@@ -11,6 +11,7 @@ import { isIe, isKeyboardSelectionEvent } from '../util/browser';
 import { navigateTo, PREFIX_ITINERARY_SUMMARY } from '../util/path';
 import { dtLocationShape } from '../util/shapes';
 import withBreakpoint from '../util/withBreakpoint';
+import { withCurrentTime } from '../util/searchUtils';
 
 export const getEmptyViaPointPlaceHolder = () => ({});
 
@@ -57,6 +58,7 @@ class DTAutosuggestPanel extends React.Component {
     router: routerShape.isRequired,
     location: locationShape.isRequired,
     intl: intlShape.isRequired,
+    getStore: PropTypes.func.isRequired,
   };
 
   static propTypes = {
@@ -265,6 +267,10 @@ class DTAutosuggestPanel extends React.Component {
     const { breakpoint, isItinerary, origin } = this.props;
     const { activeSlackInputs, isDraggingOverIndex, viaPoints } = this.state;
     const slackTime = this.getSlackTimeOptions();
+    const locationWithTime = withCurrentTime(
+      this.context.getStore,
+      this.context.location,
+    );
 
     const defaultSlackTimeValue = 0;
     const getViaPointSlackTimeOrDefault = (
@@ -319,7 +325,7 @@ class DTAutosuggestPanel extends React.Component {
               }
 
               navigateTo({
-                base: this.context.location,
+                base: locationWithTime,
                 origin: newOrigin,
                 destination,
                 context: this.props.isItinerary ? PREFIX_ITINERARY_SUMMARY : '',
@@ -480,7 +486,7 @@ class DTAutosuggestPanel extends React.Component {
                 }
 
                 navigateTo({
-                  base: this.context.location,
+                  base: locationWithTime,
                   origin: updatedOrigin,
                   destination,
                   context: isItinerary ? PREFIX_ITINERARY_SUMMARY : '',

--- a/app/component/OriginDestinationBar.js
+++ b/app/component/OriginDestinationBar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { intlShape } from 'react-intl';
 import { routerShape } from 'react-router';
-
+import { withCurrentTime } from '../util/searchUtils';
 import ComponentUsageExample from './ComponentUsageExample';
 import DTAutosuggestPanel from './DTAutosuggestPanel';
 import { PREFIX_ITINERARY_SUMMARY, navigateTo } from '../util/path';
@@ -29,6 +29,7 @@ class OriginDestinationBar extends React.Component {
   static contextTypes = {
     intl: intlShape.isRequired,
     router: routerShape.isRequired,
+    getStore: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -45,12 +46,13 @@ class OriginDestinationBar extends React.Component {
 
   swapEndpoints = () => {
     const { location } = this;
+    const locationWithTime = withCurrentTime(this.context.getStore, location);
     const intermediatePlaces = getIntermediatePlaces(location.query);
     if (intermediatePlaces.length > 1) {
       location.query.intermediatePlaces.reverse();
     }
     navigateTo({
-      base: location,
+      base: locationWithTime,
       origin: this.props.destination,
       destination: this.props.origin,
       context: PREFIX_ITINERARY_SUMMARY,

--- a/app/component/SummaryNavigation.js
+++ b/app/component/SummaryNavigation.js
@@ -91,7 +91,6 @@ class SummaryNavigation extends React.Component {
       action: 'ExtraSettingsPanelClick',
       name: newState ? 'ExtraSettingsPanelOpen' : 'ExtraSettingsPanelClose',
     });
-
     if (newState) {
       this.context.router.push({
         ...this.context.location,

--- a/app/component/map/MarkerPopupBottom.js
+++ b/app/component/map/MarkerPopupBottom.js
@@ -4,6 +4,7 @@ import get from 'lodash/get';
 import { routerShape, locationShape } from 'react-router';
 import { FormattedMessage } from 'react-intl';
 import { withLeaflet } from 'react-leaflet/es/context';
+import { withCurrentTime } from '../../util/searchUtils';
 
 import {
   PREFIX_ROUTES,
@@ -12,7 +13,6 @@ import {
   parseLocation,
   navigateTo,
 } from '../../util/path';
-import { withCurrentTime } from '../../util/searchUtils';
 import { dtLocationShape } from '../../util/shapes';
 
 class MarkerPopupBottom extends React.Component {


### PR DESCRIPTION
## Proposed Changes

  - Input fields' routing requests work now similarly as choosing origin or destination point from the map.
  - https://digitransit.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=DT&modal=detail&selectedIssue=DT-2986