### PR TITLE
DT-4088: Select from own locations does not show up in stops near you entry autosuggest

### DIFF
--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -574,9 +574,15 @@ const StopsNearYouPageWithBreakpoint = withBreakpoint(props => (
 
 const PositioningWrapper = connectToStores(
   StopsNearYouPageWithBreakpoint,
-  ['PositionStore', 'PreferencesStore'],
+  ['PositionStore', 'PreferencesStore', 'FavouriteStore'],
   (context, props) => {
     const lang = context.getStore('PreferencesStore').getLanguage();
+    if (
+      context.config.allowLogin &&
+      context.getStore('UserStore').getUser().sub !== undefined
+    ) {
+      context.getStore('FavouriteStore').getFavourites();
+    }
     const { params, location } = props.match;
     const { place } = params;
     if (place !== 'POS') {


### PR DESCRIPTION
## Proposed Changes

  - Own places show up on the first click 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
