### PR TITLE
DT-3805: update ticket sales points props

### DIFF
--- a/app/component/map/popups/TicketSalesPopup.js
+++ b/app/component/map/popups/TicketSalesPopup.js
@@ -28,15 +28,15 @@ function TicketSalesPopup(props) {
     <div className="card">
       <Card className="card-padding">
         <CardHeader
-          name={props.Name_fi}
-          description={props.Address_fi}
+          name={props.Nimi}
+          description={props.Osoite}
           icon={getIcon(props.Tyyppi)}
           unlinked
         />
       </Card>
       <MarkerPopupBottom
         location={{
-          address: props.Name_fi,
+          address: props.Nimi,
           lat: props.LAT,
           lon: props.LON,
         }}
@@ -56,8 +56,8 @@ TicketSalesPopup.description = (
 
 TicketSalesPopup.propTypes = {
   Tyyppi: PropTypes.string.isRequired,
-  Name_fi: PropTypes.string.isRequired,
-  Address_fi: PropTypes.string.isRequired,
+  Nimi: PropTypes.string.isRequired,
+  Osoite: PropTypes.string.isRequired,
   LAT: PropTypes.number.isRequired,
   LON: PropTypes.number.isRequired,
 };

--- a/app/component/map/tile-layer/MarkerSelectPopup.js
+++ b/app/component/map/tile-layer/MarkerSelectPopup.js
@@ -53,7 +53,7 @@ function MarkerSelectPopup(props) {
       return (
         <SelectTicketSalesRow
           {...option.feature.properties}
-          key={option.feature.properties.NID_fi}
+          key={option.feature.properties.FID}
           selectRow={() => props.selectRow(option)}
         />
       );
@@ -73,7 +73,7 @@ function MarkerSelectPopup(props) {
           location={{
             address:
               props.options[0].feature.properties.name ||
-              props.options[0].feature.properties.Name_fi,
+              props.options[0].feature.properties.Nimi,
             lat: props.location.lat,
             lon: props.location.lng,
           }}

--- a/app/component/map/tile-layer/SelectTicketSalesRow.js
+++ b/app/component/map/tile-layer/SelectTicketSalesRow.js
@@ -14,7 +14,7 @@ function SelectTicketSalesRow(props) {
         </div>
         <div className="padding-vertical-normal select-row-text">
           <span className="header-primary no-margin link-color">
-            {props.Name_fi} ›
+            {props.Nimi} ›
           </span>
         </div>
         <div className="clear" />
@@ -38,7 +38,7 @@ SelectTicketSalesRow.description = () => (
 SelectTicketSalesRow.propTypes = {
   selectRow: PropTypes.func.isRequired,
   Tyyppi: PropTypes.string.isRequired,
-  Name_fi: PropTypes.string.isRequired,
+  Nimi: PropTypes.string.isRequired,
 };
 
 export default SelectTicketSalesRow;

--- a/app/component/map/tile-layer/TileLayerContainer.js
+++ b/app/component/map/tile-layer/TileLayerContainer.js
@@ -303,7 +303,7 @@ class TileLayerContainer extends GridLayer {
       ({ id } = target.feature);
       contents = this.getParkAndRideContent(id, target);
     } else if (target.layer === 'ticketSales') {
-      id = target.feature.properties.NID_fi;
+      id = target.feature.properties.FID;
       contents = <TicketSalesPopup {...target.feature.properties} />;
     }
     return (


### PR DESCRIPTION
## Proposed Changes

Update ticket sales props. A new version of the HSL ticket sales dataset has been released in which the data schema for ticket-sales vector tiles changes. The new data is served by hsl-map-server via Digitransit Map API. This commit replaces the old prop values with new values of the updated dataset.

New ticket sales point dataset which is served as vector tiles by hsl-map-server: https://opendata.arcgis.com/datasets/79fe2db71b254edda68c47d2629a962e_0.geojson

The new dataset is currently served only by hsl-map-server:dev. 
Production release needs a timed production release of hsl-map-server.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
