### PR TITLE
fix: use bus as fallback mode if the message mode is non-standard

### DIFF
--- a/app/util/mqttClient.js
+++ b/app/util/mqttClient.js
@@ -2,9 +2,20 @@ import ceil from 'lodash/ceil';
 import moment from 'moment';
 import { parseFeedMQTT } from './gtfsRtParser';
 
-const modeTranslate = {
-  train: 'rail',
-  metro: 'subway',
+const standardModes = ['bus', 'tram', 'ferry'];
+
+const getMode = mode => {
+  if (standardModes.includes(mode)) {
+    return mode;
+  }
+  if (mode === 'train') {
+    return 'rail';
+  }
+  if (mode === 'metro') {
+    return 'subway';
+  }
+  // bus mode should be used as fallback if mode is not one of the standard modes
+  return 'bus';
 };
 
 // getTopic
@@ -73,7 +84,7 @@ export function parseMessage(topic, message, agency) {
         parsedMessage.oday && parsedMessage.oday !== 'XXX'
           ? parsedMessage.oday
           : moment().format('YYYY-MM-DD'),
-      mode: modeTranslate[mode] ? modeTranslate[mode] : mode,
+      mode: getMode(mode),
       next_stop: `${agency}:${nextStop}`,
       timestamp: parsedMessage.tsi,
       lat: ceil(parsedMessage.lat, 5),

--- a/test/unit/util/mqttClient.test.js
+++ b/test/unit/util/mqttClient.test.js
@@ -75,6 +75,13 @@ describe('mqttClient', () => {
       expect(message.mode).to.equal('subway');
     });
 
+    it('translates ubus -> bus', () => {
+      const ubusTopic =
+        '/hfp/v2/journey/ongoing/vp/ubus/0018/00296/1064/1/Itä-Pakila/16:12/1250101/5/60;24/29/04/85';
+      const message = parseMessage(ubusTopic, testMessage, 'HSL');
+      expect(message.mode).to.equal('bus');
+    });
+
     it('should return message when message.seq is 1', () => {
       const metroTopic =
         '/hfp/v2/journey/ongoing/vp/metro/0018/00296/1064/1/Itä-Pakila/16:12/1250101/5/60;24/29/04/85';


### PR DESCRIPTION
## Proposed Changes

  - Adds fallback mode when HFP message has non-standard mode

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
