### PR TITLE
DT-4070: bike+public view bugs and optimizations

### DIFF
--- a/app/component/ItinerarySummaryListContainer.js
+++ b/app/component/ItinerarySummaryListContainer.js
@@ -50,7 +50,7 @@ function ItinerarySummaryListContainer(
     const summaries = itineraries.map((itinerary, i) => (
       <SummaryRow
         refTime={searchTime}
-        key={`${itinerary.startTime}-${itinerary.endTime}`}
+        key={i} // eslint-disable-line react/no-array-index-key
         hash={i}
         data={itinerary}
         passive={i !== activeIndex}
@@ -71,36 +71,39 @@ function ItinerarySummaryListContainer(
       context.match.params.hash &&
       context.match.params.hash === 'bikeAndVehicle'
     ) {
-      summaries.splice(
-        0,
-        0,
-        <ItinerarySummarySubtitle
-          translationId="itinerary-summary.bikePark-title"
-          defaultMessage="Biking \u0026 public transport \u0026 walking"
-          key="itinerary-summary.bikePark-title"
-        />,
-      );
-
+      if (bikeAndParkItinerariesToShow > 0) {
+        summaries.splice(
+          0,
+          0,
+          <ItinerarySummarySubtitle
+            translationId="itinerary-summary.bikePark-title"
+            defaultMessage="Biking \u0026 public transport \u0026 walking"
+            key="itinerary-summary.bikePark-title"
+          />,
+        );
+      }
       if (
         itineraries.length > bikeAndParkItinerariesToShow &&
         bikeAndPublicItinerariesToShow > 0
       ) {
-        const bikeAndParkItineraries = itineraries.slice(
+        const bikeAndPublicItineraries = itineraries.slice(
           bikeAndParkItinerariesToShow,
         );
-        const filteredBikeAndParkItineraries = bikeAndParkItineraries.map(i =>
-          i.legs.filter(obj => obj.mode !== 'WALK' && obj.mode !== 'BICYCLE'),
+        const filteredBikeAndPublicItineraries = bikeAndPublicItineraries.map(
+          i =>
+            i.legs.filter(obj => obj.mode !== 'WALK' && obj.mode !== 'BICYCLE'),
         );
         const allModes = Array.from(
           new Set(
-            filteredBikeAndParkItineraries.length > 0
-              ? filteredBikeAndParkItineraries.map(p => p[0].mode.toLowerCase())
+            filteredBikeAndPublicItineraries.length > 0
+              ? filteredBikeAndPublicItineraries.map(p =>
+                  p[0].mode.toLowerCase(),
+                )
               : [],
           ),
         );
-
         summaries.splice(
-          bikeAndParkItinerariesToShow + 1,
+          bikeAndParkItinerariesToShow ? bikeAndParkItinerariesToShow + 1 : 0,
           0,
           <ItinerarySummarySubtitle
             translationId={`itinerary-summary.bikeAndPublic-${allModes

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -300,29 +300,12 @@ class SummaryPage extends React.Component {
     }
     this.resultsUpdatedAlertRef = React.createRef();
 
-    // set state correctly if user enters the page from a link
-    let existingStreetMode;
-    if (this.props.match.location && this.props.match.location.state) {
-      existingStreetMode = this.props.match.location.state.streetMode;
-    } else if (
-      this.props.match.params &&
-      this.props.match.params.hash &&
-      (this.props.match.params.hash === 'walk' ||
-        this.props.match.params.hash === 'bike' ||
-        this.props.match.params.hash === 'bikeAndVehicle')
-    ) {
-      existingStreetMode = this.props.match.params.hash;
-    } else {
-      existingStreetMode = '';
-    }
-
     this.state = {
       weatherData: {},
       center: null,
       loading: false,
       settingsOpen: false,
       bounds: null,
-      streetMode: existingStreetMode,
       alternativePlan: undefined,
       earlierItineraries: [],
       laterItineraries: [],
@@ -334,11 +317,11 @@ class SummaryPage extends React.Component {
       bikeParkPlan: undefined,
       scrolled: false,
     };
-    if (this.state.streetMode === 'walk') {
+    if (this.props.match.params.hash === 'walk') {
       this.selectedPlan = this.state.walkPlan;
-    } else if (this.state.streetMode === 'bike') {
+    } else if (this.props.match.params.hash === 'bike') {
       this.selectedPlan = this.state.bikePlan;
-    } else if (this.state.streetMode === 'bikeAndVehicle') {
+    } else if (this.props.match.params.hash === 'bikeAndVehicle') {
       this.selectedPlan = {
         itineraries: [
           ...this.state.bikeParkPlan?.itineraries,
@@ -385,40 +368,22 @@ class SummaryPage extends React.Component {
   };
 
   toggleStreetMode = newStreetMode => {
-    if (this.state.streetMode === newStreetMode) {
-      this.setState({ streetMode: '' }, () => {
-        const newState = {
-          ...this.context.match.location,
-          state: { streetMode: '' },
-        };
-        const indexPath = `${getRoutePath(
-          this.context.match.params.from,
-          this.context.match.params.to,
-        )}`;
-        newState.pathname = indexPath;
-        this.context.router.push(newState);
-      });
-    } else {
-      this.setState({ streetMode: newStreetMode }, () => {
-        const newState = {
-          ...this.context.match.location,
-          state: { streetMode: newStreetMode },
-        };
-        const basePath = getRoutePath(
-          this.context.match.params.from,
-          this.context.match.params.to,
-        );
-        const indexPath = `${getRoutePath(
-          this.context.match.params.from,
-          this.context.match.params.to,
-        )}/${newStreetMode}/`;
+    const newState = {
+      ...this.context.match.location,
+    };
+    const basePath = getRoutePath(
+      this.context.match.params.from,
+      this.context.match.params.to,
+    );
+    const indexPath = `${getRoutePath(
+      this.context.match.params.from,
+      this.context.match.params.to,
+    )}/${newStreetMode}/`;
 
-        newState.pathname = basePath;
-        this.context.router.replace(newState);
-        newState.pathname = indexPath;
-        this.context.router.push(newState);
-      });
-    }
+    newState.pathname = basePath;
+    this.context.router.replace(newState);
+    newState.pathname = indexPath;
+    this.context.router.push(newState);
   };
 
   setStreetModeAndSelect = newStreetMode => {
@@ -430,24 +395,13 @@ class SummaryPage extends React.Component {
       action: 'OpenItineraryDetailsWithMode',
       name: newStreetMode,
     });
-    this.setState(
-      { streetMode: newStreetMode },
-      this.selectFirstItinerary(newStreetMode),
-    );
-  };
-
-  setStreetMode = newStreetMode => {
-    this.setState({ streetMode: newStreetMode });
-  };
-
-  resetStreetMode = () => {
-    this.setState({ streetMode: '' });
+    this.selectFirstItinerary(newStreetMode);
   };
 
   selectFirstItinerary = newStreetMode => {
     const newState = {
       ...this.context.match.location,
-      state: { summaryPageSelected: 0, streetMode: newStreetMode },
+      state: { summaryPageSelected: 0 },
     };
 
     const basePath = `${getRoutePath(
@@ -973,7 +927,7 @@ class SummaryPage extends React.Component {
         this.props.match.params.hash === 'bike' ||
         this.props.match.params.hash === 'bikeAndVehicle')
     ) {
-      // Reset url and thus streetmode if intermediate places change
+      // Reset streetmode selection if intermediate places change
       if (
         !isEqual(
           getIntermediatePlaces(prevProps.match.location.query),
@@ -982,7 +936,6 @@ class SummaryPage extends React.Component {
       ) {
         const newState = {
           ...this.context.match.location,
-          state: { streetMode: '' },
         };
         const indexPath = `${getRoutePath(
           this.context.match.params.from,
@@ -990,19 +943,6 @@ class SummaryPage extends React.Component {
         )}`;
         newState.pathname = indexPath;
         this.context.router.push(newState);
-      }
-      if (this.state.streetMode !== this.props.match.params.hash) {
-        this.setStreetMode(this.props.match.params.hash);
-      }
-    } else if (
-      !this.props.match.params ||
-      !this.props.match.params.hash ||
-      (this.props.match.params.hash === '' &&
-        (!this.props.match.params.secondHash ||
-          this.props.match.params.secondHash === ''))
-    ) {
-      if (this.state.streetMode !== '' && !this.state.summaryPageSelected) {
-        this.resetStreetMode();
       }
     }
 
@@ -1324,7 +1264,7 @@ class SummaryPage extends React.Component {
           key="fromMarker"
           position={from}
           type="from"
-          streetMode={this.state.streetMode}
+          streetMode={this.props.match.params.hash}
         />,
       );
     }
@@ -1335,7 +1275,7 @@ class SummaryPage extends React.Component {
           key="toMarker"
           position={to}
           type="to"
-          streetMode={this.state.streetMode}
+          streetMode={this.props.match.params.hash}
         />,
       );
     }
@@ -1541,38 +1481,33 @@ class SummaryPage extends React.Component {
       this.state.alternativePlan.itineraries &&
       this.state.alternativePlan.itineraries.length > 0;
 
-    this.onlyBikeParkItineraries = false;
     this.bikeAndPublicItinerariesToShow = 0;
     this.bikeAndParkItinerariesToShow = 0;
-    if (this.state.streetMode === 'walk') {
+    if (this.props.match.params.hash === 'walk') {
       this.stopClient();
       if (!walkPlan) {
         return <Loading />;
       }
       this.selectedPlan = walkPlan;
-    } else if (this.state.streetMode === 'bike') {
+    } else if (this.props.match.params.hash === 'bike') {
       this.stopClient();
       if (!bikePlan) {
         return <Loading />;
       }
       this.selectedPlan = bikePlan;
-    } else if (this.state.streetMode === 'bikeAndVehicle') {
-      if (!bikeAndPublicPlan || !bikeParkPlan) {
+    } else if (this.props.match.params.hash === 'bikeAndVehicle') {
+      if (
+        !bikeAndPublicPlan ||
+        !Array.isArray(bikeAndPublicPlan.itineraries) ||
+        !bikeParkPlan ||
+        !Array.isArray(bikeParkPlan.itineraries)
+      ) {
         return <Loading />;
       }
       if (
         this.hasItinerariesContainingPublicTransit(bikeAndPublicPlan) &&
         this.hasItinerariesContainingPublicTransit(bikeParkPlan)
       ) {
-        this.bikeAndPublicItinerariesToShow = Math.min(
-          bikeAndPublicPlan.itineraries.length,
-          3,
-        );
-        this.bikeAndParkItinerariesToShow = Math.min(
-          bikeParkPlan.itineraries.length,
-          3,
-        );
-
         this.selectedPlan = {
           itineraries: [
             ...bikeParkPlan.itineraries.slice(0, 3),
@@ -1583,10 +1518,17 @@ class SummaryPage extends React.Component {
         this.hasItinerariesContainingPublicTransit(bikeAndPublicPlan)
       ) {
         this.selectedPlan = bikeAndPublicPlan;
-      } else {
+      } else if (this.hasItinerariesContainingPublicTransit(bikeParkPlan)) {
         this.selectedPlan = bikeParkPlan;
-        this.onlyBikeParkItineraries = true;
       }
+      this.bikeAndPublicItinerariesToShow = Math.min(
+        bikeAndPublicPlan.itineraries.length,
+        3,
+      );
+      this.bikeAndParkItinerariesToShow = Math.min(
+        bikeParkPlan.itineraries.length,
+        3,
+      );
     } else if (
       planHasNoItineraries &&
       hasAlternativeItineraries &&
@@ -1648,7 +1590,7 @@ class SummaryPage extends React.Component {
       (showWalkOptionButton ||
         showBikeOptionButton ||
         showBikeAndPublicOptionButton) &&
-      this.state.streetMode !== 'bikeAndVehicle';
+      this.props.match.params.hash !== 'bikeAndVehicle';
 
     const hasItineraries =
       this.selectedPlan && Array.isArray(this.selectedPlan.itineraries);
@@ -1658,8 +1600,8 @@ class SummaryPage extends React.Component {
       !isEqual(this.selectedPlan, this.state.previouslySelectedPlan)
     ) {
       if (
-        this.state.streetMode !== 'walk' &&
-        this.state.streetMode !== 'bike'
+        this.props.match.params.hash !== 'walk' &&
+        this.props.match.params.hash !== 'bike'
       ) {
         this.setState({
           previouslySelectedPlan: this.selectedPlan,
@@ -1681,7 +1623,7 @@ class SummaryPage extends React.Component {
     if (
       combinedItineraries &&
       combinedItineraries.length > 0 &&
-      this.state.streetMode !== 'walk'
+      this.props.match.params.hash !== 'walk'
     ) {
       combinedItineraries = combinedItineraries.filter(
         itinerary => !itinerary.legs.every(leg => leg.mode === 'WALK'),
@@ -1764,7 +1706,7 @@ class SummaryPage extends React.Component {
     // Call props.map directly in order to render to same map instance
     let map;
     if (
-      this.state.streetMode === 'bikeAndVehicle' &&
+      this.props.match.params.hash === 'bikeAndVehicle' &&
       !routeSelected(
         match.params.hash,
         match.params.secondHash,


### PR DESCRIPTION
## Proposed Changes

  - bike+vehicle correct heading if only bikeAndPublic itineraries and no bikeAndPark
  - reduced unnecessary renders on changing view to bike+vehicle by removing unnecessary state from summaryPage: 
    streetmode
  - reverted summaryRow key prop (duplicate key lead to "ghost" itineraries on bike+vehicle view)
  - renamed variable correctly in ItinerarySummaryListContainer 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
