### PR TITLE
DT-3701: Selecting origin or destination in front page disable realtime update of departure time

### DIFF
--- a/app/component/OriginDestinationBar.js
+++ b/app/component/OriginDestinationBar.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { intlShape } from 'react-intl';
 import { matchShape, routerShape } from 'found';
-import { withCurrentTime } from '@digitransit-search-util/digitransit-search-util-query-utils';
 import connectToStores from 'fluxible-addons-react/connectToStores';
 import DTAutosuggestPanel from '@digitransit-component/digitransit-component-autosuggest-panel';
 import ComponentUsageExample from './ComponentUsageExample';
@@ -62,14 +61,13 @@ class OriginDestinationBar extends React.Component {
 
   swapEndpoints = () => {
     const { location } = this;
-    const locationWithTime = withCurrentTime(location);
     const intermediatePlaces = getIntermediatePlaces(location.query);
     if (intermediatePlaces.length > 1) {
       location.query.intermediatePlaces.reverse();
     }
 
     navigateTo({
-      base: locationWithTime,
+      base: location,
       origin: this.props.destination,
       destination: this.props.origin,
       context: PREFIX_ITINERARY_SUMMARY,

--- a/app/component/WithSearchContext.js
+++ b/app/component/WithSearchContext.js
@@ -5,7 +5,6 @@ import { matchShape, routerShape } from 'found';
 import { intlShape } from 'react-intl';
 import getJson from '@digitransit-search-util/digitransit-search-util-get-json';
 import suggestionToLocation from '@digitransit-search-util/digitransit-search-util-suggestion-to-location';
-import moment from 'moment';
 import connectToStores from 'fluxible-addons-react/connectToStores';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
 import { navigateTo } from '../util/path';
@@ -293,9 +292,7 @@ export default function withSearchContext(WrappedComponent) {
           params.intermediatePlaces = itineraryParams.intermediatePlaces;
         }
         params.arriveBy = itineraryParams.arriveBy;
-        params.time = itineraryParams.time
-          ? itineraryParams.time
-          : moment().unix();
+        params.time = itineraryParams.time;
         return {
           ...location,
           query: {
@@ -304,13 +301,7 @@ export default function withSearchContext(WrappedComponent) {
           },
         };
       }
-      return {
-        ...location,
-        query: {
-          ...query,
-          time: moment().unix(),
-        },
-      };
+      return { ...location, query };
     };
 
     render() {

--- a/app/component/map/MarkerPopupBottom.js
+++ b/app/component/map/MarkerPopupBottom.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { matchShape, routerShape } from 'found';
 import { FormattedMessage } from 'react-intl';
 import { withLeaflet } from 'react-leaflet/es/context';
-import { withCurrentTime } from '@digitransit-search-util/digitransit-search-util-query-utils';
 import updateViaPointsFromMap from '../../action/ViaPointsActions';
 import {
   PREFIX_ROUTES,
@@ -83,7 +82,6 @@ class MarkerPopupBottom extends React.Component {
       category: 'ItinerarySettings',
       name: 'MapPopup',
     });
-    const locationWithTime = withCurrentTime(this.context.match.location);
 
     const { pathname } = this.context.match.location;
     const [, context] = pathname.split('/');
@@ -96,7 +94,7 @@ class MarkerPopupBottom extends React.Component {
       destination,
       context,
       router: this.context.router,
-      base: locationWithTime,
+      base: this.context.match.location,
       resetIndex: true,
     });
   };
@@ -107,7 +105,6 @@ class MarkerPopupBottom extends React.Component {
       category: 'ItinerarySettings',
       name: 'MapPopup',
     });
-    const locationWithTime = withCurrentTime(this.context.match.location);
 
     const { pathname } = this.context.match.location;
     const [, context] = pathname.split('/');
@@ -120,7 +117,7 @@ class MarkerPopupBottom extends React.Component {
       destination: { ...this.props.location, ready: true },
       context,
       router: this.context.router,
-      base: locationWithTime,
+      base: this.context.match.location,
       resetIndex: true,
     });
   };

--- a/app/util/path.js
+++ b/app/util/path.js
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
 import d from 'debug';
+import moment from 'moment';
 import {
   otpToLocation,
   locationToOTP,
@@ -171,6 +172,18 @@ export const navigateTo = ({
   }
 
   debug('url, push', url, push);
+
+  if (!url.query) {
+    url.query = {};
+  }
+  // set time to current time if time is not set and both origin and destination are set
+  if (
+    url.query.time === undefined &&
+    origin.set !== false &&
+    destination.set !== false
+  ) {
+    url.query.time = moment().unix();
+  }
 
   if (push) {
     router.push(url);


### PR DESCRIPTION
## Proposed Changes

  - When 'depart now' is selected in timepicker, url param 'time' is now set to current time only once both origin and departure are selected and the actual route search is made 
  - This allows the time in to keep updating in UI if one of origin or departure is selected

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
