### PR TITLE
DT-3111: Pattern selector missing from stop page stops and disruptions tabs

### DIFF
--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -279,7 +279,6 @@ class RoutePage extends React.Component {
               route={route}
               onSelectChange={this.onPatternChange}
               gtfsId={route.gtfsId}
-              activeTab={activeTab}
               className={cx({ 'bp-large': breakpoint === 'large' })}
             />
           )}

--- a/app/component/RoutePatternSelect.js
+++ b/app/component/RoutePatternSelect.js
@@ -24,7 +24,6 @@ class RoutePatternSelect extends Component {
     route: PropTypes.object,
     onSelectChange: PropTypes.func.isRequired,
     serviceDay: PropTypes.string.isRequired,
-    activeTab: PropTypes.string.isRequired,
     relay: PropTypes.object.isRequired,
     gtfsId: PropTypes.string.isRequired,
   };
@@ -49,15 +48,10 @@ class RoutePatternSelect extends Component {
   };
 
   getOptions = () => {
-    const { activeTab, gtfsId, params, route } = this.props;
+    const { gtfsId, params, route } = this.props;
     const { router } = this.context;
 
-    const patterns =
-      activeTab === 'aikataulu'
-        ? route.patterns
-        : route.patterns.filter(
-            p => Array.isArray(p.tripsForDate) && p.tripsForDate.length > 0,
-          );
+    const { patterns } = route;
 
     if (patterns.length === 0) {
       return null;
@@ -96,14 +90,7 @@ class RoutePatternSelect extends Component {
     return this.state.loading === true ? (
       <div className={cx('route-pattern-select', this.props.className)} />
     ) : (
-      <div
-        className={cx('route-pattern-select', this.props.className, {
-          hidden:
-            this.props.route.patterns.find(
-              o => o.tripsForDate && o.tripsForDate.length > 0,
-            ) === undefined && this.props.activeTab !== 'aikataulu',
-        })}
-      >
+      <div className={cx('route-pattern-select', this.props.className)}>
         {options && (options.length > 2 || options.length === 1) ? (
           <React.Fragment>
             <Icon img="icon-icon_arrow-dropdown" />
@@ -163,7 +150,6 @@ class RoutePatternSelect extends Component {
 }
 
 const defaultProps = {
-  activeTab: 'pysakit',
   className: 'bp-large',
   serviceDay: '20190306',
   relay: {

--- a/test/unit/component/RoutePatternSelect.test.js
+++ b/test/unit/component/RoutePatternSelect.test.js
@@ -34,7 +34,7 @@ describe('<RoutePatternSelect />', () => {
     expect(wrapper.find('#select-route-pattern > option')).to.have.lengthOf(3);
   });
 
-  it('should render a toggle element with divs if there are only 2 patterns with trips', () => {
+  it('should render a toggle element with divs if there are no patterns with trips', () => {
     const props = {
       activeTab: 'pysakit',
       gtfsId: 'HSL:3002U',
@@ -51,13 +51,13 @@ describe('<RoutePatternSelect />', () => {
             code: 'HSL:3002U:0:01',
             headsign: 'Kauklahti',
             stops: [{ name: 'Helsinki' }, { name: 'Kauklahti' }],
-            tripsForDate: [{}],
+            tripsForDate: [],
           },
           {
             code: 'HSL:3002U:0:02',
             headsign: 'Kirkkonummi',
             stops: [{ name: 'Helsinki' }, { name: 'Kirkkonummi' }],
-            tripsForDate: [{}],
+            tripsForDate: [],
           },
           {
             code: 'HSL:3002U:0:03',
@@ -71,8 +71,8 @@ describe('<RoutePatternSelect />', () => {
     const wrapper = shallowWithIntl(<RoutePatternSelect {...props} />, {
       context: { ...mockContext },
     });
-    expect(wrapper.find('option')).to.have.lengthOf(0);
-    expect(wrapper.find('div.route-option-togglable')).to.have.lengthOf(1);
+    expect(wrapper.find('option')).to.have.lengthOf(3);
+    expect(wrapper.find('div.route-option-togglable')).to.have.lengthOf(0);
   });
 
   it('should redirect to the first existing pattern if there is no matching pattern available', () => {


### PR DESCRIPTION
  - Removed the part of code that hid the pattern selector on route page when there were no trips for the current date
  - https://digitransit.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=DT&modal=detail&selectedIssue=DT-3111 

## Proposed Changes

  -

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
