### PR TITLE
DT-4044: no more filtering bike to vehicle itineraries when longest bike leg < 500

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -1086,9 +1086,7 @@ class SummaryPage extends React.Component {
         this.state.bikeParkPlan?.itineraries,
       ),
     };
-    const bikeAndPublicPlan = this.filteredbikeAndPublic(
-      this.state.bikeAndPublicPlan,
-    );
+    const { bikeAndPublicPlan } = this.state;
     const itin =
       (walkPlan && walkPlan.itineraries && walkPlan.itineraries[0]) ||
       (bikePlan && bikePlan.itineraries && bikePlan.itineraries[0]) ||
@@ -1440,9 +1438,7 @@ class SummaryPage extends React.Component {
         this.state.bikeParkPlan?.itineraries,
       ),
     };
-    const bikeAndPublicPlan = this.filteredbikeAndPublic(
-      this.state.bikeAndPublicPlan,
-    );
+    const { bikeAndPublicPlan } = this.state;
     const planHasNoItineraries =
       plan &&
       plan.itineraries &&


### PR DESCRIPTION
## Proposed Changes

  - no more filtering "bike to vehicle"-itineraries when longest bike leg < 500

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
