### PR TITLE
DT-3933: Near you page resets bottom sheet position

### DIFF
--- a/app/component/MobileView.js
+++ b/app/component/MobileView.js
@@ -30,7 +30,7 @@ export default function MobileView({
         },
       });
     }
-  }, [header, map]);
+  }, [header]);
 
   const onScroll = e => {
     if (map) {


### PR DESCRIPTION
## Proposed Changes

  - Bottom sheet position no longer resets when map param changes
  - This might be a temporary change only. Root cause for this bug is that near you page handles map rendering a little differently than other pages. This could be refactored later.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
