### PR TITLE
fix: bottom sheet initial position on near you and summary page

### DIFF
--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -82,6 +82,8 @@ div.map {
       width: 0;
     }
     .drawer-content {
+      min-height: 50vh;
+      background: white;
       position: relative;
       z-index: index($zindex, mobile-drawer);
       .drag-line {


### PR DESCRIPTION
## Proposed Changes

  - Fix bottom sheet not being set to middle of screen on near you page and summary page. Cause for this is that the content on those pages sometimes takes a while to load and sheet position is set asyn before that. Fix it by padding the sheet with some blank content

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
