### PR TITLE
DT-3287: Route pattern select shows two arrow indicators

### DIFF
--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -823,6 +823,10 @@ div.route-tabs {
   }
   #select-route-pattern {
     cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-image: none;
   }
 
   button.toggle-direction,


### PR DESCRIPTION
## Proposed Changes

  - Fix issue where route pattern selector showed two arrow indicators

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
