### PR TITLE
DT-3704: Street mode selector container looks off in safari

### DIFF
--- a/app/component/StreetModeSelector.scss
+++ b/app/component/StreetModeSelector.scss
@@ -7,7 +7,8 @@
   justify-content: center;
   align-items: center;
   padding: 10px;
-  height: 60px;
+  min-height: 60px;
+  max-height: 60px;
 }
 
 .mobile {


### PR DESCRIPTION
## Proposed Changes

  - Fix street mode container height on Safari
  - Tested on Browserstack, Safari 13.1

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
