### PR TITLE
DT-3874 and DT-3830

### DIFF
--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
@@ -10,7 +10,7 @@ import MobileDatepicker from './MobileDatepicker';
 import MobileTimepicker from './MobileTimepicker';
 import translations from './translations';
 import styles from './styles.scss';
-import isMobile from './isMobile';
+import { isMobile, isAndroid } from './mobileDetection';
 import dateTimeInputIsSupported from './dateTimeInputIsSupported';
 
 moment.tz.setDefault('Europe/Helsinki');
@@ -69,6 +69,7 @@ function Datetimepicker({
   const [htmlId] = useState(uniqueId('datetimepicker-'));
 
   const [useMobileInputs] = useState(isMobile() && dateTimeInputIsSupported());
+  const useDateTimeCombined = isAndroid();
 
   const translationSettings = { lng: lang };
 
@@ -336,6 +337,7 @@ function Datetimepicker({
                         <Icon img="calendar" />
                       </span>
                     }
+                    dateTimeCombined={useDateTimeCombined}
                   />
                 </span>
                 <span
@@ -354,6 +356,7 @@ function Datetimepicker({
                         <Icon img="time" />
                       </span>
                     }
+                    dateTimeCombined={useDateTimeCombined}
                   />
                 </span>
               </>

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
@@ -198,9 +198,11 @@ function Datetimepicker({
                           : 'arrival',
                         translationSettings,
                       )}
-                      {` ${getDateDisplay(
-                        displayTimestamp,
-                      ).toLowerCase()} ${getTimeDisplay(displayTimestamp)}`}
+                      {` ${
+                        moment().isSame(moment(displayTimestamp), 'day')
+                          ? ''
+                          : getDateDisplay(displayTimestamp).toLowerCase()
+                      } ${getTimeDisplay(displayTimestamp)}`}
                     </>
                   )}
                 </span>

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
@@ -17,6 +17,7 @@ function MobileDatepicker({
   id,
   label,
   icon,
+  dateTimeCombined,
 }) {
   const startFormatted = moment(startTime).format('YYYY-MM-DD');
   const endFormatted = moment(startTime)
@@ -38,15 +39,23 @@ function MobileDatepicker({
           {/* Hide input element and show formatted date instead for consistency between browsers */}
           <input
             id={inputId}
-            type="date"
+            type={dateTimeCombined ? 'datetime-local' : 'date'}
             className={styles['mobile-input-hidden']}
-            value={moment(value).format('YYYY-MM-DD')}
+            value={
+              dateTimeCombined
+                ? moment(value).format('YYYY-MM-DDTHH:mm')
+                : moment(value).format('YYYY-MM-DD')
+            }
             min={startFormatted}
             max={endFormatted}
             onChange={event => {
               const newValue = event.target.value;
               if (!newValue) {
                 // don't allow setting input to empty
+                return;
+              }
+              if (dateTimeCombined) {
+                onChange(moment(newValue).valueOf());
                 return;
               }
               const oldDate = moment(value);
@@ -73,10 +82,12 @@ MobileDatepicker.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   icon: PropTypes.node,
+  dateTimeCombined: PropTypes.bool,
 };
 
 MobileDatepicker.defaultProps = {
   icon: null,
+  dateTimeCombined: false,
 };
 
 export default MobileDatepicker;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
@@ -8,7 +8,15 @@ moment.tz.setDefault('Europe/Helsinki');
 /**
  * Component to display a time input on mobile
  */
-function MobileTimepicker({ value, getDisplay, onChange, id, label, icon }) {
+function MobileTimepicker({
+  value,
+  getDisplay,
+  onChange,
+  id,
+  label,
+  icon,
+  dateTimeCombined,
+}) {
   const inputId = `${id}-input`;
   const labelId = `${id}-label`;
   return (
@@ -24,13 +32,21 @@ function MobileTimepicker({ value, getDisplay, onChange, id, label, icon }) {
           {/* Hide input element and show formatted time instead for consistency between browsers */}
           <input
             id={inputId}
-            type="time"
+            type={dateTimeCombined ? 'datetime-local' : 'time'}
             className={styles['mobile-input-hidden']}
-            value={moment(value).format('HH:mm')}
+            value={
+              dateTimeCombined
+                ? moment(value).format('YYYY-MM-DDTHH:mm')
+                : moment(value).format('HH:mm')
+            }
             onChange={event => {
               const newValue = event.target.value;
               if (!newValue) {
                 // don't allow setting input to empty
+                return;
+              }
+              if (dateTimeCombined) {
+                onChange(moment(newValue).valueOf());
                 return;
               }
               const oldDate = moment(value);
@@ -52,10 +68,12 @@ MobileTimepicker.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   icon: PropTypes.node,
+  dateTimeCombined: PropTypes.bool,
 };
 
 MobileTimepicker.defaultProps = {
   icon: null,
+  dateTimeCombined: false,
 };
 
 export default MobileTimepicker;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/mobileDetection.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/mobileDetection.js
@@ -11,4 +11,12 @@ function isMobile() {
   return mobile;
 }
 
-export default isMobile;
+/**
+ * Detect if user is on an android device. Not 100% reliable.
+ */
+function isAndroid() {
+  const userAgent = navigator.userAgent.toLowerCase();
+  return userAgent.indexOf('android') > -1;
+}
+
+export { isMobile, isAndroid };


### PR DESCRIPTION
## Proposed Changes

  - For itinerary search, use native datetime picker for Android instead of separate date picker and time picker.
  - Remove "today" label for departure/arrival time when datetimepicker is closed and today is selected. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
