### PR TITLE
DT-3137: Clicking an external link on the disruption info doesn't redirect 

### DIFF
--- a/app/component/RouteAlertsRow.js
+++ b/app/component/RouteAlertsRow.js
@@ -90,6 +90,9 @@ export default function RouteAlertsRow(
         ))
       : [];
 
+  const checkedUrl =
+    url && (url.match(/^[a-zA-Z]+:\/\//) ? url : `http://${url}`);
+
   return (
     <div className={cx('route-alert-row', { expired })}>
       {(entityType === 'route' &&
@@ -134,7 +137,7 @@ export default function RouteAlertsRow(
                     <div className={entityMode}>{entityIdentifier}</div>
                   ))))}
             {url && (
-              <ExternalLink className="route-alert-url" href={url}>
+              <ExternalLink className="route-alert-url" href={checkedUrl}>
                 {intl.formatMessage({ id: 'extra-info' })}
               </ExternalLink>
             )}

--- a/test/unit/component/RouteAlertsRow.test.js
+++ b/test/unit/component/RouteAlertsRow.test.js
@@ -134,4 +134,13 @@ describe('<RouteAlertsRow />', () => {
       AlertSeverityLevelType.Warning,
     );
   });
+  it("should add the http prefix to the url if it's missing", () => {
+    const props = {
+      url: 'www.hsl.fi',
+    };
+    const wrapper = shallowWithIntl(<RouteAlertsRow {...props} />);
+    expect(wrapper.find('.route-alert-url').prop('href')).to.equal(
+      'http://www.hsl.fi',
+    );
+  });
 });


### PR DESCRIPTION
## Proposed Changes

  - Adds a http:// prefix to links that are lacking it to allow external linking

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
