### PR TITLE
DT-4030: Enter departure/arrival time without colon

### DIFF
--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "digitransit-component datetimepicker module",
   "main": "lib/index.js",
   "publishConfig": {

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
@@ -84,11 +84,14 @@ function DesktopDatetimepicker({
           let actualValue = newValue;
           if (
             actualValue.length === 3 &&
-            !Number.isNaN(Number(actualValue)) &&
-            actualValue[2] !== '.'
+            actualValue.split('').every(n => Number.isInteger(Number(n)))
           ) {
             // add ':' if user types three numbers in a row
-            actualValue = `${actualValue.slice(0, 2)}:${actualValue[2]}`;
+            if (Number(actualValue.slice(0, 2)) <= 23) {
+              actualValue = `${actualValue.slice(0, 2)}:${actualValue[2]}`;
+            } else {
+              actualValue = `${actualValue[0]}:${actualValue.slice(1)}`;
+            }
           }
           changeDisplayValue(actualValue);
         }

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
@@ -81,7 +81,16 @@ function DesktopDatetimepicker({
     switch (method) {
       case 'type':
         if (!disableTyping) {
-          changeDisplayValue(newValue);
+          let actualValue = newValue;
+          if (
+            actualValue.length === 3 &&
+            !Number.isNaN(Number(actualValue)) &&
+            actualValue[2] !== '.'
+          ) {
+            // add ':' if user types three numbers in a row
+            actualValue = `${actualValue.slice(0, 2)}:${actualValue[2]}`;
+          }
+          changeDisplayValue(actualValue);
         }
         break;
       case 'inputenter':


### PR DESCRIPTION
## Proposed Changes

  - Insert colon automatically in time picker if user skips typing it

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
