### PR TITLE
DT-4074: If user uses or has used own location as location in autosuggest, mobile search keeps reseting list position

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -25,7 +25,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "1.2.23",
+    "@digitransit-component/digitransit-component-autosuggest": "1.2.24",
     "@digitransit-component/digitransit-component-icon": "0.0.14",
     "@hsl-fi/sass": "^0.1.1"
   },

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "description": "digitransit-component autosuggest module",
   "main": "lib/index.js",
   "publishConfig": {

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -15,6 +15,7 @@ import { getStopName } from '@digitransit-search-util/digitransit-search-util-he
 import getLabel from '@digitransit-search-util/digitransit-search-util-get-label';
 import Icon from '@digitransit-component/digitransit-component-icon';
 import moment from 'moment-timezone';
+import isEqual from 'lodash/isEqual';
 import translations from './helpers/translations';
 import styles from './helpers/styles.scss';
 import MobileSearch from './helpers/MobileSearch';
@@ -225,6 +226,19 @@ class DTAutosuggest extends React.Component {
       suggestionIndex: 0,
       cleanExecuted: false,
     };
+  }
+
+  // DT-4074: When a user's location is updated DTAutosuggest would re-render causing suggestion list to reset.
+  // This will prevent it.
+  shouldComponentUpdate(nextProps, nextState) {
+    return (
+      !isEqual(nextState.suggestions, this.state.suggestions) ||
+      nextState.editing !== this.state.editing ||
+      !isEqual(nextState.value, this.state.value) ||
+      nextState.valid !== this.state.valid ||
+      nextState.renderMobileSearch !== this.state.renderMobileSearch ||
+      nextState.typing !== this.state.typing
+    );
   }
 
   componentDidUpdate = prevProps => {

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -231,14 +231,7 @@ class DTAutosuggest extends React.Component {
   // DT-4074: When a user's location is updated DTAutosuggest would re-render causing suggestion list to reset.
   // This will prevent it.
   shouldComponentUpdate(nextProps, nextState) {
-    return (
-      !isEqual(nextState.suggestions, this.state.suggestions) ||
-      nextState.editing !== this.state.editing ||
-      !isEqual(nextState.value, this.state.value) ||
-      nextState.valid !== this.state.valid ||
-      nextState.renderMobileSearch !== this.state.renderMobileSearch ||
-      nextState.typing !== this.state.typing
-    );
+    return !isEqual(nextState, this.state) || !isEqual(nextProps, this.props);
   }
 
   componentDidUpdate = prevProps => {


### PR DESCRIPTION
## Proposed Changes

  - Fixed issue described in title

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
