### PR TITLE
Add ability to set attribution text in configuration

### DIFF
--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -9,6 +9,7 @@ import AttributionControl from 'react-leaflet/es/AttributionControl';
 import ScaleControl from 'react-leaflet/es/ScaleControl';
 import ZoomControl from 'react-leaflet/es/ZoomControl';
 import L from 'leaflet';
+import { get, isString, isEmpty } from 'lodash';
 // Webpack handles this by bundling it with the other css files
 import 'leaflet/dist/leaflet.css';
 
@@ -153,6 +154,12 @@ export default class Map extends React.Component {
         />,
       );
     }
+
+    let attribution = get(config, 'map.attribution');
+    if (!isString(attribution) || isEmpty(attribution)) {
+      attribution = false;
+    }
+
     return (
       <div aria-hidden="true">
         <span
@@ -204,15 +211,16 @@ export default class Map extends React.Component {
             }
             minZoom={config.map.minZoom}
             maxZoom={config.map.maxZoom}
+            attribution={attribution}
           />
           <BreakpointConsumer>
             {breakpoint =>
-              config.map.showOSMCopyright && (
+              attribution && (
                 <AttributionControl
                   position={
                     breakpoint === 'large' ? 'bottomright' : 'bottomleft'
                   }
-                  prefix='<a tabindex="-1" href="http://osm.org/copyright">&copy; OpenStreetMap</a>'
+                  prefix=""
                 />
               )
             }

--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -6,7 +6,6 @@ div.map {
   max-height: 100%;
   position: relative;
   .leaflet-container .leaflet-control-attribution {
-    width: 107px;
     height: 22px;
     opacity: 0.7;
     border-radius: 11px;
@@ -24,7 +23,6 @@ div.map {
     padding: 0;
   }
   .leaflet-container .leaflet-control-attribution a {
-    width: 94px;
     height: 11px;
     font-family: $font-family;
     font-size: 11px;

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -235,7 +235,8 @@ export default {
     showLayerSelector: true, // DT-3470
     showStopMarkerPopupOnMobile: true, // DT-3470
     showScaleBar: true, // DT-3470
-    showOSMCopyright: true, // DT-3470, DT-3397
+    attribution:
+      '<a tabIndex="-1" href="http://osm.org/copyright">© OpenStreetMap</a>', // DT-3470, DT-3397
 
     useModeIconsInNonTileLayer: false,
   },

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -459,7 +459,8 @@ export default {
     showLayerSelector: false, // DT-3470
     showStopMarkerPopupOnMobile: false, // DT-3470
     showScaleBar: true, // DT-3470, DT-3397
-    showOSMCopyright: true, // DT-3470, DT-3397
+    attribution:
+      '<a tabindex="-1" href="http://osm.org/copyright">© OpenStreetMap</a>', // DT-3470, DT-3397
   },
 
   stopCard: {


### PR DESCRIPTION
## Proposed Changes

As discussed in #3670 I've added the ability to set a custom map attribution.

Here is how it looks like:

### Current HSL attribution

![Screenshot from 2020-11-06 10-55-28](https://user-images.githubusercontent.com/151346/98352818-d172c700-201e-11eb-85f5-186d647532b9.png)

### A custom attribution
![Screenshot from 2020-11-06 10-53-35](https://user-images.githubusercontent.com/151346/98352825-d3d52100-201e-11eb-9a88-f4c3fd5b98f1.png)

### No attribution at all
![Screenshot from 2020-11-06 10-54-23](https://user-images.githubusercontent.com/151346/98352820-d2a3f400-201e-11eb-94d5-7b563929ba0e.png)

I've used lodash's `get` method to get the config variable as I didn't want to rely on the field `config.map` being present, but maybe that's not in line with how the rest of the config vars are being read. Let me know if you would like me to change it.

Closes #3670 .

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
