### PR TITLE
chore: accept much more matching routes

### DIFF
--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/index.js
@@ -214,7 +214,7 @@ export function getRoutesQuery(input, feedIds) {
         .filter(route => !!route)
         .sort((x, y) => routeNameCompare(x.properties, y.properties)),
     )
-    .then(suggestions => take(suggestions, 10));
+    .then(suggestions => take(suggestions, 100));
 }
 
 export const withCurrentTime = location => {


### PR DESCRIPTION
100 route suggestions is enough for all route searches in HSL area. 100 is a sensible upper limit for searching from a scrolled list. All matching routes are shown.