### PR TITLE
Feat: toggle next departure column in Near you panel

### DIFF
--- a/app/component/DepartureRowContainer.js
+++ b/app/component/DepartureRowContainer.js
@@ -18,7 +18,10 @@ import {
 import { isCallAgencyDeparture } from '../util/legUtils';
 import { PREFIX_ROUTES, PREFIX_STOPS } from '../util/path';
 
-const DepartureRow = ({ departure, currentTime, distance }, context) => {
+const DepartureRow = (
+  { departure, currentTime, distance, displayNextDeparture },
+  context,
+) => {
   let departureTimes;
   let stopAlerts = [];
   let headsign;
@@ -55,18 +58,24 @@ const DepartureRow = ({ departure, currentTime, distance }, context) => {
     departure.pattern.route.gtfsId
   }/${PREFIX_STOPS}/${departure.pattern.code}?sort=no`;
 
+  // In case displayNextDeparture is false, only show one departure.
   // In case there's only one departure for the route,
   // add a dummy cell to keep the table layout from breaking
-  const departureTimesChecked =
-    departureTimes.length < 2
-      ? [
+  const departureTimesChecked = () => {
+    if (displayNextDeparture) {
+      if (departureTimes.length < 2) {
+        return [
           departureTimes[0],
           <td
             key={`${departureTimes[0].key}-empty`}
             className="td-departure-times"
           />,
-        ]
-      : departureTimes;
+        ];
+      }
+      return departureTimes;
+    }
+    return [departureTimes[0]];
+  };
 
   const hasActiveAlert = isAlertActive(
     departure.stoptimes.filter(stoptimeHasCancelation),
@@ -105,7 +114,7 @@ const DepartureRow = ({ departure, currentTime, distance }, context) => {
           }
         />
       </td>
-      {departureTimesChecked}
+      {departureTimesChecked()}
     </tr>
   );
 };
@@ -116,6 +125,11 @@ DepartureRow.propTypes = {
   departure: PropTypes.object.isRequired,
   distance: PropTypes.number.isRequired,
   currentTime: PropTypes.number.isRequired,
+  displayNextDeparture: PropTypes.bool,
+};
+
+DepartureRow.defaultProps = {
+  displayNextDeparture: true,
 };
 
 DepartureRow.contextTypes = {

--- a/app/component/NearbyDeparturesList.js
+++ b/app/component/NearbyDeparturesList.js
@@ -38,6 +38,7 @@ const constructPlacesList = values => {
           departure={o.node.place}
           currentTime={values.currentTime}
           timeRange={values.timeRange}
+          displayNextDeparture={values.displayNextDeparture}
         />
       );
     } else if (o.node.place.__typename === 'BikeRentalStation') {
@@ -55,37 +56,46 @@ const constructPlacesList = values => {
   return sortedList;
 };
 
-const PlaceAtDistanceList = ({
-  nearest: { places },
-  currentTime,
-  timeRange,
-}) => {
+const PlaceAtDistanceList = (
+  { nearest: { places }, currentTime, timeRange },
+  context,
+) => {
+  const { displayNextDeparture } = context.config;
+  const headers = [
+    {
+      id: 'to-stop',
+      defaultMessage: 'To Stop',
+    },
+    {
+      id: 'route',
+      defaultMessage: 'Route',
+    },
+    {
+      id: 'destination',
+      defaultMessage: 'Destination',
+    },
+    {
+      id: 'leaves',
+      defaultMessage: 'Leaves',
+    },
+  ];
+  if (displayNextDeparture) {
+    headers.push({
+      id: 'next',
+      defaultMessage: 'Next',
+    });
+  }
+
   if (places && places.edges) {
     return (
       <DeparturesTable
-        headers={[
-          {
-            id: 'to-stop',
-            defaultMessage: 'To Stop',
-          },
-          {
-            id: 'route',
-            defaultMessage: 'Route',
-          },
-          {
-            id: 'destination',
-            defaultMessage: 'Destination',
-          },
-          {
-            id: 'leaves',
-            defaultMessage: 'Leaves',
-          },
-          {
-            id: 'next',
-            defaultMessage: 'Next',
-          },
-        ]}
-        content={constructPlacesList({ places, currentTime, timeRange })}
+        headers={headers}
+        content={constructPlacesList({
+          places,
+          currentTime,
+          timeRange,
+          displayNextDeparture,
+        })}
       />
     );
   }
@@ -100,6 +110,10 @@ PlaceAtDistanceList.propTypes = {
   }).isRequired,
   currentTime: PropTypes.number.isRequired,
   timeRange: PropTypes.number.isRequired,
+};
+
+PlaceAtDistanceList.contextTypes = {
+  config: PropTypes.object,
 };
 
 export default Relay.createContainer(PlaceAtDistanceList, {


### PR DESCRIPTION
## Proposed Changes
Follow on #3230 we added the option to switch off the "next" departure column in the Near you panel at the front page. It uses the same variable as the first PR, `displayNextDeparture` from the config file.

If true:
![Screenshot_2020-05-12_09-47-42](https://user-images.githubusercontent.com/46535522/81669877-1f7b8900-9447-11ea-85b9-46e72f082ecd.png)
If false:
![Screenshot_2020-05-12_09-48-19](https://user-images.githubusercontent.com/46535522/81669880-20141f80-9447-11ea-829d-dc7349a8c557.png)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
