### PR TITLE
DT-3431 and DT-3482 part 1, Optimize Itinerary page rendering for geolocated routes

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -48,8 +48,6 @@ import {
 import VehicleMarkerContainer from './map/VehicleMarkerContainer';
 import ItineraryTab from './ItineraryTab';
 
-export const ITINERARYFILTERING_DEFAULT = 1.5;
-
 /**
  * Returns the actively selected itinerary's index. Attempts to look for
  * the information in the location's state and pathname, respectively.

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -688,6 +688,7 @@ class SummaryPage extends React.Component {
     if (
       (!error && !this.props.plan) ||
       this.state.loading !== false ||
+      this.props.loading !== false ||
       this.props.loadingPosition === true
     ) {
       content = (

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -176,12 +176,14 @@ class SummaryPage extends React.Component {
     }),
     breakpoint: PropTypes.string.isRequired,
     error: PropTypes.object,
+    loading: PropTypes.bool,
     loadingPosition: PropTypes.bool,
   };
 
   static defaultProps = {
     map: undefined,
     error: undefined,
+    loading: false,
     loadingPosition: false,
   };
 
@@ -582,6 +584,7 @@ class SummaryPage extends React.Component {
       if (
         this.state.loading === false &&
         this.props.loadingPosition === false &&
+        this.props.loading === false &&
         (error || this.props.plan)
       ) {
         if (match.params.hash) {

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -356,7 +356,11 @@ class SummaryPage extends React.Component {
   }
 
   renderMap() {
-    const { match, plan } = this.props;
+    const { match, plan, breakpoint } = this.props;
+    // don't render map on mobile
+    if (breakpoint !== 'large') {
+      return undefined;
+    }
     const {
       config: { defaultEndpoint },
     } = this.context;

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,7 +6,6 @@ import queryMiddleware from 'farce/lib/queryMiddleware';
 import createRender from 'found/lib/createRender';
 
 import Error404 from './component/404';
-import Loading from './component/LoadingPage';
 import TopLevel from './component/TopLevel';
 
 import { PREFIX_ITINERARY_SUMMARY } from './util/path';
@@ -22,6 +21,7 @@ import getStopRoutes from './stopRoutes';
 import routeRoutes from './routeRoutes';
 
 import SelectFromMapHeader from './component/SelectFromMapHeader';
+import { validateServiceTimeRange } from './util/timeUtils';
 
 export const historyMiddlewares = [queryMiddleware];
 
@@ -142,11 +142,17 @@ export default config => {
                 }
               `}
               prepareVariables={preparePlanParams(config)}
-              render={({ Component, props, error }) =>
-                Component && props ? (
-                  <Component {...props} error={error} />
+              render={({ Component, props, error, match }) =>
+                props ? (
+                  <Component {...props} error={error} loading={false} />
                 ) : (
-                  <Loading />
+                  <Component
+                    plan={{}}
+                    serviceTimeRange={validateServiceTimeRange()}
+                    match={match}
+                    loading
+                    error={error}
+                  />
                 )
               }
             >

--- a/app/routes.js
+++ b/app/routes.js
@@ -142,19 +142,22 @@ export default config => {
                 }
               `}
               prepareVariables={preparePlanParams(config)}
-              render={({ Component, props, error, match }) =>
-                props ? (
-                  <Component {...props} error={error} loading={false} />
-                ) : (
-                  <Component
-                    plan={{}}
-                    serviceTimeRange={validateServiceTimeRange()}
-                    match={match}
-                    loading
-                    error={error}
-                  />
-                )
-              }
+              render={({ Component, props, error, match }) => {
+                if (Component) {
+                  return props ? (
+                    <Component {...props} error={error} loading={false} />
+                  ) : (
+                    <Component
+                      plan={{}}
+                      serviceTimeRange={validateServiceTimeRange()}
+                      match={match}
+                      loading
+                      error={error}
+                    />
+                  );
+                }
+                return undefined;
+              }}
             >
               {{
                 content: [

--- a/app/routes.js
+++ b/app/routes.js
@@ -22,6 +22,7 @@ import routeRoutes from './routeRoutes';
 
 import SelectFromMapHeader from './component/SelectFromMapHeader';
 import { validateServiceTimeRange } from './util/timeUtils';
+import { isBrowser } from './util/browser';
 
 export const historyMiddlewares = [queryMiddleware];
 
@@ -34,7 +35,7 @@ export default config => {
       {getStopRoutes(true) /* terminals */}
       {routeRoutes}
       <Route path={`/${PREFIX_ITINERARY_SUMMARY}/:from/:to`}>
-        {{
+        {isBrowser && {
           title: (
             <Route
               path="(.*)?"

--- a/app/routes.js
+++ b/app/routes.js
@@ -35,7 +35,7 @@ export default config => {
       {getStopRoutes(true) /* terminals */}
       {routeRoutes}
       <Route path={`/${PREFIX_ITINERARY_SUMMARY}/:from/:to`}>
-        {isBrowser && {
+        {{
           title: (
             <Route
               path="(.*)?"
@@ -46,7 +46,7 @@ export default config => {
               }
             />
           ),
-          content: (
+          content: isBrowser ? (
             <Route
               getComponent={() =>
                 import(/* webpackChunkName: "itinerary" */ './component/SummaryPage').then(
@@ -198,6 +198,15 @@ export default config => {
                 ],
               }}
             </Route>
+          ) : (
+            <Route
+              path="(.*)?"
+              getComponent={() =>
+                import(/* webpackChunkName: "itinerary" */ './component/Loading').then(
+                  getDefault,
+                )
+              }
+            />
           ),
           meta: (
             <Route


### PR DESCRIPTION
## Proposed Changes

  - Renders placeholder summary page while waiting for itineraries instead of a full page loader (client side rendering)
  - Removed SSR of summary page, instead returns a loader gif from server
     - Because routing parameters don't exist to the extent in the URL anymore, SSR would in many cases do an itinerary search with different parameters than client
  - Removed unused ITINERARYFILTERING_DEFAULT export from SummaryPage
  - Removed mostly hidden map render on mobile in summary page with no itineraries selected
     - Map was occasionally briefly shown during re-renders

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
