### PR TITLE
Only process vehicle position updates of hsl metro with seq value 1

### DIFF
--- a/app/util/mqttClient.js
+++ b/app/util/mqttClient.js
@@ -57,7 +57,12 @@ export function parseMessage(topic, message, agency) {
     parsedMessage = message.VP;
   }
 
-  if (parsedMessage && parsedMessage.lat && parsedMessage.long) {
+  if (
+    parsedMessage &&
+    parsedMessage.lat &&
+    parsedMessage.long &&
+    (parsedMessage.seq === undefined || parsedMessage.seq === 1) // seq is used for hsl metro carriage sequence
+  ) {
     return {
       id: vehid,
       route: `${agency}:${line}`,

--- a/test/unit/util/mqttClient.test.js
+++ b/test/unit/util/mqttClient.test.js
@@ -74,5 +74,33 @@ describe('mqttClient', () => {
       const message = parseMessage(metroTopic, testMessage, 'HSL');
       expect(message.mode).to.equal('subway');
     });
+
+    it('should return message when message.seq is 1', () => {
+      const metroTopic =
+        '/hfp/v2/journey/ongoing/vp/metro/0018/00296/1064/1/Itä-Pakila/16:12/1250101/5/60;24/29/04/85';
+      const seqOneMessage = {
+        VP: {
+          lat: 123.123456,
+          long: 123.123456,
+          seq: 1,
+        },
+      };
+      const message = parseMessage(metroTopic, seqOneMessage, 'HSL');
+      expect(message).to.not.equal(undefined);
+    });
+
+    it('should return undefined when message.seq is 2', () => {
+      const metroTopic =
+        '/hfp/v2/journey/ongoing/vp/metro/0018/00296/1064/1/Itä-Pakila/16:12/1250101/5/60;24/29/04/85';
+      const seqOneMessage = {
+        VP: {
+          lat: 123.123456,
+          long: 123.123456,
+          seq: 2,
+        },
+      };
+      const message = parseMessage(metroTopic, seqOneMessage, 'HSL');
+      expect(message).to.equal(undefined);
+    });
   });
 });


### PR DESCRIPTION
## Proposed Changes

  - Only display one location per hsl metro train instead of displaying one for each carriage

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
