### PR TITLE
DT-3387: vehicleMode stop field from OTP should not be used in UI

### DIFF
--- a/app/component/StopPageTabContainer.js
+++ b/app/component/StopPageTabContainer.js
@@ -77,8 +77,11 @@ function StopPageTabContainer(
     );
   const stopRoutesWithAlerts = [];
 
+  const modesByRoute = []; // DT-3387
+
   if (stop.routes && stop.routes.length > 0) {
     stop.routes.forEach(route => {
+      modesByRoute.push(stop.routes.mode); // DT-3387
       const patternId = route.patterns.code;
       const hasActiveRouteAlert = isAlertActive(
         getCancelationsForRoute(route, patternId),
@@ -114,6 +117,10 @@ function StopPageTabContainer(
           alert.alertSeverityLevel === AlertSeverityLevelType.Warning,
       )) &&
       'active-service-alert');
+
+  const uniqModesByRoutes = Array.from(new Set(modesByRoute)); // DT-3387
+  const modeByRoutesOrStop =
+    uniqModesByRoutes.length === 1 ? uniqModesByRoutes[0] : stop.vehicleMode; // DT-3387
 
   return (
     <div className="stop-page-content-wrapper">
@@ -186,12 +193,14 @@ function StopPageTabContainer(
               <div>
                 <FormattedMessage
                   id={
-                    stop.vehicleMode === 'RAIL' || stop.vehicleMode === 'SUBWAY'
+                    modeByRoutesOrStop === 'RAIL' ||
+                    modeByRoutesOrStop === 'SUBWAY'
                       ? 'routes-tracks'
                       : 'routes-platforms'
                   }
                   defaultMessage={
-                    stop.vehicleMode === 'RAIL' || stop.vehicleMode === 'SUBWAY'
+                    modeByRoutesOrStop === 'RAIL' ||
+                    modeByRoutesOrStop === 'SUBWAY'
                       ? 'routes-tracks'
                       : 'routes-platforms'
                   }

--- a/app/component/StopPageTabContainer.js
+++ b/app/component/StopPageTabContainer.js
@@ -81,7 +81,7 @@ function StopPageTabContainer(
 
   if (stop.routes && stop.routes.length > 0) {
     stop.routes.forEach(route => {
-      modesByRoute.push(stop.routes.mode); // DT-3387
+      modesByRoute.push(route.mode); // DT-3387
       const patternId = route.patterns.code;
       const hasActiveRouteAlert = isAlertActive(
         getCancelationsForRoute(route, patternId),

--- a/test/unit/component/StopPageTabContainer.test.js
+++ b/test/unit/component/StopPageTabContainer.test.js
@@ -328,6 +328,11 @@ it('should render "Routes, platforms" when vehicleMode is rail or subway but rou
       routes: [
         {
           mode: 'BUS',
+          patterns: [
+            {
+              code: 'HSL:9665A:0:02',
+            },
+          ],
         },
       ],
     },

--- a/test/unit/component/StopPageTabContainer.test.js
+++ b/test/unit/component/StopPageTabContainer.test.js
@@ -311,3 +311,32 @@ describe('<StopPageTabContainer />', () => {
     ).to.equal('routes-platforms');
   });
 });
+
+// DT-3387
+it('should render "Routes, platforms" when vehicleMode is rail or subway but route´s mode is bus', () => {
+  const props = {
+    breakpoint: 'large',
+    children: <div />,
+    location: {
+      pathname: 'foobar',
+    },
+    params: {
+      stopId: 'HSL:2211275',
+    },
+    routes: [],
+    stop: {
+      routes: [
+        {
+          mode: 'BUS',
+        },
+      ],
+    },
+  };
+  const wrapper = shallowWithIntl(<StopPageTabContainer {...props} />);
+  expect(
+    wrapper
+      .find(FormattedMessage)
+      .at(2)
+      .props().id,
+  ).to.equal('routes-platforms');
+});

--- a/test/unit/component/StopPageTabContainer.test.js
+++ b/test/unit/component/StopPageTabContainer.test.js
@@ -313,7 +313,7 @@ describe('<StopPageTabContainer />', () => {
 });
 
 // DT-3387
-it('should render "Routes, platforms" when vehicleMode is rail or subway but route´s mode is bus', () => {
+it('should render "Routes, platforms" when vehicleMode is rail but route´s mode is bus', () => {
   const props = {
     breakpoint: 'large',
     children: <div />,
@@ -325,6 +325,41 @@ it('should render "Routes, platforms" when vehicleMode is rail or subway but rou
     },
     routes: [],
     stop: {
+      vehicleMode: 'RAIL',
+      routes: [
+        {
+          mode: 'BUS',
+          patterns: [
+            {
+              code: 'HSL:9665A:0:02',
+            },
+          ],
+        },
+      ],
+    },
+  };
+  const wrapper = shallowWithIntl(<StopPageTabContainer {...props} />);
+  expect(
+    wrapper
+      .find(FormattedMessage)
+      .at(2)
+      .props().id,
+  ).to.equal('routes-platforms');
+});
+
+it('should render "Routes, platforms" when vehicleMode is subway but route´s mode is bus', () => {
+  const props = {
+    breakpoint: 'large',
+    children: <div />,
+    location: {
+      pathname: 'foobar',
+    },
+    params: {
+      stopId: 'HSL:2211275',
+    },
+    routes: [],
+    stop: {
+      vehicleMode: 'SUBWAY',
       routes: [
         {
           mode: 'BUS',


### PR DESCRIPTION
## Proposed Changes

  - Fixing tab text by using routes' mode instead of stop's vehicleMode. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
