### PR TITLE
DT-3787: Prefer cycleways by default in bicycle routing

### DIFF
--- a/app/component/AdminForm.js
+++ b/app/component/AdminForm.js
@@ -33,7 +33,7 @@ class AdminForm extends React.Component {
       bikeSwitchTime: 0,
       bikeSwitchCost: 0,
       bikeBoardCost: 600,
-      optimize: 'QUICK',
+      optimize: 'GREENWAYS',
       safetyFactor: 0.334,
       slopeFactor: 0.333,
       timeFactor: 0.333,

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -109,7 +109,7 @@ export default {
     usingWheelchair: 0,
     bikeSpeed: 5.55,
     minTransferTime: 120,
-    optimize: 'QUICK',
+    optimize: 'GREENWAYS',
     preferredRoutes: [],
     ticketTypes: 'none',
     transferPenalty: 0,

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/schema.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/schema.json
@@ -1597,7 +1597,7 @@
                                 },
                                 {
                                     "name": "optimize",
-                                    "description": "Optimization type for bicycling legs, e.g. prefer flat terrain. Default value: `QUICK`",
+                                    "description": "Optimization type for bicycling legs, e.g. prefer flat terrain. Default value: `GREENWAYS`",
                                     "type": {
                                         "kind": "ENUM",
                                         "name": "OptimizeType",
@@ -7372,7 +7372,7 @@
                         },
                         {
                             "name": "GREENWAYS",
-                            "description": "GREENWAYS",
+                            "description": "Prefer cycleways",
                             "isDeprecated": false,
                             "deprecationReason": null
                         },


### PR DESCRIPTION
## Proposed Changes

  - Change default optimization for bicycle routing from QUICK to GREENWAYS for OTP queries.
  - Add more verbose description for GREENWAYS optimization in search-utils

Previous default preset QUICK resulted in some quick and legal but not preferable (unsafe) bicycle routes. By using optimization preset GREENWAYS, cycleways are preferred vs. cycling on a street. The GREENWAYS optimization is currently used in "Suosi kevyen liikeenteern reittejä" search option in `digitransit-ui:master`

GREENWAYS optimization was missing description. GREENWAYS prefers cycleways even more by treating them "safer"(=preferrable) than they are based only on OSM network attributes  

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
