### PR TITLE
DT-3724: Terminal searched as a favourite location does not work in stop search

### DIFF
--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
@@ -297,7 +297,12 @@ export function getSearchResults(
       );
     }
     if (allSources || sources.includes('History')) {
-      const stopHistory = prevSearches(context);
+      const stopHistory = prevSearches(context).filter(item => {
+        if (item.properties.gid) {
+          return item.properties.gid.includes('GTFS:');
+        }
+        return true;
+      });
       const dropLayers = [
         'currentPosition',
         'selectFromMap',


### PR DESCRIPTION
## Proposed Changes

  - Previously searched terminals without gtfs information don't come up in stop and route search

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
