### PR TITLE
DT-3676: info instead of error when only bike or walk

### DIFF
--- a/app/component/ItinerarySummaryListContainer.js
+++ b/app/component/ItinerarySummaryListContainer.js
@@ -35,6 +35,8 @@ function ItinerarySummaryListContainer(
     toggleSettings,
     bikeAndPublicItinerariesToShow,
     bikeAndParkItinerariesToShow,
+    walking,
+    biking,
   },
   context,
 ) {
@@ -152,6 +154,16 @@ function ItinerarySummaryListContainer(
     } else {
       msgId = 'no-route-origin-near-destination';
     }
+  } else if (walking || biking) {
+    iconType = 'info';
+    iconImg = 'icon-icon_info';
+    if (walking && !biking) {
+      msgId = 'walk-bike-itinerary-1';
+    } else if (!walking && biking) {
+      msgId = 'walk-bike-itinerary-2';
+    } else {
+      msgId = 'walk-bike-itinerary-3';
+    }
   } else {
     const quickOption = matchQuickOption(context);
     const currentModes = getModes(context.config);
@@ -237,12 +249,16 @@ ItinerarySummaryListContainer.propTypes = {
   toggleSettings: PropTypes.func.isRequired,
   bikeAndPublicItinerariesToShow: PropTypes.number.isRequired,
   bikeAndParkItinerariesToShow: PropTypes.number.isRequired,
+  walking: PropTypes.bool,
+  biking: PropTypes.bool,
 };
 
 ItinerarySummaryListContainer.defaultProps = {
   error: undefined,
   intermediatePlaces: [],
   itineraries: [],
+  walking: false,
+  biking: false,
 };
 
 ItinerarySummaryListContainer.contextTypes = {

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -1114,6 +1114,8 @@ class SummaryPage extends React.Component {
                 this.bikeAndPublicItinerariesToShow
               }
               bikeAndParkItinerariesToShow={this.bikeAndParkItinerariesToShow}
+              walking={showWalkOptionButton}
+              biking={showBikeOptionButton}
             >
               {this.props.content &&
                 React.cloneElement(this.props.content, {

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -54,12 +54,16 @@ class SummaryPlanContainer extends React.Component {
     toggleSettings: PropTypes.func.isRequired,
     bikeAndPublicItinerariesToShow: PropTypes.number.isRequired,
     bikeAndParkItinerariesToShow: PropTypes.number.isRequired,
+    walking: PropTypes.bool,
+    biking: PropTypes.bool,
   };
 
   static defaultProps = {
     activeIndex: 0,
     error: undefined,
     itineraries: [],
+    walking: false,
+    biking: false,
   };
 
   static contextTypes = {
@@ -497,6 +501,8 @@ class SummaryPlanContainer extends React.Component {
       toggleSettings,
       bikeAndPublicItinerariesToShow,
       bikeAndParkItinerariesToShow,
+      walking,
+      biking,
     } = this.props;
     const searchTime =
       this.props.plan.date ||
@@ -528,6 +534,8 @@ class SummaryPlanContainer extends React.Component {
           toggleSettings={toggleSettings}
           bikeAndPublicItinerariesToShow={bikeAndPublicItinerariesToShow}
           bikeAndParkItinerariesToShow={bikeAndParkItinerariesToShow}
+          walking={walking}
+          biking={biking}
         >
           {this.props.children}
         </ItinerarySummaryListContainer>

--- a/app/translations.js
+++ b/app/translations.js
@@ -1234,6 +1234,12 @@ const translations = {
     wait: 'Wait',
     'wait-amount-of-time': 'Wait {duration}',
     walk: 'walking',
+    'walk-bike-itinerary-1':
+      'Löysimme valitsemallesi reitille vain kävelyyn liittyviä reittiehdotuksia.',
+    'walk-bike-itinerary-2':
+      'Löysimme valitsemallesi reitille vain pyöräilyyn liittyviä reittiehdotuksia.',
+    'walk-bike-itinerary-3':
+      'Löysimme valitsemallesi reitille vain kävelyyn ja pyöräilyyn liittyviä reittiehdotuksia.',
     'walk-distance-duration': 'Walk {distance} ({duration})',
     walking: 'Amount of walking',
     'walking-speed': 'Walking speed',
@@ -2042,6 +2048,12 @@ const translations = {
     wait: 'Odota',
     'wait-amount-of-time': 'Odota {duration}',
     walk: 'kävelyn',
+    'walk-bike-itinerary-1':
+      'Löysimme valitsemallesi reitille vain kävelyyn liittyviä reittiehdotuksia.',
+    'walk-bike-itinerary-2':
+      'Löysimme valitsemallesi reitille vain pyöräilyyn liittyviä reittiehdotuksia.',
+    'walk-bike-itinerary-3':
+      'Löysimme valitsemallesi reitille vain kävelyyn ja pyöräilyyn liittyviä reittiehdotuksia.',
     'walk-distance-duration': 'Kävele {distance} ({duration})',
     walking: 'Kävelyn määrä',
     'walking-speed': 'Kävelynopeus',
@@ -3646,6 +3658,12 @@ const translations = {
     wait: 'Vänta',
     'wait-amount-of-time': 'Vänta {duration}',
     walk: 'gång',
+    'walk-bike-itinerary-1':
+      'Löysimme valitsemallesi reitille vain kävelyyn liittyviä reittiehdotuksia.',
+    'walk-bike-itinerary-2':
+      'Löysimme valitsemallesi reitille vain pyöräilyyn liittyviä reittiehdotuksia.',
+    'walk-bike-itinerary-3':
+      'Löysimme valitsemallesi reitille vain kävelyyn ja pyöräilyyn liittyviä reittiehdotuksia.',
     'walk-distance-duration': 'Gå {distance} ({duration})',
     walking: 'Gång',
     'walking-speed': 'Promenadhastighet',


### PR DESCRIPTION
## Proposed Changes

  - Showing info when only bike or walk itinerary is available.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
