### PR TITLE
DT-3946 Navigating back from stops near you opens location modal again and other navigating issues

### DIFF
--- a/app/component/WithSearchContext.js
+++ b/app/component/WithSearchContext.js
@@ -340,7 +340,7 @@ export default function withSearchContext(WrappedComponent) {
       if (this.context.match.location.search) {
         path += this.context.match.location.search;
       }
-      this.context.router.push(path);
+      this.context.router.replace(path);
     };
 
     onSelect = (item, id) => {


### PR DESCRIPTION
## Proposed Changes

  - Fixes so that location selection modal is not reshown when user navigates back from stops near you view

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
