### PR TITLE
DT-3175: Show trip itineraries for the next XX days

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -315,7 +315,9 @@ class SummaryPage extends React.Component {
       latestArrivalTime = Math.max(...itineraries.map(i => i.endTime));
     }
 
+    // added itineraryFutureDays parameter (DT-3175)
     const serviceTimeRange = validateServiceTimeRange(
+      get(this.context, 'config.itineraryFutureDays'),
       this.props.serviceTimeRange,
     );
     if (this.props.breakpoint === 'large') {

--- a/app/configurations/config.tampere.js
+++ b/app/configurations/config.tampere.js
@@ -226,4 +226,7 @@ export default configMerger(walttiConfig, {
   timetables: {
     tampere: tampereTimetables,
   },
+
+  // Number of days to include to the service time range from the future (DT-3175)
+  itineraryFutureDays: 60,
 });

--- a/app/util/timeUtils.js
+++ b/app/util/timeUtils.js
@@ -42,9 +42,13 @@ export const sameDay = (x, y) => dateOrEmpty(x, y) === '';
 export const RANGE_PAST = 7;
 
 // added itineraryFutureDays parameter (DT-3175)
-export const validateServiceTimeRange = (itineraryFutureDays, serviceTimeRange, now) => {
+export const validateServiceTimeRange = (
+  itineraryFutureDays,
+  serviceTimeRange,
+  now,
+) => {
   const NOW = now ? moment.unix(now) : moment();
-  const RANGE_FUTURE = itineraryFutureDays ? itineraryFutureDays : 30;
+  const RANGE_FUTURE = !itineraryFutureDays ? 30 : itineraryFutureDays;
   const START = NOW.clone()
     .subtract(RANGE_PAST, 'd')
     .unix();

--- a/app/util/timeUtils.js
+++ b/app/util/timeUtils.js
@@ -41,13 +41,10 @@ export const sameDay = (x, y) => dateOrEmpty(x, y) === '';
  */
 export const RANGE_PAST = 7;
 
-/**
- * The default number of days to include to the service time range from the future.
- */
-export const RANGE_FUTURE = 30;
-
-export const validateServiceTimeRange = (serviceTimeRange, now) => {
+// added itineraryFutureDays parameter (DT-3175)
+export const validateServiceTimeRange = (itineraryFutureDays, serviceTimeRange, now) => {
   const NOW = now ? moment.unix(now) : moment();
+  const RANGE_FUTURE = itineraryFutureDays ? itineraryFutureDays : 30;
   const START = NOW.clone()
     .subtract(RANGE_PAST, 'd')
     .unix();

--- a/test/unit/util/timeUtils.test.js
+++ b/test/unit/util/timeUtils.test.js
@@ -20,7 +20,7 @@ describe('timeUtils', () => {
   describe('validateServiceTimeRange', () => {
     it('should return valid default time range from undefined input', () => {
       const range = null;
-      const futureDays = null; //DT-3175
+      const futureDays = null; // DT-3175
       test(validateServiceTimeRange(futureDays, range, now));
     });
 
@@ -29,7 +29,7 @@ describe('timeUtils', () => {
         start: now + 3600, // future
         end: now - 3600, // past
       };
-      const futureDays = null; //DT-3175
+      const futureDays = null; // DT-3175
       test(validateServiceTimeRange(futureDays, range, now));
     });
 
@@ -38,7 +38,7 @@ describe('timeUtils', () => {
         start: now - 3600 * 24, // yesterday
         end: now + 3600 * 24 * 7, // next week
       };
-      const futureDays = null; //DT-3175
+      const futureDays = null; // DT-3175
       const validated = validateServiceTimeRange(futureDays, range, now);
       test(validated);
       expect(moment.unix(validated.start).dayOfYear()).to.equal(
@@ -54,7 +54,7 @@ describe('timeUtils', () => {
         start: now - 3600 * 24 * 365 * 2, // 2 years in the past
         end: now + 3600 * 24 * 365 * 2,
       };
-      const RANGE_FUTURE = 30; //DT-3175
+      const RANGE_FUTURE = 30; // DT-3175
       const validated = validateServiceTimeRange(RANGE_FUTURE, range, now);
       test(validated);
       expect((validated.end - validated.start) / 1000 / 86400).to.be.at.most(

--- a/test/unit/util/timeUtils.test.js
+++ b/test/unit/util/timeUtils.test.js
@@ -3,7 +3,6 @@ import { describe, it } from 'mocha';
 import moment from 'moment';
 import {
   validateServiceTimeRange,
-  RANGE_FUTURE,
   RANGE_PAST,
 } from '../../../app/util/timeUtils';
 
@@ -21,7 +20,8 @@ describe('timeUtils', () => {
   describe('validateServiceTimeRange', () => {
     it('should return valid default time range from undefined input', () => {
       const range = null;
-      test(validateServiceTimeRange(range, now));
+      const futureDays = null; //DT-3175
+      test(validateServiceTimeRange(futureDays, range, now));
     });
 
     it('should fix invalid time range', () => {
@@ -29,7 +29,8 @@ describe('timeUtils', () => {
         start: now + 3600, // future
         end: now - 3600, // past
       };
-      test(validateServiceTimeRange(range, now));
+      const futureDays = null; //DT-3175
+      test(validateServiceTimeRange(futureDays, range, now));
     });
 
     it('should not change the days of a proper time range', () => {
@@ -37,7 +38,8 @@ describe('timeUtils', () => {
         start: now - 3600 * 24, // yesterday
         end: now + 3600 * 24 * 7, // next week
       };
-      const validated = validateServiceTimeRange(range, now);
+      const futureDays = null; //DT-3175
+      const validated = validateServiceTimeRange(futureDays, range, now);
       test(validated);
       expect(moment.unix(validated.start).dayOfYear()).to.equal(
         moment.unix(range.start).dayOfYear(),
@@ -52,7 +54,8 @@ describe('timeUtils', () => {
         start: now - 3600 * 24 * 365 * 2, // 2 years in the past
         end: now + 3600 * 24 * 365 * 2,
       };
-      const validated = validateServiceTimeRange(range, now);
+      const RANGE_FUTURE = 30; //DT-3175
+      const validated = validateServiceTimeRange(RANGE_FUTURE, range, now);
       test(validated);
       expect((validated.end - validated.start) / 1000 / 86400).to.be.at.most(
         RANGE_FUTURE + RANGE_PAST + 1,


### PR DESCRIPTION
## Proposed Changes

  - Tampere wants to show trip itineraries for the next 60 days. Other cities will use 30 days by default.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
