### PR TITLE
Dt 3096: Add support providing a language parameter in searches

### DIFF
--- a/server/reittiopasParameterMiddleware.js
+++ b/server/reittiopasParameterMiddleware.js
@@ -57,8 +57,8 @@ export function validateParams(req, config) {
 
 export default function reittiopasParameterMiddleware(req, res, next) {
   const config = getConfiguration(req);
+  console.log(res);
   const newUrl = validateParams(req, config);
-
   if (newUrl) {
     res.redirect(newUrl);
   } else if (config.redirectReittiopasParams) {
@@ -71,6 +71,7 @@ export default function reittiopasParameterMiddleware(req, res, next) {
         path: '/',
       });
     }
+    const path = req.path;
     if (
       req.query.from ||
       req.query.to ||
@@ -79,9 +80,14 @@ export default function reittiopasParameterMiddleware(req, res, next) {
     ) {
       oldParamParser(req.query, config).then(url => res.redirect(url));
     } else if (
-      ['/fi/', '/en/', '/sv/', '/ru/', '/slangi/'].includes(req.path)
+      ['/fi/', '/en/', '/sv/', '/ru/'].some(lang => path.includes(lang))
     ) {
-      res.redirect('/');
+      const lang = path.substring(0,4);
+      const newPath = path.replace(lang, '/');
+      res.redirect(newPath);
+    } else if (path.includes('/slangi/')) {
+      const newPath = path.replace('/slangi/', '/');
+      res.redirect(newPath);
     } else {
       next();
     }

--- a/server/reittiopasParameterMiddleware.js
+++ b/server/reittiopasParameterMiddleware.js
@@ -55,9 +55,18 @@ export function validateParams(req, config) {
   return url;
 }
 
+export const langParamParser = path => {
+  if (path.includes('/slangi/')) {
+    const newPath = path.replace('/slangi/', '/');
+    return newPath;
+  }
+  const lang = path.substring(0, 4);
+  const newPath = path.replace(lang, '/');
+  return newPath;
+};
+
 export default function reittiopasParameterMiddleware(req, res, next) {
   const config = getConfiguration(req);
-  console.log(res);
   const newUrl = validateParams(req, config);
   if (newUrl) {
     res.redirect(newUrl);
@@ -71,7 +80,6 @@ export default function reittiopasParameterMiddleware(req, res, next) {
         path: '/',
       });
     }
-    const path = req.path;
     if (
       req.query.from ||
       req.query.to ||
@@ -80,14 +88,12 @@ export default function reittiopasParameterMiddleware(req, res, next) {
     ) {
       oldParamParser(req.query, config).then(url => res.redirect(url));
     } else if (
-      ['/fi/', '/en/', '/sv/', '/ru/'].some(lang => path.includes(lang))
+      ['/fi/', '/en/', '/sv/', '/ru/', '/slangi/'].some(param =>
+        req.path.includes(param),
+      )
     ) {
-      const lang = path.substring(0,4);
-      const newPath = path.replace(lang, '/');
-      res.redirect(newPath);
-    } else if (path.includes('/slangi/')) {
-      const newPath = path.replace('/slangi/', '/');
-      res.redirect(newPath);
+      const redirectPath = langParamParser(req.path);
+      res.redirect(redirectPath);
     } else {
       next();
     }

--- a/test/unit/reittiopasParameterMiddleware.test.js
+++ b/test/unit/reittiopasParameterMiddleware.test.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { validateParams } from '../../server/reittiopasParameterMiddleware';
+import {
+  validateParams,
+  langParamParser,
+} from '../../server/reittiopasParameterMiddleware';
 
 import config from '../../app/configurations/config.default';
 
@@ -39,6 +42,22 @@ describe('reittiopasParameterMiddleware', () => {
       req.query.modes = 'test1,test2';
       validateParams(req, config);
       expect(req.query.modes).to.be.an('undefined');
+    });
+  });
+  describe('langParamParser', () => {
+    it('should return empty path', () => {
+      const path = '/en/';
+      const newPath = langParamParser(path);
+      expect(newPath).to.equal('/');
+    });
+
+    it('should return path without language parameter', () => {
+      const path =
+        '/sv/reitti/Rautatientori%2C%20Helsinki%3A%3A60.171283%2C24.942572/Pasila%2C%20Helsinki%3A%3A60.199017%2C24.933973';
+      const newPath = langParamParser(path);
+      expect(newPath).to.equal(
+        '/reitti/Rautatientori%2C%20Helsinki%3A%3A60.171283%2C24.942572/Pasila%2C%20Helsinki%3A%3A60.199017%2C24.933973',
+      );
     });
   });
 });


### PR DESCRIPTION
## Proposed Changes

  - Added support providing a language parameter in searches, when url parameters are formed in 3rd party site (such as hsl.fi or My Helsinki)
  - Jira ticket: https://digitransit.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=DT&modal=detail&selectedIssue=DT-3096