### PR TITLE
fix: exclude txt files from service worker

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -39,6 +39,7 @@ const productionPlugins = [
     excludes: [
       '**/.*',
       '**/*.map',
+      '**/*.txt',
       '../stats.json',
       '../manifest.json',
       '**/*.gz',


### PR DESCRIPTION
## Proposed Changes

  - Prevents service worker from caching txt files (license information)
    - We probably don't even need to include those files in the build in the first place

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
