### PR TITLE
feat: use different primary color for walttiOpas and conf top bar color

### DIFF
--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -44,7 +44,7 @@ $content-background-color: $background-color;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: $primary-color;
+  background: $top-bar-color;
   text-align: center;
   overflow: visible; // Show drawer menu
   z-index: 1008;

--- a/sass/themes/default/_theme.scss
+++ b/sass/themes/default/_theme.scss
@@ -55,6 +55,7 @@ $slider-ok-color: #55b511;
 $selected-lang-background: rgba(0, 0, 0, 0.15);
 $caution-icon-color: $white;
 $caution-icon-font-color: none;
+$top-bar-color: $primary-color;
 
 /* Vehicle palette */
 $airplane-color: $livi-airplane-blue;

--- a/sass/themes/hsl/_theme.scss
+++ b/sass/themes/hsl/_theme.scss
@@ -29,6 +29,7 @@ $viewpoint-marker-color: $hsl-blue;
 $link-color: $primary-color;
 $desktop-title-color: #007ac9;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;
 
 /* Vehicle palette */
 $airplane-color: #0046ad;

--- a/sass/themes/joensuu/_theme.scss
+++ b/sass/themes/joensuu/_theme.scss
@@ -28,6 +28,7 @@ $from-color: $joensuu-rail-green;
 $to-color: $joensuu-orange;
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;
 
 /* Vehicle palette */
 $bus-color: $joensuu-bus-blue;

--- a/sass/themes/jyvaskyla/_theme.scss
+++ b/sass/themes/jyvaskyla/_theme.scss
@@ -15,6 +15,7 @@ $link-color: $secondary-color;
 /*Component palette*/
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;
 
 /* Navbar logo dimensions */
 $nav-logo-width: 4em;

--- a/sass/themes/kotka/_theme.scss
+++ b/sass/themes/kotka/_theme.scss
@@ -15,3 +15,4 @@ $link-color: $primary-color;
 /*Component palette*/
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;

--- a/sass/themes/kouvola/_theme.scss
+++ b/sass/themes/kouvola/_theme.scss
@@ -15,3 +15,4 @@ $link-color: $primary-color;
 /*Component palette*/
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;

--- a/sass/themes/kuopio/_theme.scss
+++ b/sass/themes/kuopio/_theme.scss
@@ -15,3 +15,4 @@ $link-color: $primary-color;
 /*Component palette*/
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;

--- a/sass/themes/lahti/_theme.scss
+++ b/sass/themes/lahti/_theme.scss
@@ -15,3 +15,4 @@ $link-color: $primary-color;
 /*Component palette*/
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;

--- a/sass/themes/lappeenranta/_theme.scss
+++ b/sass/themes/lappeenranta/_theme.scss
@@ -17,6 +17,7 @@ $link-color: $primary-color;
 /*Component palette*/
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;
 
 /* Navbar logo dimensions */
 $nav-logo-width: 240px;

--- a/sass/themes/mikkeli/_theme.scss
+++ b/sass/themes/mikkeli/_theme.scss
@@ -15,3 +15,4 @@ $link-color: $primary-color;
 /*Component palette*/
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;

--- a/sass/themes/oulu/_theme.scss
+++ b/sass/themes/oulu/_theme.scss
@@ -17,3 +17,4 @@ $link-color: $primary-color;
 /*Component palette*/
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;

--- a/sass/themes/rovaniemi/_theme.scss
+++ b/sass/themes/rovaniemi/_theme.scss
@@ -15,3 +15,4 @@ $link-color: $primary-color;
 /* Component palette */
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;

--- a/sass/themes/salo/_theme.scss
+++ b/sass/themes/salo/_theme.scss
@@ -15,3 +15,4 @@ $link-color: #c9466b;
 /* Component palette */
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;

--- a/sass/themes/tampere/_theme.scss
+++ b/sass/themes/tampere/_theme.scss
@@ -18,6 +18,7 @@ $desktop-title-color: #40ba54;
 $desktop-title-arrow-icon-color: $white;
 $caution-icon-color: #ec5e47;
 $caution-icon-font-color: $white;
+$top-bar-color: $primary-color;
 
 /* Navbar dimensions */
 $nav-logo-height: 2.5em;

--- a/sass/themes/turku/_theme.scss
+++ b/sass/themes/turku/_theme.scss
@@ -37,6 +37,7 @@ $slider-warning-color: $turku-red;
 $slider-ok-color: $turku-blue;
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $primary-color;
 
 /* Vehicle palette */
 $bus-color: $turku-light-yellow;

--- a/sass/themes/walttiOpas/_theme.scss
+++ b/sass/themes/walttiOpas/_theme.scss
@@ -1,8 +1,8 @@
 @import '../../base/waltti';
 
 /* main theme colors */
-$primary-color: #FFC439;
-$secondary-color: darken($primary-color, 20%);
+$primary-color: #F16522;
+$secondary-color: #FFC439;
 $hilight-color: $primary-color;
 $action-color: $primary-color;
 $bus-color: $primary-color;
@@ -15,6 +15,7 @@ $link-color: $primary-color;
 /* Component palette */
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $secondary-color;
+$top-bar-color: $secondary-color;
 
 /* Navbar dimensions */
 $nav-logo-height: 4em;


### PR DESCRIPTION
## Proposed Changes

  - Use different primary color for waltti-opas and use the old primary color as secondary color
  - Make top bar color configurable and use secondary for it in waltti opas config

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
