### PR TITLE
DT-3710: Site header links should navigate to uusi.hsl.fi with correct language

### DIFF
--- a/app/component/AppBarHsl.js
+++ b/app/component/AppBarHsl.js
@@ -62,8 +62,19 @@ const AppBarHsl = ({ lang }, { match, config }) => {
 
   initLanguage(lang);
 
+  let startPageSuffix;
+  switch (lang) {
+    case 'en':
+    case 'sv':
+      startPageSuffix = `${lang}/`;
+      break;
+    case 'fi':
+    default:
+      startPageSuffix = '';
+      break;
+  }
   const navigation = {
-    startPage: 'https://uusi.hsl.fi/',
+    startPage: `https://uusi.hsl.fi/${startPageSuffix}`,
     menu: [
       {
         name: i18next.t('traveling_name'),


### PR DESCRIPTION
## Proposed Changes

  - Change top bar hsl link url to use correct language

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
