### PR TITLE
DT-3745: Front page link from Stops near you view partly broken

### DIFF
--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -573,6 +573,8 @@ class MapWithTrackingStateHandler extends React.Component {
       !this.state.focusOnPosition
     ) {
       location = config.defaultMapCenter || config.defaultEndpoint;
+    } else if (this.state.focusOnPosition) {
+      location = position;
     }
     const leafletObjs = [];
     if (this.props.leafletObjs) {


### PR DESCRIPTION
## Proposed Changes

  - Fix back button from near you page resulting in a broken map
  - This happened because user was already geolocated when coming from near you page and front page map did not handle that correctly

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
