### PR TITLE
[next] Fix display of layer switcher button

### DIFF
--- a/app/component/bubble-dialog.scss
+++ b/app/component/bubble-dialog.scss
@@ -4,6 +4,8 @@ $bubble-dialog-font-size--fullscreen: 1.5rem;
 .bubble-dialog-component-container {
   position: relative;
   z-index: auto;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  margin: 0 0 8px 8px;
 
   .bubble-dialog-container {
     bottom: 2.5em;
@@ -20,6 +22,8 @@ $bubble-dialog-font-size--fullscreen: 1.5rem;
     }
 
     .bubble-dialog {
+      position: relative;
+      right: 175px;
       background-color: $white;
       border-radius: $border-radius-bigger;
       box-shadow: $bubble-dialog-box-shadow;

--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -276,10 +276,10 @@ div.leaflet-marker-icon.vehicle-icon.small-map-icon {
 
 .map-with-tracking-buttons {
   z-index: 401;
-  bottom: 192px;
+  bottom: 157px;
   display: flex;
+  flex-direction: column;
   right: 30px;
-  max-height: 36px;
   max-width: calc(100% - 2em);
   position: absolute;
 

--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -29,6 +29,11 @@ $offcanvas-link-text-font-size: 15px;
 /* Content */
 $content-background-color: $background-color;
 
+#mainContent {
+  // so that the layer selector bubble doesn't cause scroll bars
+  overflow: hidden;
+}
+
 .top-bar-login {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Proposed Changes

This fixes the display of the layer switcher so that it can be activated without the bubble moving beyond the edge of the visible area. It also moves the bubbles underneath each other.

## Before
![Screenshot from 2020-11-04 15-57-27](https://user-images.githubusercontent.com/151346/98126978-77ef8880-1eb6-11eb-8fa9-4b26ea53029b.png)

## After
![Screenshot from 2020-11-04 15-27-36](https://user-images.githubusercontent.com/151346/98127047-889ffe80-1eb6-11eb-8974-81c61045531a.png)

### Without layer switcher
![Screenshot from 2020-11-04 15-52-33](https://user-images.githubusercontent.com/151346/98127041-876ed180-1eb6-11eb-921f-be76c50c5d0d.png)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
