### PR TITLE
DT-4065 Opening summary page can cause multiple selectMapPoint analytics events

### DIFF
--- a/app/component/map/non-tile-layer/StopMarker.js
+++ b/app/component/map/non-tile-layer/StopMarker.js
@@ -41,6 +41,25 @@ class StopMarker extends React.Component {
   };
 
   redirectToStopPage = () => {
+    if (
+      window.location.pathname.indexOf('bike') === -1 &&
+      window.location.pathname.indexOf('walk') === -1
+    ) {
+      const pathPrefixMatch = window.location.pathname.match(
+        /^\/([a-z]{2,})\//,
+      );
+      const context =
+        pathPrefixMatch && pathPrefixMatch[1] !== this.context.config.indexPath
+          ? pathPrefixMatch[1]
+          : 'index';
+      addAnalyticsEvent({
+        action: 'SelectMapPoint',
+        category: 'Map',
+        name: 'stop',
+        type: this.props.mode.toUpperCase(),
+        context,
+      });
+    }
     const prefix = PREFIX_STOPS;
     this.context.router.push(
       `/${prefix}/${encodeURIComponent(this.props.stop.gtfsId)}`,
@@ -114,23 +133,6 @@ class StopMarker extends React.Component {
       return '';
     }
 
-    const pathPrefixMatch = window.location.pathname.match(/^\/([a-z]{2,})\//);
-    const context =
-      pathPrefixMatch && pathPrefixMatch[1] !== this.context.config.indexPath
-        ? pathPrefixMatch[1]
-        : 'index';
-    if (
-      window.location.pathname.indexOf('bike') === -1 &&
-      window.location.pathname.indexOf('walk') === -1
-    ) {
-      addAnalyticsEvent({
-        action: 'SelectMapPoint',
-        category: 'Map',
-        name: 'stop',
-        type: this.props.mode.toUpperCase(),
-        context,
-      });
-    }
     return (
       <GenericMarker
         position={{


### PR DESCRIPTION
## Proposed Changes

  - Only send SelectMapPoint analytics event on StopMarker click instead of doing it on every render

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
