### PR TITLE
Add opportunity to disable "next" column in Route panel on Next

### DIFF
--- a/app/component/PatternStopsContainer.js
+++ b/app/component/PatternStopsContainer.js
@@ -17,6 +17,10 @@ class PatternStopsContainer extends React.PureComponent {
     router: routerShape.isRequired,
   };
 
+  static contextTypes = {
+    config: PropTypes.object.isRequired,
+  };
+
   toggleFullscreenMap = () => {
     if (
       this.props.match.location.state &&
@@ -51,6 +55,7 @@ class PatternStopsContainer extends React.PureComponent {
       >
         <RouteListHeader
           key="header"
+          displayNextDeparture={this.context.config.displayNextDeparture}
           className={`bp-${this.props.breakpoint}`}
         />
         <RouteStopListContainer

--- a/app/component/RouteListHeader.js
+++ b/app/component/RouteListHeader.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import cx from 'classnames';
 
-const RouteListHeader = ({ className }) => (
+const RouteListHeader = ({ displayNextDeparture, className }) => (
   <div
     className={cx(
       'route-list-header route-stop row padding-vertical-small',
@@ -19,14 +19,21 @@ const RouteListHeader = ({ className }) => (
     <div className="route-stop-time">
       <FormattedMessage id="leaves" defaultMessage="Leaves" />
     </div>
-    <div className="route-stop-time">
-      <FormattedMessage id="next" defaultMessage="Next" />
-    </div>
+    {displayNextDeparture && (
+      <div className="route-stop-time">
+        <FormattedMessage id="next" defaultMessage="Next" />
+      </div>
+    )}
   </div>
 );
 
 RouteListHeader.propTypes = {
   className: PropTypes.string,
+  displayNextDeparture: PropTypes.bool,
+};
+
+RouteListHeader.defaultProps = {
+  displayNextDeparture: true,
 };
 
 export default RouteListHeader;

--- a/app/component/RouteStop.js
+++ b/app/component/RouteStop.js
@@ -51,6 +51,11 @@ class RouteStop extends React.PureComponent {
     distance: PropTypes.number,
     currentTime: PropTypes.number.isRequired,
     last: PropTypes.bool,
+    displayNextDeparture: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    displayNextDeparture: true,
   };
 
   static description = () => (
@@ -129,6 +134,7 @@ class RouteStop extends React.PureComponent {
       mode,
       stop,
       vehicle,
+      displayNextDeparture,
     } = this.props;
     const patternExists =
       stop.stopTimesForPattern && stop.stopTimesForPattern.length > 0;
@@ -206,14 +212,23 @@ class RouteStop extends React.PureComponent {
               </div>
               {patternExists && (
                 <div className="departure-times-container">
-                  {stop.stopTimesForPattern.map(stopTime => (
+                  {displayNextDeparture ? (
+                    stop.stopTimesForPattern.map(stopTime => (
+                      <div
+                        key={stopTime.scheduledDeparture}
+                        className="route-stop-time"
+                      >
+                        {fromStopTime(stopTime, currentTime)}
+                      </div>
+                    ))
+                  ) : (
                     <div
-                      key={stopTime.scheduledDeparture}
+                      key={stop.stopTimesForPattern[0].scheduledDeparture}
                       className="route-stop-time"
                     >
-                      {fromStopTime(stopTime, currentTime)}
+                      {fromStopTime(stop.stopTimesForPattern[0], currentTime)}
                     </div>
-                  ))}
+                  )}
                 </div>
               )}
             </div>

--- a/app/component/RouteStopListContainer.js
+++ b/app/component/RouteStopListContainer.js
@@ -83,6 +83,7 @@ class RouteStopListContainer extends React.PureComponent {
           last={i === stops.length - 1}
           first={i === 0}
           className={rowClassName}
+          displayNextDeparture={this.context.config.displayNextDeparture}
         />
       );
     });

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -774,4 +774,7 @@ export default {
   nearYouModes: [],
 
   zoneIconsAsSvg: false,
+
+  /* Option to disable the "next" column of the Route panel as it can be confusing sometimes: https://github.com/mfdz/digitransit-ui/issues/167 */
+  displayNextDeparture: true,
 };

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "request": "2.88.2",
     "serialize-javascript": "4.0.0",
     "suncalc": "1.8.0",
+    "trim-right": "1.0.1",
     "uuid": "8.3.0",
     "zurb-foundation-5": "5.4.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17972,6 +17972,11 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
+trim-right@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
 trim-trailing-lines@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz#7f0739881ff76657b7776e10874128004b625a94"


### PR DESCRIPTION
## Proposed Changes
It has been done previously in #3230 for the old UI and we'd like to use this feature on the next branch too.

- added new config variable `displayNextDeparture` to config.default.js with the value `true`
- modified corresponding components of the Route panel in order to make show / display the "Next" column
- If true:
![Screenshot_2020-11-20_10-10-19](https://user-images.githubusercontent.com/46535522/99782326-43680780-2b19-11eb-8c06-ec6657fe2fe1.png)
- If false:
![Screenshot_2020-11-20_10-10-52](https://user-images.githubusercontent.com/46535522/99782339-46fb8e80-2b19-11eb-84e9-b5074f343195.png)

## Pull Request Check List
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
