### PR TITLE
Add opportunity to disable "next" column in Route panel

### DIFF
--- a/app/component/PatternStopsContainer.js
+++ b/app/component/PatternStopsContainer.js
@@ -25,6 +25,7 @@ class PatternStopsContainer extends React.PureComponent {
 
   static contextTypes = {
     router: routerShape.isRequired,
+    config: PropTypes.object.isRequired,
   };
 
   toggleFullscreenMap = () => {
@@ -51,6 +52,7 @@ class PatternStopsContainer extends React.PureComponent {
       <div className="route-page-content">
         <RouteListHeader
           key="header"
+          displayNextDeparture={this.context.config.displayNextDeparture}
           className={`bp-${this.props.breakpoint}`}
         />
         <RouteStopListContainer

--- a/app/component/RouteListHeader.js
+++ b/app/component/RouteListHeader.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import cx from 'classnames';
 
-const RouteListHeader = ({ className }) => (
+const RouteListHeader = ({ displayNextDeparture, className }) => (
   <div
     className={cx(
       'route-list-header route-stop row padding-vertical-small',
@@ -19,14 +19,23 @@ const RouteListHeader = ({ className }) => (
     <div className="route-stop-time">
       <FormattedMessage id="leaves" defaultMessage="Leaves" />
     </div>
-    <div className="route-stop-time">
-      <FormattedMessage id="next" defaultMessage="Next" />
-    </div>
+    {displayNextDeparture ? (
+      <div className="route-stop-time">
+        <FormattedMessage id="next" defaultMessage="Next" />
+      </div>
+    ) : (
+      ''
+    )}
   </div>
 );
 
 RouteListHeader.propTypes = {
   className: PropTypes.string,
+  displayNextDeparture: PropTypes.bool,
+};
+
+RouteListHeader.defaultProps = {
+  displayNextDeparture: true,
 };
 
 export default RouteListHeader;

--- a/app/component/RouteStop.js
+++ b/app/component/RouteStop.js
@@ -55,6 +55,11 @@ class RouteStop extends React.PureComponent {
     currentTime: PropTypes.number.isRequired,
     first: PropTypes.bool,
     last: PropTypes.bool,
+    displayNextDeparture: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    displayNextDeparture: true,
   };
 
   static description = () => (
@@ -133,6 +138,7 @@ class RouteStop extends React.PureComponent {
       mode,
       stop,
       vehicle,
+      displayNextDeparture,
     } = this.props;
     const patternExists =
       stop.stopTimesForPattern && stop.stopTimesForPattern.length > 0;
@@ -239,14 +245,23 @@ class RouteStop extends React.PureComponent {
             </div>
             {patternExists && (
               <div className="departure-times-container">
-                {stop.stopTimesForPattern.map(stopTime => (
+                {displayNextDeparture ? (
+                  stop.stopTimesForPattern.map(stopTime => (
+                    <div
+                      key={stopTime.scheduledDeparture}
+                      className="route-stop-time"
+                    >
+                      {fromStopTime(stopTime, currentTime)}
+                    </div>
+                  ))
+                ) : (
                   <div
-                    key={stopTime.scheduledDeparture}
+                    key={stop.stopTimesForPattern[0].scheduledDeparture}
                     className="route-stop-time"
                   >
-                    {fromStopTime(stopTime, currentTime)}
+                    {fromStopTime(stop.stopTimesForPattern[0], currentTime)}
                   </div>
-                ))}
+                )}
               </div>
             )}
           </Link>

--- a/app/component/RouteStopListContainer.js
+++ b/app/component/RouteStopListContainer.js
@@ -90,6 +90,7 @@ class RouteStopListContainer extends React.PureComponent {
           last={i === stops.length - 1}
           first={i === 0}
           className={rowClassName}
+          displayNextDeparture={this.context.config.displayNextDeparture}
         />
       );
     });

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -171,6 +171,9 @@ export default {
     'Europe/Helsinki|EET EEST|-20 -30|01010101010101010101010|1BWp0 1qM0 WM0 1qM0 ' +
     'WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00|35e5',
 
+  /* Option to disable the "next" column of the Route panel as it can be confusing sometimes: https://github.com/mfdz/digitransit-ui/issues/167 */
+  displayNextDeparture: true,
+
   mainMenu: {
     // Whether to show the left menu toggle button at all
     show: true,


### PR DESCRIPTION
## Proposed Changes
Based on MFDZ issue [#167](https://github.com/mfdz/digitransit-ui/issues/167): in our region there are small differences between routes which are handled as totally different ones, and so next departure is set to the next day (which is not true).
- added new config variable `displayNextDeparture` to config.default.js with the value `true`
- modified corresponding components of the Route panel in order to make show / display the "Next" column
- If true:
![Screenshot_2020-05-05_11-13-54](https://user-images.githubusercontent.com/46535522/81053592-9c49b880-8ec5-11ea-9781-0a1871f76817.png)
- If false:
![Screenshot_2020-05-05_11-13-09](https://user-images.githubusercontent.com/46535522/81053591-9bb12200-8ec5-11ea-8a82-45d2b69ac1bc.png)

We were a bit unsure about the config key - what do you think, should it be a subkey of something or would you prefer another name?

## Pull Request Check List
  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request