### PR TITLE
fix: catch error from fetching relay cache

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -275,7 +275,7 @@ export default async function(req, res, next) {
     try {
       relayData = await environment.relaySSRMiddleware.getCache();
     } catch {
-      relayData = {};
+      relayData = [];
     }
 
     const spriteName = config.sprites;

--- a/app/server.js
+++ b/app/server.js
@@ -271,7 +271,12 @@ export default async function(req, res, next) {
 
     const contentWithBreakpoint = `<div id="app" data-initial-breakpoint="${breakpoint}">${content}</div>\n`;
 
-    const relayData = await environment.relaySSRMiddleware.getCache();
+    let relayData;
+    try {
+      relayData = await environment.relaySSRMiddleware.getCache();
+    } catch {
+      relayData = {};
+    }
 
     const spriteName = config.sprites;
 


### PR DESCRIPTION
This fixes occasional errors when refreshing page on some itinerary summary page. An error (RRNLBatchMiddlewareError: Server does not return response for request at index 0.
R) was rendered instead of continuing the render process. 

## Proposed Changes

  - Catches error from fetching relay's cache so UI does not render the relay error which can block SSR from working properly.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
