### PR TITLE
fix: exit server if availableTickets can't be fetched with BASE_CONFIG

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -354,20 +354,27 @@ function setUpAvailableTickets() {
         },
         err => {
           console.log(err);
-          // If after 5 tries no available ticketTypes are found, start server anyway
-          resolve();
-          console.log('failed to load availableTickets at launch, retrying');
-          // Continue attempts to fetch available ticketTypes in the background for one day once every minute
-          retryFetch(`${config.URL.OTP}index/graphql`, options, 1440, 60000)
-            .then(res => res.json())
-            .then(
-              result => {
-                processTicketTypeResult(result);
-              },
-              error => {
-                console.log(error);
-              },
-            );
+          if (process.env.BASE_CONFIG) {
+            // Patching of availableTickets into cached configs would not work with BASE_CONFIG
+            // if availableTickets are fetched after launch
+            console.log('failed to load availableTickets at launch, exiting');
+            process.exit(1);
+          } else {
+            // If after 5 tries no available ticketTypes are found, start server anyway
+            resolve();
+            console.log('failed to load availableTickets at launch, retrying');
+            // Continue attempts to fetch available ticketTypes in the background for one day once every minute
+            retryFetch(`${config.URL.OTP}index/graphql`, options, 1440, 60000)
+              .then(res => res.json())
+              .then(
+                result => {
+                  processTicketTypeResult(result);
+                },
+                error => {
+                  console.log(error);
+                },
+              );
+          }
         },
       );
   });


### PR DESCRIPTION
## Proposed Changes

  - There was a potential risk that when BASE_CONFIG env was used that OTP would be unresponsive at launch and when tickets are refetched after launch, they would not be patched into CONFIGs that were already cached

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
