### PR TITLE
DT-3618: mobile's front page to match with HSL.fi's front page

### DIFF
--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -215,7 +215,7 @@ class IndexPage extends React.Component {
               onAddFavourite={this.addFavourite}
               onClickFavourite={this.clickFavourite}
             />
-            <CtrlPanel.SeparatorLine />
+            <CtrlPanel.SeparatorLine usePaddingBottom20 />
             <div className="stops-near-you-text">
               <h2>
                 {' '}

--- a/app/component/front-page.scss
+++ b/app/component/front-page.scss
@@ -279,7 +279,7 @@ $heading-color: #858585;
   display: flex;
   flex-direction: column;
   background-color: #fff;
-  padding-top: 30px;
+  padding: 25px 10px;
 }
 .control-panel-container-left {
   display: flex;
@@ -310,10 +310,10 @@ $heading-color: #858585;
 }
 
 .stops-near-you-text {
-  font-size: $font-size-large;
-  margin-bottom: 1rem;
   h2 {
     margin: 0;
+    font-size: 18px;
+    margin-bottom: 17px;
   }
 }
 

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/helpers/styles.scss
@@ -11,13 +11,13 @@ $zindex: base, map-container, footer, map-gradient, map-fullscreen-toggle,
 }
 
 .autosuggest-searchpanel-text {
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 500;
-  letter-spacing: -0.6px;
+  letter-spacing: -0.8px;
   color: #333333;
-  margin-top: 0;
+  //margin-top: 0;
   margin-bottom: 17px;
-  line-height: 24px;
+  //line-height: 24px;
 
   @media screen and (min-width: 768px) {
     font-size: 24px;

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.generated",
   "publishConfig": {

--- a/digitransit-component/packages/digitransit-component-control-panel/helpers/styles.js
+++ b/digitransit-component/packages/digitransit-component-control-panel/helpers/styles.js
@@ -33,20 +33,32 @@ export function getStyleSeparatorDiv() {
     position: 'relative',
     display: 'block',
     width: '100%',
-    marginTop: 30,
-    marginBottom: 29,
+    // marginTop: 20,
+    marginBottom: 19,
+    paddingBottom: 29,
+  };
+}
+
+export function getStyleSeparatorDiv2() {
+  return {
+    position: 'relative',
+    display: 'block',
+    width: '100%',
+    // marginTop: 20,
+    marginBottom: 19,
+    paddingBottom: 20,
   };
 }
 
 export function getStyleSeparatorLine() {
   return {
-    backgroundColor: '#dddddd',
+    backgroundColor: '#ccc',
     content: '',
     display: 'block',
     height: 1,
     position: 'absolute',
     bottom: 0,
-    right: -11,
-    left: -11,
+    right: -5,
+    left: -5,
   };
 }

--- a/digitransit-component/packages/digitransit-component-control-panel/index.js
+++ b/digitransit-component/packages/digitransit-component-control-panel/index.js
@@ -8,6 +8,7 @@ import {
   getStyleMain,
   getStyleMainBottom,
   getStyleSeparatorDiv,
+  getStyleSeparatorDiv2,
   getStyleSeparatorLine,
 } from './helpers/styles';
 import translations from './helpers/translations';
@@ -18,13 +19,26 @@ i18next.addResourceBundle('en', 'translation', translations.en);
 i18next.addResourceBundle('fi', 'translation', translations.fi);
 i18next.addResourceBundle('sv', 'translation', translations.sv);
 
-function SeparatorLine() {
+function SeparatorLine({ usePaddingBottom20 }) {
   return (
-    <div id="SeparatorDiv" style={getStyleSeparatorDiv()}>
+    <div
+      id="SeparatorDiv"
+      style={
+        usePaddingBottom20 ? getStyleSeparatorDiv2() : getStyleSeparatorDiv()
+      }
+    >
       <div id="SeparatorLine" style={getStyleSeparatorLine()} />
     </div>
   );
 }
+
+SeparatorLine.propTypes = {
+  usePaddingBottom20: PropTypes.bool,
+};
+
+SeparatorLine.defaultProps = {
+  usePaddingBottom20: false,
+};
 
 function OriginToDestination({ showTitle, language }) {
   i18next.changeLanguage(language);

--- a/digitransit-component/packages/digitransit-component-control-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-control-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-control-panel",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "digitransit-component control-panel module",
   "main": "index.generated",
   "publishConfig": {


### PR DESCRIPTION
## Proposed Changes

  - Text sized and paddings to be same as in HSL.fi's mobile page

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
