### PR TITLE
DT-3060: Add Matkahuolto GTFS data to dev.digitransit.fi

### DIFF
--- a/app/component/map/ItineraryLine.js
+++ b/app/component/map/ItineraryLine.js
@@ -49,7 +49,6 @@ class ItineraryLine extends React.Component {
     }
 
     const objs = [];
-
     this.props.legs.forEach((leg, i) => {
       if (leg.mode === 'WAIT') {
         return;
@@ -82,17 +81,19 @@ class ItineraryLine extends React.Component {
           this.props.showIntermediateStops &&
           leg.intermediatePlaces != null
         ) {
-          leg.intermediatePlaces.forEach(place =>
-            objs.push(
-              <StopMarker
-                disableModeIcons
-                stop={place.stop}
-                key={`intermediate-${place.stop.gtfsId}`}
-                mode={modePlusClass}
-                thin
-              />,
-            ),
-          );
+          leg.intermediatePlaces
+            .filter(place => place.stop)
+            .forEach(place =>
+              objs.push(
+                <StopMarker
+                  disableModeIcons
+                  stop={place.stop}
+                  key={`intermediate-${place.stop.gtfsId}`}
+                  mode={modePlusClass}
+                  thin
+                />,
+              ),
+            );
         }
 
         if (leg.from.vertexType === 'BIKESHARE') {

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -38,7 +38,26 @@ export default {
 
   favicon: './app/configurations/images/hsl/icon_favicon-matkafi.svg',
 
-  feedIds: ['MATKA', 'HSL', 'tampere', 'LINKKI', 'lautta', 'OULU'],
+  feedIds: [
+    'MATKA',
+    'HSL',
+    'tampere',
+    'LINKKI',
+    'lautta',
+    'OULU',
+    'MatkahuoltoKainuu',
+    'MatkahuoltoSavo',
+    'MatkahuoltoKanta',
+    'MatkahuoltoKarjala',
+    'MatkahuoltoKeski',
+    'MatkahuoltoKyme',
+    'MatkahuoltoLappi',
+    'MatkahuoltoPohjanmaa',
+    'MatkahuoltoSatakunta',
+    'MatkahuoltoVakka',
+    'MatkahuoltoVantaa',
+    'MatkahuoltoVarsinais',
+  ],
 
   meta: {
     description: APP_DESCRIPTION,


### PR DESCRIPTION

## Proposed Changes

  - Added matkahuolto feed ids to matka config
  - Fixed issue where matkahuolto data crashed ui due to missing stop code in graphiql
  - https://digitransit.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=DT&selectedIssue=DT-3060
## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
