### PR TITLE
chore: New location for Matka.fi yleisviestipalvelu

### DIFF
--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -5,7 +5,7 @@ const APP_TITLE = 'Matka.fi';
 const YEAR = 1900 + new Date().getYear();
 const STATIC_MESSAGE_URL =
   process.env.STATIC_MESSAGE_URL ||
-  'https://beta.vayla.fi/joukkoliikenne/yleisviesti/';
+  'https://tyokalu.navici.com/yleisviestipalvelu/messages/';
 
 // route timetable data needs to be up-to-date before this is enabled
 // const HSLRouteTimetable = require('./timetableConfigUtils').default.HSLRoutes;


### PR DESCRIPTION
## Proposed Changes

  - Services at beta.vayla.fi are moving to tyokalu.navici.com. It means that Matka.fi needs new config for yleisviestipalvelu.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
