### PR TITLE
fix: pattern switching on route timetable view

### DIFF
--- a/app/component/RouteScheduleContainer.js
+++ b/app/component/RouteScheduleContainer.js
@@ -56,21 +56,12 @@ class RouteScheduleContainer extends Component {
     config: PropTypes.object.isRequired,
   };
 
-  constructor(props) {
-    super(props);
-    this.initState(props, true);
-  }
-
-  componentDidMount() {
-    this.props.relay.refetch(
-      {
-        serviceDay: this.props.serviceDay,
-        code: this.props.match.params.patternId,
-      },
-      null,
-      () => this.setState({ hasLoaded: true }),
-    );
-  }
+  state = {
+    from: 0,
+    to: this.props.pattern.stops.length - 1,
+    serviceDay: this.props.serviceDay,
+    hasLoaded: true,
+  };
 
   onFromSelectChange = event => {
     const from = Number(event.target.value);
@@ -191,32 +182,12 @@ class RouteScheduleContainer extends Component {
 
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
-    // If route has changed, reset state.
     if (nextProps.pattern.code !== this.props.pattern.code) {
-      this.initState(nextProps, false);
-      nextProps.relay.refetch(
-        {
-          serviceDay: nextProps.serviceDay,
-          code: this.props.pattern.code,
-        },
-        null,
-        () => this.setState({ hasLoaded: true }),
-      );
-    }
-  }
-
-  initState(props, isInitialState) {
-    const state = {
-      from: 0,
-      to: props.pattern.stops.length - 1,
-      serviceDay: props.serviceDay,
-      hasLoaded: false,
-    };
-
-    if (isInitialState) {
-      this.state = state;
-    } else {
-      this.setState(state);
+      this.setState({
+        from: 0,
+        to: nextProps.pattern.stops.length - 1,
+        serviceDay: nextProps.serviceDay,
+      });
     }
   }
 
@@ -312,6 +283,7 @@ const connectedComponent = createRefetchContainer(
         @argumentDefinitions(
           serviceDay: { type: "String!", defaultValue: "19700101" }
         ) {
+        code
         stops {
           id
           name

--- a/app/routeRoutes.js
+++ b/app/routeRoutes.js
@@ -189,12 +189,15 @@ export default (
               query={graphql`
                 query routeRoutes_RouteScheduleContainer_Query(
                   $patternId: String!
+                  $date: String!
                 ) {
                   pattern(id: $patternId) {
                     ...RouteScheduleContainer_pattern
+                      @arguments(serviceDay: $date)
                   }
                 }
               `}
+              prepareVariables={prepareServiceDay}
               render={getComponentOrLoadingRenderer}
             />
           </Route>,


### PR DESCRIPTION
## Proposed Changes

  - Fixes issue where switching back to timetables of an already viewed pattern in route page timetable view showed always an empty list
    - The state handling and react lifecycle usage is still a bit of a mess but perhaps slightly less of a mess now

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
