### PR TITLE
DT-3430: Map should not constantly center on a vehicle

### DIFF
--- a/app/component/RouteMapContainer.js
+++ b/app/component/RouteMapContainer.js
@@ -30,10 +30,8 @@ class RouteMapContainer extends React.PureComponent {
 
   constructor(props) {
     super(props);
-
     this.state = {
-      hasCentered: false,
-      shouldFitBounds: true,
+      centerToMarker: true,
     };
   }
 
@@ -41,33 +39,29 @@ class RouteMapContainer extends React.PureComponent {
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.match.params.tripId !== nextProps.match.params.tripId) {
       this.setState({
-        hasCentered: false,
-        shouldFitBounds: true,
+        centerToMarker: true,
+      });
+    } else if (this.state.centerToMarker) {
+      this.setState({
+        centerToMarker: false,
       });
     }
   }
 
   render() {
     const { pattern, lat, lon, match, router, breakpoint } = this.props;
-    const { hasCentered, shouldFitBounds } = this.state;
+    const { centerToMarker } = this.state;
     const { config } = this.context;
 
     const fullscreen =
       match.location.state && match.location.state.fullscreenMap === true;
 
     const [dispLat, dispLon] =
-      (!hasCentered && match.params.tripId) ||
-      (!fullscreen && breakpoint !== 'large')
+      centerToMarker &&
+      (match.params.tripId || (!fullscreen && breakpoint !== 'large'))
         ? [lat, lon]
         : [undefined, undefined];
 
-    // TODO this code existed to stop centering on every coordinate update
-    // but it can cause an infinite loop so needs refactoring
-    // if (!hasCentered && lat && lon) {
-    //   this.setState({ hasCentered: true, shouldFitBounds: false });
-    // }
-
-    // ,
     if (!pattern) {
       return false;
     }
@@ -116,7 +110,7 @@ class RouteMapContainer extends React.PureComponent {
         lon={dispLon}
         className="full"
         leafletObjs={leafletObjs}
-        fitBounds={!(dispLat && dispLon) && shouldFitBounds}
+        fitBounds={!(dispLat && dispLon) && !match.params.tripId}
         bounds={(filteredPoints || pattern.stops).map(p => [p.lat, p.lon])}
         zoom={dispLat && dispLon ? 15 : undefined}
         showScaleBar={showScale}


### PR DESCRIPTION
## Proposed Changes

  - Map now only focuses on vehicle when it is first selected and will not follow it.
  - When vehicle popup is open, the map will still partially follow the popup

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
