### PR TITLE
fix: handle uncaught relay parsing error globally

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -371,7 +371,7 @@ export default function(req, res, next) {
       .catch(err => {
         // eslint-disable-next-line no-console
         console.log(err);
-        return ['', undefined];
+        return ['There was an error fetching your data.', undefined];
       });
 
     const [[content, relayData]] = await Promise.all([

--- a/server/server.js
+++ b/server/server.js
@@ -33,6 +33,16 @@ if (process.env.NODE_ENV === 'production' && process.env.SENTRY_SECRET_DSN) {
   });
 }
 
+process.on('uncaughtException', error => {
+  // perhaps this is a little too careful but i want to make sure that things like out of memory errors
+  // are still crashing the process as there is no point in trying to recover from these.
+  if (error.name === 'RRNLRequestError') {
+    console.log('Unhandled Error', error);
+  } else {
+    throw error;
+  }
+});
+
 /* ********* Server ********* */
 const express = require('express');
 const expressStaticGzip = require('express-static-gzip');


### PR DESCRIPTION
## Proposed Changes

When relay 1.6.0 encounters a GraphQL parsing error it doesn't seem to return a failed promise or at least a synchronous exception but it schedules an exception to be thrown later: https://github.com/facebook/relay/blob/v1.6.0/packages/react-relay/classic/util/throwFailedPromise.js

For example, you can provoke a parsing error by setting the triangle factors of the bike routing in the URL to add up to more than 1.0.

When the page is rendered with `react-isomorphic-relay-router` then this leads to a server crash as the exception is thrown completely outside the ordinary request/response cycle and there is no handler for it.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
