### PR TITLE
DT-4111 Scale map popup zone icon font size based on text length

### DIFF
--- a/app/component/StopCardHeader.js
+++ b/app/component/StopCardHeader.js
@@ -7,7 +7,11 @@ import ComponentUsageExample from './ComponentUsageExample';
 import Icon from './Icon';
 import ServiceAlertIcon from './ServiceAlertIcon';
 import ZoneIcon from './ZoneIcon';
-import { getZoneLabelColor, getZoneLabel } from '../util/mapIconUtils';
+import {
+  getZoneLabelColor,
+  getZoneLabel,
+  getZoneLabelSize,
+} from '../util/mapIconUtils';
 import { getActiveAlertSeverityLevel } from '../util/alertUtils';
 import ExternalLink from './ExternalLink';
 
@@ -49,16 +53,6 @@ class StopCardHeader extends React.Component {
     );
   }
 
-  getZoneLabelSize(zoneId) {
-    if (
-      this.context.config.zoneIdFontSize &&
-      typeof this.context.config.zoneIdFontSize[zoneId] !== 'undefined'
-    ) {
-      return this.context.config.zoneIdFontSize[zoneId];
-    }
-    return '26px';
-  }
-
   render() {
     const {
       className,
@@ -96,11 +90,10 @@ class StopCardHeader extends React.Component {
             <ZoneIcon
               showTitle
               zoneId={getZoneLabel(stop.zoneId, this.context.config)}
-              zoneIdFontSize={
-                this.getZoneLabelSize(stop.zoneId)
-                  ? this.getZoneLabelSize(stop.zoneId)
-                  : null
-              }
+              zoneIdFontSize={getZoneLabelSize(
+                getZoneLabel(stop.zoneId, this.context.config),
+                this.context.config,
+              )}
               zoneLabelColor={getZoneLabelColor(this.context.config)}
             />
           )}

--- a/app/component/map/popups/LocationPopup.js
+++ b/app/component/map/popups/LocationPopup.js
@@ -44,7 +44,10 @@ class LocationPopup extends React.Component {
 
     function parseZoneName(fullZoneName) {
       if (fullZoneName) {
-        return fullZoneName.split(':')[1];
+        const [feedId, zoneId] = fullZoneName.split(':');
+        if (config.feedIds.includes(feedId)) {
+          return zoneId;
+        }
       }
       return undefined;
     }

--- a/app/component/map/popups/LocationPopup.js
+++ b/app/component/map/popups/LocationPopup.js
@@ -11,7 +11,10 @@ import ZoneIcon from '../../ZoneIcon';
 import PreferencesStore from '../../../store/PreferencesStore';
 import { getLabel } from '../../../util/suggestionUtils';
 import { reverseGeocode } from '../../../util/searchUtils';
-import { getZoneLabelColor } from '../../../util/mapIconUtils';
+import {
+  getZoneLabelColor,
+  getZoneLabelSize,
+} from '../../../util/mapIconUtils';
 import { addAnalyticsEvent } from '../../../util/analyticsUtils';
 
 class LocationPopup extends React.Component {
@@ -145,6 +148,7 @@ class LocationPopup extends React.Component {
             <ZoneIcon
               showTitle
               zoneId={zoneId}
+              zoneIdFontSize={getZoneLabelSize(zoneId, this.context.config)}
               zoneLabelColor={getZoneLabelColor(this.context.config)}
             />
           </CardHeader>

--- a/app/configurations/config.lahti.js
+++ b/app/configurations/config.lahti.js
@@ -183,6 +183,11 @@ export default configMerger(walttiConfig, {
     9: 'H',
     10: 'I',
   },
+  zoneIdFontSize: {
+    F1: '20px',
+    F2: '20px',
+    'B/C': '16px',
+  },
   stopCard: {
     header: {
       showZone: true,

--- a/app/configurations/config.oulu.js
+++ b/app/configurations/config.oulu.js
@@ -178,7 +178,7 @@ export default configMerger(walttiConfig, {
     5: 'D',
   },
   zoneIdFontSize: {
-    1: '10px',
+    'A-city': '10px',
   },
   stopCard: {
     header: {

--- a/app/util/mapIconUtils.js
+++ b/app/util/mapIconUtils.js
@@ -365,3 +365,13 @@ export const getZoneLabel = (zoneId, config) => {
   }
   return zoneId;
 };
+
+export const getZoneLabelSize = (zoneId, config) => {
+  if (
+    config.zoneIdFontSize &&
+    typeof config.zoneIdFontSize[zoneId] !== 'undefined'
+  ) {
+    return config.zoneIdFontSize[zoneId];
+  }
+  return '26px';
+};


### PR DESCRIPTION
## Proposed Changes

  - Allow custom font size scaling for location popup zone
  - Check that the zone belongs to one of the configured feedIds before showing it in location popup
  - Configure custom font sizes for lahti zones
   - Fixes location popup and stop page font size issues

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
