### PR TITLE
DT-4017 Vehicles for earlier/later departures are never shown on map and DT-4048 Reset itinerary index after earlier/later searches

### DIFF
--- a/app/component/StreetModeSelector.js
+++ b/app/component/StreetModeSelector.js
@@ -21,8 +21,8 @@ export const StreetModeSelector = ({
   const bikeAndVehicle = !loading
     ? {
         itineraries: [
-          ...bikeParkPlan.itineraries,
-          ...bikeAndPublicPlan.itineraries,
+          ...bikeParkPlan?.itineraries,
+          ...bikeAndPublicPlan?.itineraries,
         ],
       }
     : {};

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -205,6 +205,9 @@ const getTopicOptions = (context, planitineraries, match) => {
 };
 
 const getVehicleInfos = itinerary => {
+  if (!itinerary) {
+    return {};
+  }
   let itineraryVehicles = {};
   const gtfsIdsOfRouteAndDirection = [];
   const gtfsIdsOfTrip = [];

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -310,9 +310,10 @@ class SummaryPage extends React.Component {
     }
 
     if (this.showVehicles()) {
+      const combinedItineraries = this.getCombinedItineraries();
       const itineraryTopics = getTopicOptions(
         this.context,
-        this.selectedPlan?.itineraries,
+        combinedItineraries,
         this.props.match,
       );
       if (itineraryTopics && itineraryTopics.length > 0) {
@@ -1004,9 +1005,10 @@ class SummaryPage extends React.Component {
       reportError(this.props.error);
     }
     if (this.showVehicles()) {
+      const combinedItineraries = this.getCombinedItineraries();
       const itineraryTopics = getTopicOptions(
         this.context,
-        this.selectedPlan?.itineraries,
+        combinedItineraries,
         this.props.match,
       );
       if (itineraryTopics && itineraryTopics.length > 0) {
@@ -1185,11 +1187,7 @@ class SummaryPage extends React.Component {
       config: { defaultEndpoint },
     } = this.context;
 
-    const combinedItineraries = [
-      ...(this.state.earlierItineraries || []),
-      ...(this.selectedPlan.itineraries || []),
-      ...(this.state.laterItineraries || []),
-    ];
+    const combinedItineraries = this.getCombinedItineraries();
     let filteredItineraries;
     if (combinedItineraries && combinedItineraries.length > 0) {
       filteredItineraries = combinedItineraries.filter(
@@ -1427,6 +1425,14 @@ class SummaryPage extends React.Component {
     });
   };
 
+  getCombinedItineraries = () => {
+    return [
+      ...(this.state.earlierItineraries || []),
+      ...(this.selectedPlan.itineraries || []),
+      ...(this.state.laterItineraries || []),
+    ];
+  };
+
   render() {
     const { match, error } = this.props;
     const { walkPlan, bikePlan } = this.state;
@@ -1604,11 +1610,7 @@ class SummaryPage extends React.Component {
         });
       }
     }
-    let combinedItineraries = [
-      ...(this.state.earlierItineraries || []),
-      ...(this.selectedPlan.itineraries || []),
-      ...(this.state.laterItineraries || []),
-    ];
+    let combinedItineraries = this.getCombinedItineraries();
 
     if (
       combinedItineraries &&

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-nested-ternary */
-/* eslint-disable no-console */
 import connectToStores from 'fluxible-addons-react/connectToStores';
 import moment from 'moment';
 import PropTypes from 'prop-types';
@@ -403,6 +402,13 @@ class SummaryPlanContainer extends React.Component {
           this.setState({
             loadingMoreItineraries: undefined,
           });
+          this.context.router.replace({
+            ...this.context.match.location,
+            state: {
+              ...this.context.match.location.state,
+              summaryPageSelected: undefined,
+            },
+          });
         } else {
           this.props.addLaterItineraries(result.itineraries);
           this.setState({
@@ -700,6 +706,13 @@ class SummaryPlanContainer extends React.Component {
           );
           this.setState({
             loadingMoreItineraries: undefined,
+          });
+          this.context.router.replace({
+            ...this.context.match.location,
+            state: {
+              ...this.context.match.location.state,
+              summaryPageSelected: undefined,
+            },
           });
         }
       },

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -880,78 +880,8 @@ const connectedContainer = createFragmentContainer(
         date
       }
     `,
-    earlierItineraries: graphql`
-      fragment SummaryPlanContainer_earlierItineraries on Itinerary
-      @relay(plural: true) {
-        ...ItinerarySummaryListContainer_itineraries
-        endTime
-        startTime
-        legs {
-          mode
-          to {
-            bikePark {
-              bikeParkId
-              name
-            }
-          }
-          ...ItineraryLine_legs
-          transitLeg
-          legGeometry {
-            points
-          }
-          route {
-            gtfsId
-          }
-          trip {
-            gtfsId
-            directionId
-            stoptimesForDate {
-              scheduledDeparture
-            }
-            pattern {
-              ...RouteLine_pattern
-            }
-          }
-        }
-      }
-    `,
     itineraries: graphql`
       fragment SummaryPlanContainer_itineraries on Itinerary
-      @relay(plural: true) {
-        ...ItinerarySummaryListContainer_itineraries
-        endTime
-        startTime
-        legs {
-          mode
-          to {
-            bikePark {
-              bikeParkId
-              name
-            }
-          }
-          ...ItineraryLine_legs
-          transitLeg
-          legGeometry {
-            points
-          }
-          route {
-            gtfsId
-          }
-          trip {
-            gtfsId
-            directionId
-            stoptimesForDate {
-              scheduledDeparture
-            }
-            pattern {
-              ...RouteLine_pattern
-            }
-          }
-        }
-      }
-    `,
-    laterItineraries: graphql`
-      fragment SummaryPlanContainer_laterItineraries on Itinerary
       @relay(plural: true) {
         ...ItinerarySummaryListContainer_itineraries
         endTime

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -371,6 +371,7 @@ class SummaryPlanContainer extends React.Component {
                 }
               }
               trip {
+                directionId
                 gtfsId
                 tripHeadsign
                 stoptimesForDate {
@@ -646,6 +647,7 @@ class SummaryPlanContainer extends React.Component {
                 }
               }
               trip {
+                directionId
                 gtfsId
                 tripHeadsign
                 stoptimesForDate {

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -742,7 +742,9 @@ class SummaryPlanContainer extends React.Component {
             id: 'set-time-later-button-label',
             defaultMessage: 'Set travel time to later',
           })}
-          className="time-navigation-btn later"
+          className={`time-navigation-btn ${
+            reversed ? 'top-btn' : 'bottom-btn'
+          }`}
           onClick={() => this.onLater(reversed)}
         >
           <Icon
@@ -768,7 +770,9 @@ class SummaryPlanContainer extends React.Component {
             id: 'set-time-earlier-button-label',
             defaultMessage: 'Set travel time to earlier',
           })}
-          className="time-navigation-btn earlier"
+          className={`time-navigation-btn ${
+            reversed ? 'bottom-btn' : 'top-btn'
+          }`}
           onClick={() => this.onEarlier(reversed)}
         >
           <Icon

--- a/app/component/summary.scss
+++ b/app/component/summary.scss
@@ -408,10 +408,10 @@
     transform: rotate(180deg);
   }
 
-  &.earlier {
+  &.top-btn {
     font-size: 13px;
   }
-  &.later {
+  &.bottom-btn {
     border-top: 1px solid #ddd;
     font-size: $font-size-normal;
     height: 50px;


### PR DESCRIPTION
## Proposed Changes

  - Show vehicles for earlier and later itineraries
  - Show vehicles when examining some itinerary that was not highlighted in the summary view
     - Also don't show vehicles that are not related to the itinerary
  - Always show earlier/later button that is on the top of the list smaller than the earlier/later button that is on the bottom of the list
  - If user searches for more itineraries that will be put on the top of the list, reset highlighted itinerary index

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
