### PR TITLE
DT-3928: Itinerary summary bars render incorrectly in firefox

### DIFF
--- a/app/component/IconWithIcon.js
+++ b/app/component/IconWithIcon.js
@@ -6,7 +6,7 @@ import Icon from './Icon';
 import ComponentUsageExample from './ComponentUsageExample';
 
 const subIconTemplate = {
-  fontSize: '65%',
+  fontSize: '30px',
   position: 'absolute',
   bottom: '-4px',
   left: '-2px',

--- a/app/component/IconWithIcon.js
+++ b/app/component/IconWithIcon.js
@@ -6,7 +6,7 @@ import Icon from './Icon';
 import ComponentUsageExample from './ComponentUsageExample';
 
 const subIconTemplate = {
-  fontSize: '30px',
+  fontSize: '65%',
   position: 'absolute',
   bottom: '-4px',
   left: '-2px',

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -271,7 +271,7 @@ const SummaryRow = (
     let legLength =
       ((leg.endTime - leg.startTime) / durationWithoutSlack) * 100; // length of the current leg in %
     const longName =
-      leg.route && leg.route.shortName && leg.route.shortName.length > 3;
+      leg.route && leg.route.shortName && leg.route.shortName.length > 5;
 
     if (nextLeg && !nextLeg.intermediatePlace) {
       // don't show waiting in intermediate places

--- a/app/component/summary-row.scss
+++ b/app/component/summary-row.scss
@@ -153,6 +153,8 @@
       justify-content: center;
       &.fit-route-number {
         min-width: fit-content;
+        /* stylelint-disable-next-line */
+        min-width: -moz-fit-content;
         .vcenter-children {
           min-width: max-content !important; // forces the leg to fit the route number in it
         }

--- a/app/component/summary-row.scss
+++ b/app/component/summary-row.scss
@@ -556,7 +556,6 @@
 .mobile {
   .subicon-caution {
     left: -0.3em;
-    top: 0.5em;
   }
   .summary-clickable-area {
     border-bottom: 1px solid #ddd !important;


### PR DESCRIPTION
## Proposed Changes

  - Itinerary bars render correctly in firefox
  - Disruption icon placement in mobile

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
