### PR TITLE
refactor: update ticket sales props

### DIFF
--- a/app/component/map/popups/TicketSalesPopup.js
+++ b/app/component/map/popups/TicketSalesPopup.js
@@ -10,13 +10,11 @@ export function getIcon(type) {
   switch (type) {
     case 'Palvelupiste':
       return 'icon-icon_service-point';
-    case 'HSL Automaatti MNL':
+    case 'Monilippuautomaatti':
       return 'icon-icon_ticket-machine';
-    case 'HSL Automaatti KL':
+    case 'Kertalippuautomaatti':
       return 'icon-icon_ticket-machine-single';
     case 'Myyntipiste':
-      return 'icon-icon_ticket-sales-point';
-    case 'R-kioski':
       return 'icon-icon_ticket-sales-point';
     default:
       // eslint-disable-next-line no-console
@@ -30,15 +28,15 @@ function TicketSalesPopup(props) {
     <div className="card">
       <Card className="card-padding">
         <CardHeader
-          name={props.NIMI}
-          description={props.OSOITE}
-          icon={getIcon(props.TYYPPI)}
+          name={props.Name_fi}
+          description={props.Address_fi}
+          icon={getIcon(props.Tyyppi)}
           unlinked
         />
       </Card>
       <MarkerPopupBottom
         location={{
-          address: props.NIMI,
+          address: props.Name_fi,
           lat: props.LAT,
           lon: props.LON,
         }}
@@ -57,9 +55,9 @@ TicketSalesPopup.description = (
 );
 
 TicketSalesPopup.propTypes = {
-  TYYPPI: PropTypes.string.isRequired,
-  NIMI: PropTypes.string.isRequired,
-  OSOITE: PropTypes.string.isRequired,
+  Tyyppi: PropTypes.string.isRequired,
+  Name_fi: PropTypes.string.isRequired,
+  Address_fi: PropTypes.string.isRequired,
   LAT: PropTypes.number.isRequired,
   LON: PropTypes.number.isRequired,
 };

--- a/app/component/map/tile-layer/MarkerSelectPopup.js
+++ b/app/component/map/tile-layer/MarkerSelectPopup.js
@@ -53,7 +53,7 @@ function MarkerSelectPopup(props) {
       return (
         <SelectTicketSalesRow
           {...option.feature.properties}
-          key={option.feature.properties.FID}
+          key={option.feature.properties.NID_fi}
           selectRow={() => props.selectRow(option)}
         />
       );
@@ -73,7 +73,7 @@ function MarkerSelectPopup(props) {
           location={{
             address:
               props.options[0].feature.properties.name ||
-              props.options[0].feature.properties.NIMI,
+              props.options[0].feature.properties.Name_fi,
             lat: props.location.lat,
             lon: props.location.lng,
           }}

--- a/app/component/map/tile-layer/SelectTicketSalesRow.js
+++ b/app/component/map/tile-layer/SelectTicketSalesRow.js
@@ -10,11 +10,11 @@ function SelectTicketSalesRow(props) {
     <div className="no-margin">
       <div className="cursor-pointer select-row" onClick={props.selectRow}>
         <div className="padding-vertical-normal select-row-icon">
-          <Icon img={getIcon(props.TYYPPI)} />
+          <Icon img={getIcon(props.Tyyppi)} />
         </div>
         <div className="padding-vertical-normal select-row-text">
           <span className="header-primary no-margin link-color">
-            {props.NIMI} ›
+            {props.Name_fi} ›
           </span>
         </div>
         <div className="clear" />
@@ -37,8 +37,8 @@ SelectTicketSalesRow.description = () => (
 
 SelectTicketSalesRow.propTypes = {
   selectRow: PropTypes.func.isRequired,
-  TYYPPI: PropTypes.string.isRequired,
-  NIMI: PropTypes.string.isRequired,
+  Tyyppi: PropTypes.string.isRequired,
+  Name_fi: PropTypes.string.isRequired,
 };
 
 export default SelectTicketSalesRow;

--- a/app/component/map/tile-layer/TicketSales.js
+++ b/app/component/map/tile-layer/TicketSales.js
@@ -22,11 +22,10 @@ export default class TicketSales {
     switch (type) {
       case 'Palvelupiste':
         return 'icon-icon_service-point';
-      case 'HSL Automaatti MNL':
-      case 'HSL Automaatti KL':
+      case 'Kertalippuautomaatti':
+      case 'Monilippuautomaatti':
         return 'icon-icon_ticket-machine';
       case 'Myyntipiste':
-      case 'R-kioski':
         return 'icon-icon_ticket-sales-point';
       default:
         return undefined;
@@ -71,7 +70,7 @@ export default class TicketSales {
               }
               [[feature.geom]] = feature.loadGeometry();
               // Do not show VR ticket machines and ticket offices
-              const icon = TicketSales.getIcon(feature.properties.TYYPPI);
+              const icon = TicketSales.getIcon(feature.properties.Tyyppi);
               if (icon) {
                 this.features.push(pick(feature, ['geom', 'properties']));
                 drawIcon(icon, this.tile, feature.geom, size);

--- a/app/component/map/tile-layer/TileLayerContainer.js
+++ b/app/component/map/tile-layer/TileLayerContainer.js
@@ -222,7 +222,7 @@ class TileLayerContainer extends GridLayer {
       name = target.layer;
       switch (name) {
         case 'ticketSales':
-          type = properties.TYYPPI;
+          type = properties.Tyyppi;
           break;
         case 'stop':
           ({ type } = properties);
@@ -343,7 +343,7 @@ class TileLayerContainer extends GridLayer {
             />
           );
         } else if (this.state.selectableTargets[0].layer === 'ticketSales') {
-          id = this.state.selectableTargets[0].feature.properties.FID;
+          id = this.state.selectableTargets[0].feature.properties.NID_fi;
           contents = (
             <TicketSalesPopup
               {...this.state.selectableTargets[0].feature.properties}

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -471,10 +471,9 @@ export default {
     featureMapping: {
       ticketSales: {
         Palvelupiste: 'servicePoint',
-        'HSL Automaatti MNL': 'ticketMachine',
-        'HSL Automaatti KL': 'ticketMachine',
+        Monilippuautomaatti: 'ticketMachine',
+        Kertalippuautomaatti: 'ticketMachine',
         Myyntipiste: 'salesPoint',
-        'R-kioski': 'salesPoint',
       },
     },
   },

--- a/app/util/mapLayerUtils.js
+++ b/app/util/mapLayerUtils.js
@@ -49,9 +49,9 @@ export const isFeatureLayerEnabled = (
     }
     return Boolean(mapLayers[layerName][featureType]);
   }
-  if (layerName === 'ticketSales' && feature.properties.TYYPPI && config) {
+  if (layerName === 'ticketSales' && feature.properties.Tyyppi && config) {
     const customLayerName =
-      config.mapLayers.featureMapping.ticketSales[feature.properties.TYYPPI];
+      config.mapLayers.featureMapping.ticketSales[feature.properties.Tyyppi];
     return Boolean(mapLayers.ticketSales[customLayerName]);
   }
   return isLayerEnabled(layerName, mapLayers);

--- a/test/unit/util/mapLayerUtils.test.js
+++ b/test/unit/util/mapLayerUtils.test.js
@@ -166,7 +166,7 @@ describe('mapLayerUtils', () => {
     it('should use the config to match ticketSales features', () => {
       const feature = {
         properties: {
-          TYYPPI: 'foobar',
+          Tyyppi: 'foobar',
         },
       };
       const layerName = 'ticketSales';


### PR DESCRIPTION
## Proposed Changes
Update ticket sales props. A new version of the HSL ticket sales dataset has been released in which the data schema for ticket-sales vector tiles changes. This commit replaces the old prop values with new values of the updated dataset.

Corresponding changes to the hsl-map-server: https://github.com/HSLdevcom/hsl-map-server/pull/70

New dataset: https://public-transport-hslhrt.opendata.arcgis.com/datasets/hsln-myyntipisteet/data

 Following schema values have been replaced with new ones:
 FID -> NID_fi
 TYYPPI -> Tyyppi
 NAME -> Name_fi
 OSOITE -> Address_fi
 'HSL Automaatti MNL' -> Monilippuautomaatti
 'HSL Automaatti KL' -> Kertalippuautomaatti

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
