### PR TITLE
DT-3143

### DIFF
--- a/app/util/fareUtils.js
+++ b/app/util/fareUtils.js
@@ -37,7 +37,12 @@ export const getFares = (fares, routes, config) => {
       .map(route => route.gtfsId),
   );
 
-  const unknownFares = ((Array.isArray(routes) && routes) || [])
+  const unknownTotalFare =
+    fares && fares[0] && fares[0].type === 'regular' && fares[0].cents === -1;
+  const unknownFares = (
+    (unknownTotalFare && Array.isArray(routes) && routes) ||
+    []
+  )
     .filter(route => !routesWithFares.includes(route.gtfsId))
     .map(route => ({
       agency: {

--- a/test/unit/util/fareUtils.test.js
+++ b/test/unit/util/fareUtils.test.js
@@ -218,5 +218,48 @@ describe('fareUtils', () => {
       expect(unknown.routeGtfsId).to.equal('FOO:1234');
       expect(unknown.routeName).to.equal('Merisataman lautta');
     });
+
+    it('should not suggest unknown tickets if the total fare is known', () => {
+      const fares = [
+        {
+          cents: 280,
+          components: [
+            {
+              cents: 280,
+              fareId: 'HSL:AB',
+              routes: [
+                {
+                  agency: {
+                    gtfsId: 'HSL:HSL',
+                  },
+                  gtfsId: 'HSL:1003',
+                },
+              ],
+            },
+          ],
+          type: 'regular',
+        },
+      ];
+      const routes = [
+        {
+          agency: {
+            gtfsId: 'HSL:HSL',
+          },
+          gtfsId: 'HSL:foo',
+          longName: 'route with a certain block id',
+        },
+        {
+          agency: {
+            gtfsId: 'HSL:HSL',
+          },
+          gtfsId: 'HSL:bar',
+          longName: 'this has the same block id',
+        },
+      ];
+
+      const result = getFares(fares, routes, defaultConfig);
+      expect(result).to.have.lengthOf(1);
+      expect(result.filter(fare => fare.isUnknown)).to.have.lengthOf(0);
+    });
   });
 });


### PR DESCRIPTION
UI no longer claims that an unknown ticket is needed if fare component routes and transit legs routes do not match. The total fare must be unknown before such logic is applied.