### PR TITLE
DT-3715: Design how mobile bottom sheet type areas should function

### DIFF
--- a/app/component/ItineraryPageMap.js
+++ b/app/component/ItineraryPageMap.js
@@ -1,16 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import get from 'lodash/get';
-import cx from 'classnames';
 import { matchShape, routerShape } from 'found';
 import LocationMarker from './map/LocationMarker';
 import ItineraryLine from './map/ItineraryLine';
 import MapContainer from './map/MapContainer';
 import { otpToLocation } from '../util/otpStrings';
-import Icon from './Icon';
 import { isBrowser } from '../util/browser';
 import { dtLocationShape } from '../util/shapes';
-import { addAnalyticsEvent } from '../util/analyticsUtils';
 import withBreakpoint from '../util/withBreakpoint';
 import BackButton from './BackButton';
 import VehicleMarkerContainer from './map/VehicleMarkerContainer'; // DT-3473
@@ -26,7 +23,7 @@ let timeout;
 
 function ItineraryPageMap(
   { itinerary, center, breakpoint, bounds, streetMode },
-  { router, match, config },
+  { match, config },
 ) {
   const { from, to } = match.params;
 
@@ -78,34 +75,12 @@ function ItineraryPageMap(
       />,
     );
   }
-  const fullscreen =
-    match.location.state && match.location.state.fullscreenMap === true;
-
-  const toggleFullscreenMap = () => {
-    if (fullscreen) {
-      router.go(-1);
-    } else {
-      router.push({
-        ...match.location,
-        state: { ...match.location.state, fullscreenMap: true },
-      });
-    }
-    addAnalyticsEvent({
-      action: fullscreen ? 'MinimizeMapOnMobile' : 'MaximizeMapOnMobile',
-      category: 'Map',
-      name: 'SummaryPage',
-    });
-  };
-  const overlay = fullscreen ? undefined : (
-    /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-    <div className="map-click-prevent-overlay" onClick={toggleFullscreenMap} />
-  );
 
   if (!center && itinerary && !itinerary.legs[0].transitLeg) {
     // bounds = polyline.decode(itinerary.legs[0].legGeometry.points);
   }
 
-  const showScale = fullscreen || breakpoint === 'large';
+  const showScale = breakpoint === 'large';
 
   // onCenterMap() used to check if the layer has a marker for an itinerary
   // stop, emulate a click on the map to open up the popup
@@ -116,7 +91,7 @@ function ItineraryPageMap(
     }
     map.closePopup();
     clearTimeout(timeout);
-    if ((fullscreen && !bounds) || (breakpoint === 'large' && !bounds)) {
+    if (!bounds || (breakpoint === 'large' && !bounds)) {
       const latlngPoint = new L.LatLng(center.lat, center.lon);
       map.eachLayer(layer => {
         if (
@@ -153,22 +128,11 @@ function ItineraryPageMap(
       mapRef={onCenterMap}
       hideOrigin
     >
-      {breakpoint !== 'large' && overlay}
       <BackButton
         icon="icon-icon_arrow-collapse--left"
         iconClassName="arrow-icon"
         color={config.colors.primary}
       />
-      <div
-        className={cx('fullscreen-toggle', 'itineraryPage')}
-        onClick={toggleFullscreenMap}
-      >
-        {fullscreen ? (
-          <Icon img="icon-icon_minimize" className="cursor-pointer" />
-        ) : (
-          <Icon img="icon-icon_maximize" className="cursor-pointer" />
-        )}
-      </div>
     </MapContainer>
   );
 }

--- a/app/component/MobileView.js
+++ b/app/component/MobileView.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
-import React, { useRef, useLayoutEffect } from 'react';
+import React, { useRef, useLayoutEffect, useState } from 'react';
+import MapBottomsheetContext from './map/MapBottomsheetContext';
 
 export default function MobileView({
   header,
@@ -12,12 +13,25 @@ export default function MobileView({
     return <div className="mobile">{settingsDrawer}</div>;
   }
   const scrollRef = useRef(null);
-  const bottomsheetPosition = useRef({ default: null });
+  const topBarHeight = 64;
+  const [bottomsheetState, changeBottomsheetState] = useState({
+    position: 0,
+    context: { paddingBottomRight: [0, 0] },
+  });
   useLayoutEffect(() => {
     if (map) {
-      const sheetPaddingHeight = window.innerHeight * 0.9 - 64; // defined in map.scss
-      bottomsheetPosition.current.default = sheetPaddingHeight / 2;
-      scrollRef.current.scrollTop = bottomsheetPosition.current.default;
+      const paddingHeight = window.innerHeight * 0.9 - topBarHeight; // height of .drawer-padding, defined in map.scss
+      const newSheetPosition = paddingHeight / 2;
+      if (Math.abs(newSheetPosition - bottomsheetState.position) < 1) {
+        return;
+      }
+      const mapHeight = window.innerHeight - topBarHeight;
+      const paddingBottomRight = [0, mapHeight - mapHeight / 2];
+      scrollRef.current.scrollTop = newSheetPosition;
+      changeBottomsheetState({
+        position: newSheetPosition,
+        context: { paddingBottomRight },
+      });
     }
   }, [header, map]);
 
@@ -26,7 +40,9 @@ export default function MobileView({
       {selectFromMapHeader}
       {map ? (
         <>
-          {map}
+          <MapBottomsheetContext.Provider value={bottomsheetState.context}>
+            {map}
+          </MapBottomsheetContext.Provider>
           <div className="drawer-container" ref={scrollRef}>
             <div className="drawer-padding" />
             <div className="drawer-content">

--- a/app/component/MobileView.js
+++ b/app/component/MobileView.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useRef, useLayoutEffect } from 'react';
 
 export default function MobileView({
   header,
@@ -11,12 +11,37 @@ export default function MobileView({
   if (settingsDrawer && settingsDrawer.props.open) {
     return <div className="mobile">{settingsDrawer}</div>;
   }
+  const scrollRef = useRef(null);
+  const bottomsheetPosition = useRef({ default: null });
+  useLayoutEffect(() => {
+    if (map) {
+      const sheetPaddingHeight = window.innerHeight * 0.9 - 64; // defined in map.scss
+      bottomsheetPosition.current.default = sheetPaddingHeight / 2;
+      scrollRef.current.scrollTop = bottomsheetPosition.current.default;
+    }
+  }, [header, map]);
+
   return (
     <div className="mobile">
       {selectFromMapHeader}
-      {map}
-      {header}
-      {content}
+      {map ? (
+        <>
+          {map}
+          <div className="drawer-container" ref={scrollRef}>
+            <div className="drawer-padding" />
+            <div className="drawer-content">
+              <div className="drag-line" />
+              {header}
+              {content}
+            </div>
+          </div>
+        </>
+      ) : (
+        <>
+          {header}
+          {content}
+        </>
+      )}
     </div>
   );
 }

--- a/app/component/TopLevel.js
+++ b/app/component/TopLevel.js
@@ -157,7 +157,7 @@ class TopLevel extends React.Component {
         <DesktopOrMobile
           mobile={() => (
             <MobileView
-              map={this.disableMapOnMobile || this.props.map}
+              map={this.disableMapOnMobile ? null : this.props.map}
               content={this.props.content}
               header={this.props.header}
               selectFromMapHeader={this.props.selectFromMapHeader}

--- a/app/component/map/IndexPageMap.js
+++ b/app/component/map/IndexPageMap.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { connectToStores } from 'fluxible-addons-react';
@@ -14,7 +14,6 @@ import LazilyLoad, { importLazy } from '../LazilyLoad';
 import { dtLocationShape } from '../../util/shapes';
 import { parseLocation } from '../../util/path';
 import * as ModeUtils from '../../util/modeUtils';
-import Icon from '../Icon';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 
 const renderMapLayerSelector = () => <SelectMapLayersDialog />;
@@ -127,15 +126,9 @@ function IndexPageMap(
       />
     );
   } else {
-    const [mapExpanded, toggleFullscreen] = useState(false);
-
     map = (
       <>
-        <div
-          className={cx('flex-grow', 'map-container', {
-            expanded: mapExpanded,
-          })}
-        >
+        <div className={cx('flex-grow', 'map-container')}>
           <MapWithTracking
             breakpoint={breakpoint}
             showStops
@@ -151,22 +144,6 @@ function IndexPageMap(
             )}
           />
         </div>
-        {/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <div style={{ position: 'relative' }}>
-          <div
-            className={cx('fullscreen-toggle', {
-              expanded: mapExpanded,
-            })}
-            onClick={() => toggleFullscreen(!mapExpanded)}
-          >
-            {mapExpanded ? (
-              <Icon img="icon-icon_minimize" className="cursor-pointer" />
-            ) : (
-              <Icon img="icon-icon_maximize" className="cursor-pointer" />
-            )}
-          </div>
-        </div>
-        {/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       </>
     );
   }

--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -57,6 +57,7 @@ export default class Map extends React.Component {
     showScaleBar: false,
     mapRef: null,
     disableLocationPopup: false,
+    boundsOptions: {},
   };
 
   static contextTypes = {
@@ -109,6 +110,9 @@ export default class Map extends React.Component {
     if (this.props.padding) {
       boundsOptions.paddingTopLeft = this.props.padding;
     }
+    if (center && zoom) {
+      boundsOptions.maxZoom = zoom;
+    }
     let mapUrl =
       (isDebugTiles && `${config.URL.OTP}inspector/tile/traversal/`) ||
       config.URL.MAP;
@@ -136,15 +140,14 @@ export default class Map extends React.Component {
               this.props.mapRef(el);
             }
           }}
-          center={center}
-          zoom={zoom}
           minZoom={config.map.minZoom}
           maxZoom={config.map.maxZoom}
           zoomControl={false}
           attributionControl={false}
           bounds={
-            (this.props.fitBounds && boundWithMinimumArea(this.props.bounds)) ||
-            undefined
+            this.props.fitBounds
+              ? boundWithMinimumArea(this.props.bounds)
+              : boundWithMinimumArea([center])
           }
           animate={this.props.animate}
           {...this.props.leafletOptions}

--- a/app/component/map/MapBottomsheetContext.js
+++ b/app/component/map/MapBottomsheetContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const context = React.createContext({ paddingBottomRight: [0, 0] });
+
+export default context;

--- a/app/component/map/MapContainer.js
+++ b/app/component/map/MapContainer.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import connectToStores from 'fluxible-addons-react/connectToStores';
+import MapBottomsheetContext from './MapBottomsheetContext';
 
 import LazilyLoad, { importLazy } from '../LazilyLoad';
 
@@ -12,7 +13,18 @@ function MapContainer({ className, children, ...props }) {
   return (
     <div className={`map ${className}`}>
       <LazilyLoad modules={mapModules}>
-        {({ Map }) => <Map {...props} />}
+        {({ Map }) => {
+          return (
+            <MapBottomsheetContext.Consumer>
+              {context => {
+                const padding = context ? context.paddingBottomRight : null;
+                const { boundsOptions } = props;
+                boundsOptions.paddingBottomRight = padding;
+                return <Map boundsOptions={boundsOptions} {...props} />;
+              }}
+            </MapBottomsheetContext.Consumer>
+          );
+        }}
       </LazilyLoad>
       {children}
     </div>
@@ -22,11 +34,15 @@ function MapContainer({ className, children, ...props }) {
 MapContainer.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
+  boundsOptions: PropTypes.shape({
+    paddingBottomRight: PropTypes.arrayOf(PropTypes.number),
+  }),
 };
 
 MapContainer.defaultProps = {
   className: '',
   children: undefined,
+  boundsOptions: {},
 };
 
 export default connectToStores(MapContainer, ['PreferencesStore'], context => ({

--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -102,7 +102,7 @@ div.map {
     .icon-holder, .icon-holder:focus, .icon-holder:hover {
       padding: 0.55em 0.2em 0px 0px !important;
       font-size: 16px;
-      z-index: 805;
+      z-index: index($zindex, map-buttons);
       background: white;
       height: 2.5em;
       width: 2.5em;

--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -69,9 +69,33 @@ div.map {
     div.leaflet-control-scale.leaflet-control {
       margin-right: 15px;
     }
+    z-index: index($zindex, map-container);
   }
-  .map.full {
-    z-index: 1;
+
+  .drawer-container {
+    overflow-y: scroll;
+    height: calc(100vh - 64px); // 100% - topbar
+    position: absolute;
+    width: 100%;
+    .drawer-padding {
+      height: calc(90vh - 64px);
+      width: 0;
+    }
+    .drawer-content {
+      position: relative;
+      z-index: index($zindex, mobile-drawer);
+      .drag-line {
+        width: 30px;
+        height: 4px;
+        border-radius: 2px;
+        background-color: #cccccc;
+        display: block;
+        z-index: index($zindex, mobile-drawer-drag-line);
+        margin: auto;
+        position: relative;
+        top: -5px;
+      }
+    }
   }
 
   .back-button {

--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -81,7 +81,6 @@ $margin-left-right: 1.25em;
     background-color: transparent;
     position: relative;
     top: -15px;
-    z-index: 2;
     &.aikataulu, &.hairiot {
       top: 0;
       .route-container {

--- a/app/component/stops-near-you.scss
+++ b/app/component/stops-near-you.scss
@@ -1,7 +1,6 @@
 .map.flex-grow {
     position: relative;
     min-height: 20rem;
-    z-index: 0;
 }
 
 .stops-near-you-page {

--- a/sass/base/_zindex.scss
+++ b/sass/base/_zindex.scss
@@ -1,5 +1,5 @@
 $zindex: base, map-container, footer, map-gradient, map-fullscreen-toggle,
-  map-buttons, context-panel, search-panel, search-overlay, preferred-input, destination-input,
+  map-buttons, mobile-drawer, mobile-drawer-drag-line, context-panel, search-panel, search-overlay, preferred-input, destination-input,
   viapoint-input-5, viapoint-input-4, viapoint-input-3, viapoint-input-2,
   viapoint-input-1, origin-input, search-input-focus, search-input-icon, autosuggest-suggestion-container, front;
 $leaflet-overlay: 800;


### PR DESCRIPTION
## Proposed Changes

 - Make bottom sheet that is shown on top of map in mobile views draggable and consistent on all pages.
 - This is a first version, some improvements need to be made on future tickets
 - Map should now focus correctly on page load and not be obscured by bottom sheet.
 - There is a bug where bottom sheet is not correctly placed to middle of page on near you page, maybe this has to do with server side rendering? Resolve this in another ticket

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
