### PR TITLE
DT-3939: Select from your places doesn't show up in itinerary page at first when coming from hsl.fi

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "digitransit-component autosuggest-panel module",
   "main": "lib/index.js",
   "publishConfig": {
@@ -25,7 +25,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "1.2.15",
+    "@digitransit-component/digitransit-component-autosuggest": "1.2.16",
     "@digitransit-component/digitransit-component-icon": "0.0.14",
     "@hsl-fi/sass": "^0.1.1"
   },

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "digitransit-component autosuggest module",
   "main": "lib/index.js",
   "publishConfig": {

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -269,6 +269,14 @@ class DTAutosuggest extends React.Component {
     }
   };
 
+  // Make sure change of targets is reflected immediately
+  static getDerivedStateFromProps(props, state) {
+    if (props.targets.join(',') !== state.targets.join(',')) {
+      return { targets: props.targets };
+    }
+    return null;
+  }
+
   onBlur = () => {
     this.setState({
       editing: false,


### PR DESCRIPTION
## Proposed Changes

  - Fix "your own places" button sometimes not showing on initial load in search field
  - This mainly affects the situation when page is fully reloaded (or coming from hsl.fi)
  - It is difficult to test this locally, so probably need to test again after merging to next 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
