### PR TITLE
DT-3952: Use same default walk speed as in old reittopas

### DIFF
--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -119,7 +119,7 @@ export default {
     unpreferredRoutes: [],
     walkBoardCost: 600,
     walkReluctance: 2,
-    walkSpeed: 1.38,
+    walkSpeed: 1.22,
     includeBikeSuggestions: true,
   },
 

--- a/build/schema.json
+++ b/build/schema.json
@@ -1628,7 +1628,7 @@
                                 },
                                 {
                                     "name": "walkSpeed",
-                                    "description": "Max walk speed along streets, in meters per second. Default value: 1.33",
+                                    "description": "Max walk speed along streets, in meters per second. Default value: 1.22",
                                     "type": {
                                         "kind": "SCALAR",
                                         "name": "Float",

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/schema.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/schema.json
@@ -1628,7 +1628,7 @@
                                 },
                                 {
                                     "name": "walkSpeed",
-                                    "description": "Max walk speed along streets, in meters per second. Default value: 1.33",
+                                    "description": "Max walk speed along streets, in meters per second. Default value: 1.22",
                                     "type": {
                                         "kind": "SCALAR",
                                         "name": "Float",


### PR DESCRIPTION
## Proposed Changes

  - Use same default walk speed as in old reittopas (1.38 --> 1.22 m/s) 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
