### PR TITLE
DT-3741: Reordering favourites or via points doesn't work on iphone

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/helpers/styles.scss
@@ -51,10 +51,6 @@ $zindex: base, map-container, footer, map-gradient, map-fullscreen-toggle,
     flex: 1 0 100%;
     margin-top: 6px;
     min-height: 50px;
-    &.drop-target-before {
-      border-top: 1px solid $primary-color;
-      width: 100%;
-    }
     .light-gray-background {
       display: flex;
       padding: 3px 0;

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.generated",
   "publishConfig": {

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -37,6 +37,7 @@
     "react": "^16.13.0",
     "react-autosuggest": "10.0.0",
     "react-autowhatever": "10.2.1",
+    "react-sortablejs": "2.0.11",
     "recompose": "0.30.0"
   }
 }

--- a/digitransit-component/packages/digitransit-component-autosuggest/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/index.js
@@ -231,6 +231,10 @@ class DTAutosuggest extends React.Component {
           suggestionToLocation(ref.suggestion),
           ref.suggestionIndex,
         );
+        this.setState({
+          renderMobileSearch: false,
+          suggestions: [],
+        });
       }
       this.setState(
         {

--- a/digitransit-component/packages/digitransit-component-favourite-editing-modal/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-favourite-editing-modal/helpers/styles.scss
@@ -64,12 +64,6 @@ $primary-color: #007ac9;
       border-radius: 5px;
       border: solid 1px #d9d9d9;
       list-style: none;
-      &.drop-target-before {
-        border-top-left-radius: 0;
-        border-top-right-radius: 0;
-        border-top: 1px solid $primary-color;
-        width: 100%;
-      }
 
       .favourite-edit-list-item-left {
         display: flex;

--- a/digitransit-component/packages/digitransit-component-favourite-editing-modal/index.js
+++ b/digitransit-component/packages/digitransit-component-favourite-editing-modal/index.js
@@ -107,7 +107,6 @@ class FavouriteEditingModal extends React.Component {
     i18next.changeLanguage(props.lang);
     this.draggableFavourites = [];
     this.state = {
-      isDraggingOverIndex: undefined,
       favourites: props.favourites,
       showDeletePlaceModal: false,
       selectedFavourite: null,
@@ -140,7 +139,7 @@ class FavouriteEditingModal extends React.Component {
   isMobile = () =>
     window && window.innerWidth ? window.innerWidth < 768 : false;
 
-  renderFavouriteListItem = (favourite, index) => {
+  renderFavouriteListItem = favourite => {
     const iconId = favourite.selectedIconId.replace('icon-icon_', '');
     const address = favourite.address.replace(
       new RegExp(`${escapeRegExp(favourite.name)}(,)?( )?`),
@@ -148,10 +147,7 @@ class FavouriteEditingModal extends React.Component {
     );
     return (
       <li
-        className={cx(styles['favourite-edit-list-item'], {
-          [styles['drop-target-before']]:
-            index === this.state.isDraggingOverIndex,
-        })}
+        className={cx(styles['favourite-edit-list-item'])}
         key={favourite.favouriteId}
       >
         <div className={styles['favourite-edit-list-item-left']}>
@@ -238,9 +234,7 @@ class FavouriteEditingModal extends React.Component {
           animation={200}
           handle={`.${styles['favourite-edit-list-item-left']}`}
         >
-          {favourites.map((favourite, i) =>
-            this.renderFavouriteListItem(favourite, i),
-          )}
+          {favourites.map(favourite => this.renderFavouriteListItem(favourite))}
         </ReactSortable>
       </div>
     );

--- a/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
@@ -29,6 +29,7 @@
     "@digitransit-component/digitransit-component-dialog-modal": "^0.0.1",
     "i18next": "^19.3.3",
     "prop-types": "^15.7.2",
-    "react": "^16.13.0"
+    "react": "^16.13.0",
+    "react-sortablejs": "2.0.11"
   }
 }

--- a/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-editing-modal",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "digitransit-component favourite-editing-modal module",
   "main": "index.generated",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
     "react-relay": "9.0.0",
     "react-relay-network-modern": "4.5.0",
     "react-relay-network-modern-ssr": "1.3.0",
+    "react-sortablejs": "2.0.11",
     "react-swipeable-views": "0.13.9",
     "react-transition-group": "1.2.1",
     "recompose": "0.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,6 +2530,11 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/sortablejs@^1.10.0":
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/@types/sortablejs/-/sortablejs-1.10.5.tgz#341f5af3372180ce3cbfbd2b34a6fdefaca8d227"
+  integrity sha512-U/i9rGkCwmgmsa0UzHlGnQtL4y57tjywjp6j3GbA64MLaGO+sEBLVhBrQokWfgzeV2T6hQRYC4dZtXkl6dCMfw==
+
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -5073,7 +5078,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.2.6:
+classnames@2.2.6, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -15490,6 +15495,16 @@ react-side-effect@^1.1.0:
   dependencies:
     shallowequal "^1.0.1"
 
+react-sortablejs@2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/react-sortablejs/-/react-sortablejs-2.0.11.tgz#eecf621f801ab8c16a8a5c3c856005f0795ccbcf"
+  integrity sha512-Id44yygU6H/fNRp0uWkGZnKGuBF8GF/Ts6gKX5NfwmzceRjH0e0XHsmBuQ6WXhBIVnMM+XgkEPub851mdti0TA==
+  dependencies:
+    "@types/sortablejs" "^1.10.0"
+    classnames "^2.2.6"
+    sortablejs "1.10.1"
+    tiny-invariant "^1.0.6"
+
 react-static-container@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-static-container/-/react-static-container-1.0.2.tgz#30a4f7548860be1d55d5eb4c20645b835c2bdf34"
@@ -17124,6 +17139,11 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortablejs@1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.10.1.tgz#3d52b00f871be00f00f84d99a60d120bf3dfe52c"
+  integrity sha512-N6r7GrVmO8RW1rn0cTdvK3JR0BcqecAJ0PmYMCL3ZuqTH3pY+9QyqkmJSkkLyyDvd+AJnwaxTP22Ybr/83V9hQ==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -18113,6 +18133,11 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tiny-invariant@^1.0.6:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
 tiny-lr@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
## Proposed Changes

  - Add react-sortablejs library for sorting favourites and via points.
  - Fix bug where mobile search wasn't closed after selecting location.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
