### PR TITLE
DT-3138: The amount of disruptions and service alerts in the tab doesn't match the list

### DIFF
--- a/app/component/AlertList.js
+++ b/app/component/AlertList.js
@@ -6,7 +6,7 @@ import { FormattedMessage } from 'react-intl';
 
 import ComponentUsageExample from './ComponentUsageExample';
 import RouteAlertsRow from './RouteAlertsRow';
-import { alertCompare, createUniqueAlertList } from '../util/alertUtils';
+import { createUniqueAlertList } from '../util/alertUtils';
 import { AlertSeverityLevelType } from '../constants';
 
 const AlertList = ({
@@ -35,47 +35,46 @@ const AlertList = ({
       </div>
     );
   }
+
   return (
     <div className={cx({ 'momentum-scroll': !disableScrolling })}>
       <div className="route-alerts-list">
-        {groupedAlerts
-          .sort(alertCompare)
-          .map(
-            (
-              {
-                description,
-                expired,
-                header,
-                route: { color, mode, shortName, routeGtfsId } = {},
-                severityLevel,
-                stop: { code, vehicleMode, stopGtfsId } = {},
-                url,
-                validityPeriod: { startTime, endTime },
-              },
-              i,
-            ) => (
-              <RouteAlertsRow
-                color={color ? `#${color}` : null}
-                currentTime={currentTime}
-                description={description}
-                endTime={endTime}
-                entityIdentifier={shortName || code}
-                entityMode={
-                  (mode && mode.toLowerCase()) ||
-                  (vehicleMode && vehicleMode.toLowerCase())
-                }
-                entityType={(shortName && 'route') || (code && 'stop')}
-                expired={expired}
-                header={header}
-                key={`alert-${shortName}-${severityLevel}-${i}`} // eslint-disable-line react/no-array-index-key
-                severityLevel={severityLevel}
-                startTime={startTime}
-                url={url}
-                gtfsIds={routeGtfsId || stopGtfsId}
-                showRouteNameLink={showRouteNameLink}
-              />
-            ),
-          )}
+        {groupedAlerts.map(
+          (
+            {
+              description,
+              expired,
+              header,
+              route: { color, mode, shortName, routeGtfsId } = {},
+              severityLevel,
+              stop: { code, vehicleMode, stopGtfsId } = {},
+              url,
+              validityPeriod: { startTime, endTime },
+            },
+            i,
+          ) => (
+            <RouteAlertsRow
+              color={color ? `#${color}` : null}
+              currentTime={currentTime}
+              description={description}
+              endTime={endTime}
+              entityIdentifier={shortName || code}
+              entityMode={
+                (mode && mode.toLowerCase()) ||
+                (vehicleMode && vehicleMode.toLowerCase())
+              }
+              entityType={(shortName && 'route') || (code && 'stop')}
+              expired={expired}
+              header={header}
+              key={`alert-${shortName}-${severityLevel}-${i}`} // eslint-disable-line react/no-array-index-key
+              severityLevel={severityLevel}
+              startTime={startTime}
+              url={url}
+              gtfsIds={routeGtfsId || stopGtfsId}
+              showRouteNameLink={showRouteNameLink}
+            />
+          ),
+        )}
       </div>
     </div>
   );

--- a/app/component/AlertList.js
+++ b/app/component/AlertList.js
@@ -1,51 +1,13 @@
 import cx from 'classnames';
 import connectToStores from 'fluxible-addons-react/connectToStores';
-import isEmpty from 'lodash/isEmpty';
-import groupBy from 'lodash/groupBy';
-import uniqBy from 'lodash/uniqBy';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import ComponentUsageExample from './ComponentUsageExample';
 import RouteAlertsRow from './RouteAlertsRow';
-import { isAlertValid } from '../util/alertUtils';
-import { routeNameCompare } from '../util/searchUtils';
+import { alertCompare, createUniqueAlertList } from '../util/alertUtils';
 import { AlertSeverityLevelType } from '../constants';
-
-/**
- * Compares the given alerts in order to sort them.
- *
- * @param {*} a the first alert to compare.
- * @param {*} b the second alert to compare.
- */
-export const alertCompare = (a, b) => {
-  // sort by expiration status
-  if (a.expired !== b.expired) {
-    return a.expired ? 1 : -1;
-  }
-
-  // sort by missing route information (for stop level alerts)
-  if (!a.route || !a.route.shortName) {
-    // sort by stop information if it exists
-    if (a.stop && b.stop) {
-      return `${a.stop.code}`.localeCompare(`${b.stop.code}`);
-    }
-    return -1;
-  }
-
-  // sort by route information
-  const routeOrder = routeNameCompare(a.route || {}, b.route || {});
-  if (routeOrder !== 0) {
-    return routeOrder;
-  }
-
-  // sort by alert validity period
-  return b.validityPeriod.startTime - a.validityPeriod.startTime;
-};
-
-const hasRoute = alert => alert && !isEmpty(alert.route);
-const hasStop = alert => alert && !isEmpty(alert.stop);
 
 const AlertList = ({
   cancelations,
@@ -55,50 +17,15 @@ const AlertList = ({
   serviceAlerts,
   showRouteNameLink,
 }) => {
-  const getRoute = alert => alert.route || {};
-  const getMode = alert => getRoute(alert).mode;
-  const getShortName = alert => getRoute(alert).shortName;
-  const getRouteGtfsId = alert => getRoute(alert).gtfsId;
+  const groupedAlerts =
+    createUniqueAlertList(
+      serviceAlerts,
+      cancelations,
+      currentTime,
+      showExpired,
+    ) || [];
 
-  const getStop = alert => alert.stop || {};
-  const getVehicleMode = alert => getStop(alert).vehicleMode;
-  const getCode = alert => getStop(alert).code;
-  const getStopGtfsId = alert => getStop(alert).gtfsId;
-
-  const getGroupKey = alert =>
-    `${alert.severityLevel}${(hasRoute(alert) && `route_${getMode(alert)}`) ||
-      (hasStop(alert) && `stop_${getVehicleMode(alert)}`)}${alert.header}${
-      alert.description
-    }`;
-  const getUniqueId = alert =>
-    `${getShortName(alert) || getCode(alert)}${getGroupKey(alert)}`;
-
-  const uniqueAlerts = uniqBy(
-    [
-      ...(Array.isArray(cancelations)
-        ? cancelations
-            .map(cancelation => ({
-              ...cancelation,
-              severityLevel: AlertSeverityLevelType.Warning,
-              expired: !isAlertValid(cancelation, currentTime, {
-                isFutureValid: true,
-              }),
-            }))
-            .filter(alert => (showExpired ? true : !alert.expired))
-        : []),
-      ...(Array.isArray(serviceAlerts)
-        ? serviceAlerts
-            .map(alert => ({
-              ...alert,
-              expired: !isAlertValid(alert, currentTime),
-            }))
-            .filter(alert => (showExpired ? true : !alert.expired))
-        : []),
-    ],
-    getUniqueId,
-  );
-
-  if (uniqueAlerts.length === 0) {
+  if (groupedAlerts.length === 0) {
     return (
       <div className="stop-no-alerts-container">
         <FormattedMessage
@@ -108,41 +35,6 @@ const AlertList = ({
       </div>
     );
   }
-
-  const alertGroups = groupBy(uniqueAlerts, getGroupKey);
-  const groupedAlerts = Object.keys(alertGroups).map(key => {
-    const alerts = alertGroups[key];
-    const alert = alerts[0];
-    return {
-      ...alert,
-      route:
-        (hasRoute(alert) && {
-          mode: getMode(alert),
-          routeGtfsId: alerts
-            .sort(alertCompare)
-            .map(getRouteGtfsId)
-            .join(','),
-          shortName: alerts
-            .sort(alertCompare)
-            .map(getShortName)
-            .join(', '),
-        }) ||
-        undefined,
-      stop:
-        (hasStop(alert) && {
-          stopGtfsId: alerts
-            .sort(alertCompare)
-            .map(getStopGtfsId)
-            .join(','),
-          code: alerts
-            .sort(alertCompare)
-            .map(getCode)
-            .join(', '),
-          vehicleMode: getVehicleMode(alert),
-        }) ||
-        undefined,
-    };
-  });
   return (
     <div className={cx({ 'momentum-scroll': !disableScrolling })}>
       <div className="route-alerts-list">

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -2,6 +2,8 @@ import find from 'lodash/find';
 import get from 'lodash/get';
 import isNumber from 'lodash/isNumber';
 import uniqBy from 'lodash/uniqBy';
+import isEmpty from 'lodash/isEmpty';
+import groupBy from 'lodash/groupBy';
 import PropTypes from 'prop-types';
 
 import {
@@ -9,6 +11,7 @@ import {
   AlertSeverityLevelType,
   AlertEffectType,
 } from '../constants';
+import { routeNameCompare } from './searchUtils';
 
 /**
  * Checks if the alert is for the given pattern.
@@ -568,6 +571,135 @@ export const getActiveLegAlertSeverityLevel = leg => {
     serviceAlerts,
     leg.startTime / 1000, // this field is in ms format
   );
+};
+
+/**
+ * Compares the given alerts in order to sort them.
+ *
+ * @param {*} a the first alert to compare.
+ * @param {*} b the second alert to compare.
+ */
+export const alertCompare = (a, b) => {
+  // sort by expiration status
+  if (a.expired !== b.expired) {
+    return a.expired ? 1 : -1;
+  }
+
+  // sort by missing route information (for stop level alerts)
+  if (!a.route || !a.route.shortName) {
+    // sort by stop information if it exists
+    if (a.stop && b.stop) {
+      return `${a.stop.code}`.localeCompare(`${b.stop.code}`);
+    }
+    return -1;
+  }
+
+  // sort by route information
+  const routeOrder = routeNameCompare(a.route || {}, b.route || {});
+  if (routeOrder !== 0) {
+    return routeOrder;
+  }
+
+  // sort by alert validity period
+  return b.validityPeriod.startTime - a.validityPeriod.startTime;
+};
+
+/**
+ * Creates a list of unique alerts grouped under one header
+ *@param {*} serviceAlerts The list of Service alerts to be mapped and filtered,
+  @param {*} cancelations The list of Cancelations to be mapped and filtered,
+  @param {*} currentTime The current time to check for alert validity,
+  @param {*} showExpired If the expired alerts need to be shown,
+ */
+export const createUniqueAlertList = (
+  serviceAlerts,
+  cancelations,
+  currentTime,
+  showExpired,
+) => {
+  const hasRoute = alert => alert && !isEmpty(alert.route);
+  const hasStop = alert => alert && !isEmpty(alert.stop);
+
+  const getRoute = alert => alert.route || {};
+  const getMode = alert => getRoute(alert).mode;
+  const getShortName = alert => getRoute(alert).shortName;
+  const getRouteGtfsId = alert => getRoute(alert).gtfsId;
+
+  const getStop = alert => alert.stop || {};
+  const getVehicleMode = alert => getStop(alert).vehicleMode;
+  const getCode = alert => getStop(alert).code;
+  const getStopGtfsId = alert => getStop(alert).gtfsId;
+
+  const getGroupKey = alert =>
+    `${alert.severityLevel}${(hasRoute(alert) && `route_${getMode(alert)}`) ||
+      (hasStop(alert) && `stop_${getVehicleMode(alert)}`)}${alert.header}${
+      alert.description
+    }`;
+  const getUniqueId = alert =>
+    `${getShortName(alert) || getCode(alert)}${getGroupKey(alert)}`;
+
+  const uniqueAlerts = uniqBy(
+    [
+      ...(Array.isArray(cancelations)
+        ? cancelations
+            .map(cancelation => ({
+              ...cancelation,
+              severityLevel: AlertSeverityLevelType.Warning,
+              expired: !isAlertValid(cancelation, currentTime, {
+                isFutureValid: true,
+              }),
+            }))
+            .filter(alert => (showExpired ? true : !alert.expired))
+        : []),
+      ...(Array.isArray(serviceAlerts)
+        ? serviceAlerts
+            .map(alert => ({
+              ...alert,
+              expired: !isAlertValid(alert, currentTime),
+            }))
+            .filter(alert => (showExpired ? true : !alert.expired))
+        : []),
+    ],
+    getUniqueId,
+  );
+
+  const alertGroups = groupBy(uniqueAlerts, getGroupKey);
+
+  const groupedAlerts = Object.keys(alertGroups).map(key => {
+    const alerts = alertGroups[key];
+    const alert = alerts[0];
+    return {
+      ...alert,
+      route:
+        (hasRoute(alert) && {
+          mode: getMode(alert),
+          routeGtfsId: alerts
+            .sort(alertCompare)
+            .map(getRouteGtfsId)
+            .join(','),
+          shortName: alerts
+            .sort(alertCompare)
+            .map(getShortName)
+            .join(', '),
+        }) ||
+        undefined,
+      stop:
+        (hasStop(alert) && {
+          stopGtfsId: alerts
+            .sort(alertCompare)
+            .map(getStopGtfsId)
+            .join(','),
+          code: alerts
+            .sort(alertCompare)
+            .map(getCode)
+            .join(', '),
+          vehicleMode: getVehicleMode(alert),
+        }) ||
+        undefined,
+    };
+  });
+
+  return groupedAlerts;
 };
 
 /**

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -699,7 +699,7 @@ export const createUniqueAlertList = (
     };
   });
 
-  return groupedAlerts;
+  return groupedAlerts.sort(alertCompare);
 };
 
 /**

--- a/test/unit/test-data/dt3138.js
+++ b/test/unit/test-data/dt3138.js
@@ -1,0 +1,488 @@
+export const disruptions = [
+  {
+    description:
+      'Linja 576 poikkeusreitillä Suokallionkuja - Katriinantie. Kesto: 19.8. klo 24 asti.',
+    header: 'Linja 576 poikkeusreitillä',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjQ1NzY=',
+      color: null,
+      mode: 'BUS',
+      shortName: '576',
+      gtfsId: 'HSL:4576',
+    },
+    severityLevel: 'WARNING',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/linja-576-poikkeusreitilla-17983',
+    validityPeriod: {
+      endTime: 1566247800,
+      startTime: 1566050160,
+    },
+  },
+  {
+    description:
+      'Linja 576 poikkeusreitillä Suokallionkuja - Katriinantie. Kesto: 19.8. klo 24 asti.',
+    header: 'Linja 576 poikkeusreitillä',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjQ1NzY=',
+      color: null,
+      mode: 'BUS',
+      shortName: '576',
+      gtfsId: 'HSL:4576',
+    },
+    severityLevel: 'WARNING',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/linja-576-poikkeusreitilla-17983',
+    validityPeriod: {
+      endTime: 1566247800,
+      startTime: 1566050160,
+    },
+  },
+];
+
+export const serviceAlerts = [
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDJB',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'A',
+      gtfsId: 'HSL:3002A',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+  {
+    description:
+      'Linja 232 poikkeusreitillä 22.7-31.8 rakennustyömaan vuoksi, pysäkkipari Dosentintie jää ajamatta. Info: hsl.fi',
+    header: 'Linja 232 poikkeusreitillä 22.7-31.8, Dosentintie jää ajamatta',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjIyMzI=',
+      color: null,
+      mode: 'BUS',
+      shortName: '232',
+      gtfsId: 'HSL:2232',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/kauniaisissa-linja-232-poikkeusreitilla-227-318-dosentintie-jaa-ajamatta',
+    validityPeriod: {
+      endTime: 1567283400,
+      startTime: 1563328800,
+    },
+  },
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDJQ',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'P',
+      gtfsId: 'HSL:3002P',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDJV',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'U',
+      gtfsId: 'HSL:3002U',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+  {
+    description:
+      'Lähibussin 802 reitti muuttuu Laajasalossa 12.8. alkaen - Hevossalmentien lenkkiä ei ajeta.',
+    header: 'Lähibussin 802 reitti muuttuu Laajasalossa 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjE4MDI=',
+      color: null,
+      mode: 'BUS',
+      shortName: '802',
+      gtfsId: 'HSL:1802',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/lahibussin-802-reitti-muuttuu-laajasalossa-128-alkaen-hevossalmentien',
+    validityPeriod: {
+      endTime: 1566246600,
+      startTime: 1564729920,
+    },
+  },
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDJZ',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'Y',
+      gtfsId: 'HSL:3002Y',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDFJ',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'I',
+      gtfsId: 'HSL:3001I',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+  {
+    description:
+      'Kämnerintien pysäkki H3358 poistuu käytöstä 19.8. alkaen kaivuutyön vuoksi. Info: hsl.fi',
+    header: 'Kämnerintien pysäkki H3358 poistuu käytöstä 19.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjEwNzlO',
+      color: null,
+      mode: 'BUS',
+      shortName: '79N',
+      gtfsId: 'HSL:1079N',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/lyhtytien-pysakki-h3493-seka-kamnerintien-pysakki-h3358-pois-kaytosta',
+    validityPeriod: {
+      endTime: 1566370800,
+      startTime: 1565863200,
+    },
+  },
+  {
+    description:
+      'Linja 90R on kokeilussa oleva automaattibussi, jonka käyttäminen on maksutonta. Lisätietoa: sohjoabaltic.eu ',
+    header: 'Robottibussi 90R koeliikenteessä',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjEwOTBS',
+      color: null,
+      mode: 'BUS',
+      shortName: '90R',
+      gtfsId: 'HSL:1090R',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'http://www.sohjoabaltic.eu/fi/2019/06/26/helsinki-vuosaari-aurinkolahti/',
+    validityPeriod: {
+      endTime: 1574427600,
+      startTime: 1558936500,
+    },
+  },
+  {
+    description:
+      'Runkolinjojen 500 ja 510 busseissa sisäänkäynti myös keskiovista – voimassa olevaa lippua ei tarvitse näyttää lukijaan. Info: hsl.fi',
+    header:
+      'Runkolinjojen 500 ja 510 busseissa sisäänkäynti mahdollista myös keskiovista',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjE1MDA=',
+      color: null,
+      mode: 'BUS',
+      shortName: '500',
+      gtfsId: 'HSL:1500',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/runkolinjoissa-500-ja-510-sisaankaynti-myos-keskiovista-runkolinjoissa',
+    validityPeriod: {
+      endTime: 1566765000,
+      startTime: 1565877960,
+    },
+  },
+  {
+    description:
+      'Bussit: 576. Koskee pysäkkejä: V4148 Mossaberget ja V4165 Katriinantie. Poikkeusreitti. Syy: Katu suljettu. Arvioitu kesto: 17.08. 16:40 - 19.08. 23:30. Paikka: Tikkurilantie',
+    header: 'Katu suljettu ',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjQ1NzY=',
+      color: null,
+      mode: 'BUS',
+      shortName: '576',
+      gtfsId: 'HSL:4576',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url: 'https://www.hsl.fi/',
+    validityPeriod: {
+      endTime: 1566246600,
+      startTime: 1566049200,
+    },
+  },
+  {
+    description:
+      'Bussilinja 212 ajaa Kasavuoren lenkkiä molempiin suuntiin Kauniaisissa 12.8 alkaen',
+    header:
+      'Bussilinja 212 ajaa Kasavuoren lenkkiä molempiin suuntiin Kauniaisissa 12.8 alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjIyMTI=',
+      color: null,
+      mode: 'BUS',
+      shortName: '212',
+      gtfsId: 'HSL:2212',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/bussilinja-212-ajaa-kasavuoren-lenkkia-molempiin-suuntiin-kauniaisissa-128',
+    validityPeriod: {
+      endTime: 1566247500,
+      startTime: 1564730880,
+    },
+  },
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDJM',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'L',
+      gtfsId: 'HSL:3002L',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+  {
+    description:
+      'Kämnerintien pysäkki H3358 poistuu käytöstä 19.8. alkaen kaivuutyön vuoksi. Info: hsl.fi',
+    header: 'Kämnerintien pysäkki H3358 poistuu käytöstä 19.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjEwNzk=',
+      color: null,
+      mode: 'BUS',
+      shortName: '79',
+      gtfsId: 'HSL:1079',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/lyhtytien-pysakki-h3493-seka-kamnerintien-pysakki-h3358-pois-kaytosta',
+    validityPeriod: {
+      endTime: 1566370800,
+      startTime: 1565863200,
+    },
+  },
+  {
+    description:
+      'Runkolinjojen 500 ja 510 busseissa sisäänkäynti myös keskiovista – voimassa olevaa lippua ei tarvitse näyttää lukijaan. Info: hsl.fi',
+    header:
+      'Runkolinjojen 500 ja 510 busseissa sisäänkäynti mahdollista myös keskiovista',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjI1MTA=',
+      color: null,
+      mode: 'BUS',
+      shortName: '510',
+      gtfsId: 'HSL:2510',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/runkolinjoissa-500-ja-510-sisaankaynti-myos-keskiovista-runkolinjoissa',
+    validityPeriod: {
+      endTime: 1566765000,
+      startTime: 1565877960,
+    },
+  },
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDJF',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'E',
+      gtfsId: 'HSL:3002E',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDFS',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'R',
+      gtfsId: 'HSL:3001R',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+  {
+    description:
+      'Linja 26R on kokeilussa oleva automaattibussi, jonka käyttäminen on maksutonta. ',
+    header: 'Robottibussi 26R koeliikenteessä',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjEwMjZS',
+      color: null,
+      mode: 'BUS',
+      shortName: '26R',
+      gtfsId: 'HSL:1026R',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url: 'https://www.helsinkirobobusline.fi/',
+    validityPeriod: {
+      endTime: 1574427600,
+      startTime: 1558936500,
+    },
+  },
+  {
+    description:
+      'Lähibussin 702 reittiin 12.8.2019 alkaen muutoksia Pukinmäessä ja Tapaninvainiossa',
+    header:
+      'Lähibussin 702 reittiin 12.8.2019 alkaen muutoksia Pukinmäessä ja Tapaninvainiossa',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjE3MDI=',
+      color: null,
+      mode: 'BUS',
+      shortName: '702',
+      gtfsId: 'HSL:1702',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/lahibussin-702-reittiin-1282019-alkaen-muutoksia-pukinmaessa-ja',
+    validityPeriod: {
+      endTime: 1566244800,
+      startTime: 1564729020,
+    },
+  },
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDFE',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'D',
+      gtfsId: 'HSL:3001D',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+  {
+    description:
+      'Runkolinja 550 ei aja Huopalahden asemalta - Eliel Saarisen tien tunneli suljetaan ajoneuvoliikenteeltä pikaraitiotien rakennustöiden takia. Info HSL.fi',
+    header:
+      'Runkolinja 550  12.8. poikkeusreitille Huopalahdessa A-vyöhykkeen kautta',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjI1NTA=',
+      color: null,
+      mode: 'BUS',
+      shortName: '550',
+      gtfsId: 'HSL:2550',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/runkolinja-550-seka-linjat-41-ja-552-siirtyvat-128-poikkeusreiteille',
+    validityPeriod: {
+      endTime: 1566592200,
+      startTime: 1564246020,
+    },
+  },
+  {
+    description:
+      'Laitureiden numerointi muuttuu Pasilan asemalla maanantaina 12.8.,laituri 5b muuttuu 6:ksi ja laituri 6:sta tulee 7 jne.  Muutos ei vaikuta junien käyttämiin raiteisiin eli junat lähtevät normaaleilta paikoiltaan myös 12.8. jälkeen. ',
+    header: 'Laiturinumerointi muuttuu Pasilan asemalla 12.8. alkaen',
+    route: {
+      __dataID__: 'Um91dGU6SFNMOjMwMDFa',
+      color: null,
+      mode: 'RAIL',
+      shortName: 'Z',
+      gtfsId: 'HSL:3001Z',
+    },
+    severityLevel: 'INFO',
+    stop: {},
+    url:
+      'https://www.hsl.fi/liikennetiedotteet/2019/laiturinumerointi-muuttuu-pasilan-asemalla-128-alkaen-17822',
+    validityPeriod: {
+      endTime: 1566333900,
+      startTime: 1564639440,
+    },
+  },
+];

--- a/test/unit/util/alertUtils.test.js
+++ b/test/unit/util/alertUtils.test.js
@@ -3,6 +3,7 @@ import {
   AlertSeverityLevelType,
   RealtimeStateType,
 } from '../../../app/constants';
+import { disruptions, serviceAlerts } from '../test-data/dt3138';
 import * as utils from '../../../app/util/alertUtils';
 
 describe('alertUtils', () => {
@@ -1272,6 +1273,20 @@ describe('alertUtils', () => {
       expect(utils.patternIdPredicate({ trip: undefined }, 'foobar')).to.equal(
         true,
       );
+    });
+  });
+  describe('createUniqueAlertList', () => {
+    it('should group disruptions under unique headers', () => {
+      expect(
+        utils.createUniqueAlertList(disruptions, false, 1566199501, true)
+          .length,
+      ).to.equal(1);
+    });
+    it('should group service alerts under unique headers', () => {
+      expect(
+        utils.createUniqueAlertList(serviceAlerts, false, 1566199501, true)
+          .length,
+      ).to.equal(11);
     });
   });
 });


### PR DESCRIPTION
## Proposed Changes

  - Fixed the amount of disruptions/service alerts to correspond to the amount of unique headers

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
