### PR TITLE
fix: return 404 for missing js, css and asset paths that contain /

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -258,9 +258,9 @@ export default config => {
           }
         />
       )}
-      <Route path="/js/:name" Component={Error404} />
-      <Route path="/css/:name" Component={Error404} />
-      <Route path="/assets/:name" Component={Error404} />
+      <Route path="/js/*" Component={Error404} />
+      <Route path="/css/*" Component={Error404} />
+      <Route path="/assets/*" Component={Error404} />
       <Route path="/:from?/:to?" topBarOptions={{ disableBackButton: true }}>
         {{
           title: (


### PR DESCRIPTION
## Proposed Changes

  - Ensures that 404 is returned for missing files from /js/, /css/ and /assets/ subdirectories instead of just for the missing files from those root paths.
    - This problem did not affect the new version of routes but could have potentially caused issues in the future if queries were caught by some other path than the general 404 path.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
