### PR TITLE
DT-3387: vehicleMode stop field from OTP should not be used in UI

### DIFF
--- a/app/component/StopPageTabs.js
+++ b/app/component/StopPageTabs.js
@@ -74,7 +74,10 @@ function StopPageTabs({ breakpoint, stop }, { intl, match }) {
     );
   const stopRoutesWithAlerts = [];
 
+  const modesByRoute = []; // DT-3387
+
   if (stop.routes && stop.routes.length > 0) {
+    modesByRoute.push(stop.routes.mode); // DT-3387
     stop.routes.forEach(route => {
       const patternId = route.patterns.code;
       const hasActiveRouteAlert = isAlertActive(
@@ -111,6 +114,10 @@ function StopPageTabs({ breakpoint, stop }, { intl, match }) {
           alert.alertSeverityLevel === AlertSeverityLevelType.Warning,
       )) &&
       'active-service-alert');
+
+  const uniqModesByRoutes = Array.from(new Set(modesByRoute)); // DT-3387
+  const modeByRoutesOrStop =
+    uniqModesByRoutes.length === 1 ? uniqModesByRoutes[0] : stop.vehicleMode; // DT-3387
 
   return (
     <div>
@@ -179,12 +186,14 @@ function StopPageTabs({ breakpoint, stop }, { intl, match }) {
             <div>
               <FormattedMessage
                 id={
-                  stop.vehicleMode === 'RAIL' || stop.vehicleMode === 'SUBWAY'
+                  modeByRoutesOrStop === 'RAIL' ||
+                  modeByRoutesOrStop === 'SUBWAY'
                     ? 'routes-tracks'
                     : 'routes-platforms'
                 }
                 defaultMessage={
-                  stop.vehicleMode === 'RAIL' || stop.vehicleMode === 'SUBWAY'
+                  modeByRoutesOrStop === 'RAIL' ||
+                  modeByRoutesOrStop === 'SUBWAY'
                     ? 'routes-tracks'
                     : 'routes-platforms'
                 }

--- a/app/component/StopPageTabs.js
+++ b/app/component/StopPageTabs.js
@@ -77,8 +77,8 @@ function StopPageTabs({ breakpoint, stop }, { intl, match }) {
   const modesByRoute = []; // DT-3387
 
   if (stop.routes && stop.routes.length > 0) {
-    modesByRoute.push(stop.routes.mode); // DT-3387
     stop.routes.forEach(route => {
+      modesByRoute.push(route.mode); // DT-3387
       const patternId = route.patterns.code;
       const hasActiveRouteAlert = isAlertActive(
         getCancelationsForRoute(route, patternId),

--- a/test/unit/component/StopPageTabs.test.js
+++ b/test/unit/component/StopPageTabs.test.js
@@ -270,3 +270,64 @@ describe('<StopPageTabs />', () => {
     ).to.equal('routes-platforms');
   });
 });
+
+// DT-3387
+it('should render "Routes, platforms" when vehicleMode is rail but route´s mode is bus', () => {
+  const props = {
+    breakpoint: 'large',
+    children: <div />,
+    routes: [],
+    stop: {
+      vehicleMode: 'RAIL',
+      routes: [
+        {
+          mode: 'BUS',
+          patterns: [
+            {
+              code: 'HSL:9665A:0:02',
+            },
+          ],
+        },
+      ],
+    },
+  };
+  const wrapper = shallowWithIntl(<StopPageTabs {...props} />, {
+    context,
+  });
+  expect(
+    wrapper
+      .find(FormattedMessage)
+      .at(2)
+      .props().id,
+  ).to.equal('routes-platforms');
+});
+
+it('should render "Routes, platforms" when vehicleMode is subway but route´s mode is bus', () => {
+  const props = {
+    breakpoint: 'large',
+    children: <div />,
+    routes: [],
+    stop: {
+      vehicleMode: 'SUBWAY',
+      routes: [
+        {
+          mode: 'BUS',
+          patterns: [
+            {
+              code: 'HSL:9665A:0:02',
+            },
+          ],
+        },
+      ],
+    },
+  };
+  const wrapper = shallowWithIntl(<StopPageTabs {...props} />, {
+    context,
+  });
+  expect(
+    wrapper
+      .find(FormattedMessage)
+      .at(2)
+      .props().id,
+  ).to.equal('routes-platforms');
+});


### PR DESCRIPTION
## Proposed Changes

  - Fixing tab text by using routes' mode instead of stop's vehicleMode.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
