### PR TITLE
DT-4109: filter out only walking suggestions from earlier/later itineraries

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -357,30 +357,6 @@ class SummaryPage extends React.Component {
     this.mapLoaded = true;
   }
 
-  addEarlierItineraries = newItineraries => {
-    const newFilteredItineraries = newItineraries.filter(
-      itinerary => !itinerary.legs.every(leg => leg.mode === 'WALK'),
-    );
-    this.setState(prevState => ({
-      earlierItineraries: [
-        ...newFilteredItineraries,
-        ...prevState.earlierItineraries,
-      ],
-    }));
-  };
-
-  addLaterItineraries = newItineraries => {
-    const newFilteredItineraries = newItineraries.filter(
-      itinerary => !itinerary.legs.every(leg => leg.mode === 'WALK'),
-    );
-    this.setState(prevState => ({
-      laterItineraries: [
-        ...prevState.laterItineraries,
-        ...newFilteredItineraries,
-      ],
-    }));
-  };
-
   toggleStreetMode = newStreetMode => {
     const newState = {
       ...this.context.match.location,

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -357,14 +357,26 @@ class SummaryPage extends React.Component {
   }
 
   addEarlierItineraries = newItineraries => {
+    const newFilteredItineraries = newItineraries.filter(
+      itinerary => !itinerary.legs.every(leg => leg.mode === 'WALK'),
+    );
     this.setState(prevState => ({
-      earlierItineraries: [...newItineraries, ...prevState.earlierItineraries],
+      earlierItineraries: [
+        ...newFilteredItineraries,
+        ...prevState.earlierItineraries,
+      ],
     }));
   };
 
   addLaterItineraries = newItineraries => {
+    const newFilteredItineraries = newItineraries.filter(
+      itinerary => !itinerary.legs.every(leg => leg.mode === 'WALK'),
+    );
     this.setState(prevState => ({
-      laterItineraries: [...prevState.laterItineraries, ...newItineraries],
+      laterItineraries: [
+        ...prevState.laterItineraries,
+        ...newFilteredItineraries,
+      ],
     }));
   };
 

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -321,6 +321,7 @@ class SummaryPage extends React.Component {
       bikeAndPublicPlan: undefined,
       bikeParkPlan: undefined,
       scrolled: false,
+      loadingMoreItineraries: undefined,
     };
     if (this.props.match.params.hash === 'walk') {
       this.selectedPlan = this.state.walkPlan;
@@ -378,10 +379,6 @@ class SummaryPage extends React.Component {
         ...newFilteredItineraries,
       ],
     }));
-  };
-
-  updateSeparatorPosition = pos => {
-    this.setState({ separatorPosition: pos });
   };
 
   toggleStreetMode = newStreetMode => {
@@ -891,6 +888,398 @@ class SummaryPage extends React.Component {
           this.isFetching = false;
           this.params = this.context.match.params;
         });
+      },
+    );
+  };
+
+  onLater = (itineraries, reversed) => {
+    addAnalyticsEvent({
+      event: 'sendMatomoEvent',
+      category: 'Itinerary',
+      action: 'ShowLaterItineraries',
+      name: null,
+    });
+    this.setState({ loadingMoreItineraries: reversed ? 'top' : 'bottom' });
+
+    const end = moment.unix(this.props.serviceTimeRange.end);
+    const latestDepartureTime = itineraries.reduce((previous, current) => {
+      const startTime = moment(current.startTime);
+
+      if (previous == null) {
+        return startTime;
+      }
+      if (startTime.isAfter(previous)) {
+        return startTime;
+      }
+      return previous;
+    }, null);
+
+    latestDepartureTime.add(1, 'minutes');
+
+    if (latestDepartureTime >= end) {
+      // Departure time is going beyond available time range
+      this.setError('no-route-end-date-not-in-range');
+      this.setLoading(false);
+      return;
+    }
+
+    const params = preparePlanParams(this.context.config)(
+      this.context.match.params,
+      this.context.match,
+    );
+
+    const tunedParams = {
+      wheelchair: null,
+      ...params,
+      numItineraries: 5,
+      arriveBy: false,
+      date: latestDepartureTime.format('YYYY-MM-DD'),
+      time: latestDepartureTime.format('HH:mm'),
+    };
+
+    const query = graphql`
+      query SummaryPage_later_Query(
+        $fromPlace: String!
+        $toPlace: String!
+        $intermediatePlaces: [InputCoordinates!]
+        $numItineraries: Int!
+        $modes: [TransportMode!]
+        $date: String!
+        $time: String!
+        $walkReluctance: Float
+        $walkBoardCost: Int
+        $minTransferTime: Int
+        $walkSpeed: Float
+        $maxWalkDistance: Float
+        $wheelchair: Boolean
+        $ticketTypes: [String]
+        $disableRemainingWeightHeuristic: Boolean
+        $arriveBy: Boolean
+        $transferPenalty: Int
+        $bikeSpeed: Float
+        $optimize: OptimizeType
+        $itineraryFiltering: Float
+        $unpreferred: InputUnpreferred
+        $allowedBikeRentalNetworks: [String]
+        $locale: String
+      ) {
+        plan(
+          fromPlace: $fromPlace
+          toPlace: $toPlace
+          intermediatePlaces: $intermediatePlaces
+          numItineraries: $numItineraries
+          transportModes: $modes
+          date: $date
+          time: $time
+          walkReluctance: $walkReluctance
+          walkBoardCost: $walkBoardCost
+          minTransferTime: $minTransferTime
+          walkSpeed: $walkSpeed
+          maxWalkDistance: $maxWalkDistance
+          wheelchair: $wheelchair
+          allowedTicketTypes: $ticketTypes
+          disableRemainingWeightHeuristic: $disableRemainingWeightHeuristic
+          arriveBy: $arriveBy
+          transferPenalty: $transferPenalty
+          bikeSpeed: $bikeSpeed
+          optimize: $optimize
+          itineraryFiltering: $itineraryFiltering
+          unpreferred: $unpreferred
+          allowedBikeRentalNetworks: $allowedBikeRentalNetworks
+          locale: $locale
+        ) {
+          ...SummaryPlanContainer_plan
+          ...ItineraryTab_plan
+          itineraries {
+            startTime
+            endTime
+            ...ItineraryTab_itinerary
+            ...SummaryPlanContainer_itineraries
+            legs {
+              mode
+              ...ItineraryLine_legs
+              transitLeg
+              legGeometry {
+                points
+              }
+              route {
+                gtfsId
+              }
+              trip {
+                gtfsId
+                directionId
+                stoptimesForDate {
+                  scheduledDeparture
+                  pickupType
+                }
+                pattern {
+                  ...RouteLine_pattern
+                }
+              }
+              from {
+                name
+                lat
+                lon
+                stop {
+                  gtfsId
+                  zoneId
+                }
+                bikeRentalStation {
+                  bikesAvailable
+                  networks
+                }
+              }
+              to {
+                stop {
+                  gtfsId
+                  zoneId
+                }
+                bikePark {
+                  bikeParkId
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    fetchQuery(this.props.relayEnvironment, query, tunedParams).then(
+      ({ plan: result }) => {
+        if (reversed) {
+          const reversedItineraries = result.itineraries.slice().reverse(); // Need to copy because result is readonly
+          this.setState({
+            earlierItineraries: reversedItineraries,
+            loadingMoreItineraries: undefined,
+          });
+          this.context.router.replace({
+            ...this.context.match.location,
+            state: {
+              ...this.context.match.location.state,
+              summaryPageSelected: undefined,
+            },
+          });
+        } else {
+          this.setState({
+            laterItineraries: result.itineraries,
+            loadingMoreItineraries: undefined,
+          });
+        }
+        /*
+          const max = result.itineraries.reduce(
+            (previous, { endTime }) =>
+              endTime > previous ? endTime : previous,
+            Number.MIN_VALUE,
+          );
+
+          // OTP can't always find later routes. This leads to a situation where
+          // new search is done without increasing time, and nothing seems to happen
+          let newTime;
+          if (this.props.plan.date >= max) {
+            newTime = moment(this.props.plan.date).add(5, 'minutes');
+          } else {
+            newTime = moment(max).add(1, 'minutes');
+          }
+          */
+        // this.props.setLoading(false);
+        /* replaceQueryParams(this.context.router, this.context.match, {
+            time: newTime.unix(),
+          }); */
+      },
+    );
+    // }
+  };
+
+  onEarlier = (itineraries, reversed) => {
+    addAnalyticsEvent({
+      event: 'sendMatomoEvent',
+      category: 'Itinerary',
+      action: 'ShowEarlierItineraries',
+      name: null,
+    });
+    this.setState({ loadingMoreItineraries: reversed ? 'bottom' : 'top' });
+
+    const start = moment.unix(this.props.serviceTimeRange.start);
+    const earliestArrivalTime = itineraries.reduce((previous, current) => {
+      const endTime = moment(current.endTime);
+      if (previous == null) {
+        return endTime;
+      }
+      if (endTime.isBefore(previous)) {
+        return endTime;
+      }
+      return previous;
+    }, null);
+
+    earliestArrivalTime.subtract(1, 'minutes');
+    if (earliestArrivalTime <= start) {
+      this.setError('no-route-start-date-too-early');
+      this.setLoading(false);
+      return;
+    }
+
+    const params = preparePlanParams(this.context.config)(
+      this.context.match.params,
+      this.context.match,
+    );
+
+    const tunedParams = {
+      wheelchair: null,
+      ...params,
+      numItineraries: 5,
+      arriveBy: true,
+      date: earliestArrivalTime.format('YYYY-MM-DD'),
+      time: earliestArrivalTime.format('HH:mm'),
+    };
+
+    const query = graphql`
+      query SummaryPage_earlier_Query(
+        $fromPlace: String!
+        $toPlace: String!
+        $intermediatePlaces: [InputCoordinates!]
+        $numItineraries: Int!
+        $modes: [TransportMode!]
+        $date: String!
+        $time: String!
+        $walkReluctance: Float
+        $walkBoardCost: Int
+        $minTransferTime: Int
+        $walkSpeed: Float
+        $maxWalkDistance: Float
+        $wheelchair: Boolean
+        $ticketTypes: [String]
+        $disableRemainingWeightHeuristic: Boolean
+        $arriveBy: Boolean
+        $transferPenalty: Int
+        $bikeSpeed: Float
+        $optimize: OptimizeType
+        $itineraryFiltering: Float
+        $unpreferred: InputUnpreferred
+        $allowedBikeRentalNetworks: [String]
+        $locale: String
+      ) {
+        plan(
+          fromPlace: $fromPlace
+          toPlace: $toPlace
+          intermediatePlaces: $intermediatePlaces
+          numItineraries: $numItineraries
+          transportModes: $modes
+          date: $date
+          time: $time
+          walkReluctance: $walkReluctance
+          walkBoardCost: $walkBoardCost
+          minTransferTime: $minTransferTime
+          walkSpeed: $walkSpeed
+          maxWalkDistance: $maxWalkDistance
+          wheelchair: $wheelchair
+          allowedTicketTypes: $ticketTypes
+          disableRemainingWeightHeuristic: $disableRemainingWeightHeuristic
+          arriveBy: $arriveBy
+          transferPenalty: $transferPenalty
+          bikeSpeed: $bikeSpeed
+          optimize: $optimize
+          itineraryFiltering: $itineraryFiltering
+          unpreferred: $unpreferred
+          allowedBikeRentalNetworks: $allowedBikeRentalNetworks
+          locale: $locale
+        ) {
+          ...SummaryPlanContainer_plan
+          ...ItineraryTab_plan
+          itineraries {
+            startTime
+            endTime
+            ...ItineraryTab_itinerary
+            ...SummaryPlanContainer_itineraries
+            legs {
+              mode
+              ...ItineraryLine_legs
+              transitLeg
+              legGeometry {
+                points
+              }
+              route {
+                gtfsId
+              }
+              trip {
+                gtfsId
+                directionId
+                stoptimesForDate {
+                  scheduledDeparture
+                  pickupType
+                }
+                pattern {
+                  ...RouteLine_pattern
+                }
+              }
+              from {
+                name
+                lat
+                lon
+                stop {
+                  gtfsId
+                  zoneId
+                }
+                bikeRentalStation {
+                  bikesAvailable
+                  networks
+                }
+              }
+              to {
+                stop {
+                  gtfsId
+                  zoneId
+                }
+                bikePark {
+                  bikeParkId
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    fetchQuery(this.props.relayEnvironment, query, tunedParams).then(
+      ({ plan: result }) => {
+        if (result.itineraries.length === 0) {
+          // Could not find routes arriving at original departure time
+          // --> cannot calculate earlier start time
+          this.setError('no-route-start-date-too-early');
+        }
+
+        if (reversed) {
+          this.setState(prevState => {
+            return {
+              laterItineraries: result.itineraries,
+              loadingMoreItineraries: undefined,
+              separatorPosition: prevState.separatorPosition
+                ? prevState.separatorPosition + result.itineraries.length
+                : result.itineraries.length,
+            };
+          });
+        } else {
+          // Reverse the results so that route suggestions are in ascending order
+          const reversedItineraries = result.itineraries.slice().reverse(); // Need to copy because result is readonly
+          this.setState(prevState => {
+            return {
+              earlierItineraries: reversedItineraries,
+              loadingMoreItineraries: undefined,
+              separatorPosition: prevState.separatorPosition
+                ? prevState.separatorPosition + reversedItineraries.length
+                : reversedItineraries.length,
+            };
+          });
+
+          this.context.router.replace({
+            ...this.context.match.location,
+            state: {
+              ...this.context.match.location.state,
+              summaryPageSelected: undefined,
+            },
+          });
+        }
       },
     );
   };
@@ -1845,13 +2234,9 @@ class SummaryPage extends React.Component {
               activeIndex={activeIndex}
               plan={this.selectedPlan}
               serviceTimeRange={serviceTimeRange}
-              earlierItineraries={this.state.earlierItineraries}
               itineraries={selectedItineraries}
-              laterItineraries={this.state.laterItineraries}
               params={match.params}
               error={error || this.state.error}
-              setLoading={this.setLoading}
-              setError={this.setError}
               bikeAndPublicItinerariesToShow={
                 this.bikeAndPublicItinerariesToShow
               }
@@ -1861,11 +2246,11 @@ class SummaryPage extends React.Component {
               showAlternativePlan={
                 planHasNoItineraries && hasAlternativeItineraries
               }
-              addLaterItineraries={this.addLaterItineraries}
-              addEarlierItineraries={this.addEarlierItineraries}
               separatorPosition={this.state.separatorPosition}
-              updateSeparatorPosition={this.updateSeparatorPosition}
               loading={this.isFetchingWalkAndBike && !error}
+              onLater={this.onLater}
+              onEarlier={this.onEarlier}
+              loadingMoreItineraries={this.state.loadingMoreItineraries}
             >
               {this.props.content &&
                 React.cloneElement(this.props.content, {
@@ -1990,13 +2375,9 @@ class SummaryPage extends React.Component {
             }
             plan={this.selectedPlan}
             serviceTimeRange={serviceTimeRange}
-            earlierItineraries={this.state.earlierItineraries}
             itineraries={combinedItineraries}
-            laterItineraries={this.state.laterItineraries}
             params={match.params}
             error={error || this.state.error}
-            setLoading={this.setLoading}
-            setError={this.setError}
             from={match.params.from}
             to={match.params.to}
             intermediatePlaces={intermediatePlaces}
@@ -2007,11 +2388,11 @@ class SummaryPage extends React.Component {
             showAlternativePlan={
               planHasNoItineraries && hasAlternativeItineraries
             }
-            addLaterItineraries={this.addLaterItineraries}
-            addEarlierItineraries={this.addEarlierItineraries}
             separatorPosition={this.state.separatorPosition}
-            updateSeparatorPosition={this.updateSeparatorPosition}
             loading={this.isFetchingWalkAndBike && !error}
+            onLater={this.onLater}
+            onEarlier={this.onEarlier}
+            loadingMoreItineraries={this.state.loadingMoreItineraries}
           />
           {screenReaderUpdateAlert}
         </>

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -6,7 +6,6 @@ import React from 'react';
 import {
   graphql,
   createFragmentContainer,
-  fetchQuery,
   ReactRelayContext,
 } from 'react-relay';
 import { matchShape, routerShape } from 'found';
@@ -22,28 +21,14 @@ import { getRoutePath } from '../util/path';
 import { replaceQueryParams } from '../util/queryUtils';
 import withBreakpoint from '../util/withBreakpoint';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
-import { preparePlanParams } from '../util/planParamUtil';
 
 class SummaryPlanContainer extends React.Component {
   static propTypes = {
     activeIndex: PropTypes.number,
     children: PropTypes.node,
-    config: PropTypes.object.isRequired,
     currentTime: PropTypes.number.isRequired,
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    earlierItineraries: PropTypes.arrayOf(
-      PropTypes.shape({
-        endTime: PropTypes.number,
-        startTime: PropTypes.number,
-      }),
-    ),
     itineraries: PropTypes.arrayOf(
-      PropTypes.shape({
-        endTime: PropTypes.number,
-        startTime: PropTypes.number,
-      }),
-    ),
-    laterItineraries: PropTypes.arrayOf(
       PropTypes.shape({
         endTime: PropTypes.number,
         startTime: PropTypes.number,
@@ -61,30 +46,26 @@ class SummaryPlanContainer extends React.Component {
       start: PropTypes.number.isRequired,
       end: PropTypes.number.isRequired,
     }).isRequired,
-    setError: PropTypes.func.isRequired,
-    setLoading: PropTypes.func.isRequired,
-    relayEnvironment: PropTypes.object,
     bikeAndPublicItinerariesToShow: PropTypes.number.isRequired,
     bikeAndParkItinerariesToShow: PropTypes.number.isRequired,
     walking: PropTypes.bool,
     biking: PropTypes.bool,
     showAlternativePlan: PropTypes.bool,
-    addLaterItineraries: PropTypes.func.isRequired,
-    addEarlierItineraries: PropTypes.func.isRequired,
     separatorPosition: PropTypes.number,
-    updateSeparatorPosition: PropTypes.func.isRequired,
     loading: PropTypes.bool.isRequired,
+    onLater: PropTypes.func.isRequired,
+    onEarlier: PropTypes.func.isRequired,
+    loadingMoreItineraries: PropTypes.string,
   };
 
   static defaultProps = {
     activeIndex: 0,
     error: undefined,
-    earlierItineraries: [],
     itineraries: [],
-    laterItineraries: [],
     walking: false,
     biking: false,
     showAlternativePlan: false,
+    loadingMoreItineraries: undefined,
   };
 
   static contextTypes = {
@@ -92,10 +73,6 @@ class SummaryPlanContainer extends React.Component {
     match: matchShape.isRequired,
     intl: intlShape.isRequired,
     executeAction: PropTypes.func.isRequired,
-  };
-
-  state = {
-    loadingMoreItineraries: undefined,
   };
 
   onSelectActive = index => {
@@ -153,571 +130,6 @@ class SummaryPlanContainer extends React.Component {
     this.context.router.push(newState);
   };
 
-  onLater = reversed => {
-    addAnalyticsEvent({
-      event: 'sendMatomoEvent',
-      category: 'Itinerary',
-      action: 'ShowLaterItineraries',
-      name: null,
-    });
-    this.setState({ loadingMoreItineraries: reversed ? 'top' : 'bottom' });
-    const combinedItineraries = [
-      ...(this.props.earlierItineraries || []),
-      ...(this.props.itineraries || []),
-      ...(this.props.laterItineraries || []),
-    ];
-
-    const end = moment.unix(this.props.serviceTimeRange.end);
-    const latestDepartureTime = combinedItineraries.reduce(
-      (previous, current) => {
-        const startTime = moment(current.startTime);
-
-        if (previous == null) {
-          return startTime;
-        }
-        if (startTime.isAfter(previous)) {
-          return startTime;
-        }
-        return previous;
-      },
-      null,
-    );
-
-    latestDepartureTime.add(1, 'minutes');
-
-    if (latestDepartureTime >= end) {
-      // Departure time is going beyond available time range
-      this.props.setError('no-route-end-date-not-in-range');
-      this.props.setLoading(false);
-      return;
-    }
-
-    const params = preparePlanParams(this.props.config)(
-      this.context.match.params,
-      this.context.match,
-    );
-
-    const tunedParams = {
-      wheelchair: null,
-      ...params,
-      numItineraries: 5,
-      arriveBy: false,
-      date: latestDepartureTime.format('YYYY-MM-DD'),
-      time: latestDepartureTime.format('HH:mm'),
-    };
-
-    const query = graphql`
-      query SummaryPlanContainer_later_Query(
-        $fromPlace: String!
-        $toPlace: String!
-        $intermediatePlaces: [InputCoordinates!]
-        $numItineraries: Int!
-        $modes: [TransportMode!]
-        $date: String!
-        $time: String!
-        $walkReluctance: Float
-        $walkBoardCost: Int
-        $minTransferTime: Int
-        $walkSpeed: Float
-        $maxWalkDistance: Float
-        $wheelchair: Boolean
-        $ticketTypes: [String]
-        $disableRemainingWeightHeuristic: Boolean
-        $arriveBy: Boolean
-        $transferPenalty: Int
-        $bikeSpeed: Float
-        $optimize: OptimizeType
-        $itineraryFiltering: Float
-        $unpreferred: InputUnpreferred
-        $allowedBikeRentalNetworks: [String]
-        $locale: String
-      ) {
-        plan(
-          fromPlace: $fromPlace
-          toPlace: $toPlace
-          intermediatePlaces: $intermediatePlaces
-          numItineraries: $numItineraries
-          transportModes: $modes
-          date: $date
-          time: $time
-          walkReluctance: $walkReluctance
-          walkBoardCost: $walkBoardCost
-          minTransferTime: $minTransferTime
-          walkSpeed: $walkSpeed
-          maxWalkDistance: $maxWalkDistance
-          wheelchair: $wheelchair
-          allowedTicketTypes: $ticketTypes
-          disableRemainingWeightHeuristic: $disableRemainingWeightHeuristic
-          arriveBy: $arriveBy
-          transferPenalty: $transferPenalty
-          bikeSpeed: $bikeSpeed
-          optimize: $optimize
-          itineraryFiltering: $itineraryFiltering
-          unpreferred: $unpreferred
-          allowedBikeRentalNetworks: $allowedBikeRentalNetworks
-          locale: $locale
-        ) {
-          ...ItineraryTab_plan
-          itineraries {
-            ...ItinerarySummaryListContainer_itineraries
-            walkDistance
-            duration
-            startTime
-            endTime
-            elevationGained
-            elevationLost
-            fares {
-              cents
-              components {
-                cents
-                fareId
-                routes {
-                  agency {
-                    gtfsId
-                    fareUrl
-                    name
-                  }
-                  gtfsId
-                }
-              }
-              type
-            }
-            legs {
-              mode
-              ...ItineraryLine_legs
-              ...LegAgencyInfo_leg
-              from {
-                lat
-                lon
-                name
-                vertexType
-                bikeRentalStation {
-                  networks
-                  bikesAvailable
-                  lat
-                  lon
-                  stationId
-                }
-                stop {
-                  gtfsId
-                  code
-                  platformCode
-                  zoneId
-                }
-              }
-              to {
-                lat
-                lon
-                name
-                vertexType
-                bikeRentalStation {
-                  lat
-                  lon
-                  stationId
-                  networks
-                  bikesAvailable
-                }
-                stop {
-                  gtfsId
-                  code
-                  platformCode
-                  zoneId
-                }
-                bikePark {
-                  bikeParkId
-                  name
-                }
-              }
-              legGeometry {
-                length
-                points
-              }
-              intermediatePlaces {
-                arrivalTime
-                stop {
-                  gtfsId
-                  lat
-                  lon
-                  name
-                  code
-                  platformCode
-                  zoneId
-                }
-              }
-              realTime
-              realtimeState
-              transitLeg
-              rentedBike
-              startTime
-              endTime
-              mode
-              interlineWithPreviousLeg
-              distance
-              duration
-              intermediatePlace
-              route {
-                shortName
-                color
-                gtfsId
-                longName
-                desc
-                agency {
-                  gtfsId
-                  fareUrl
-                  name
-                  phone
-                }
-              }
-              trip {
-                directionId
-                gtfsId
-                tripHeadsign
-                stoptimesForDate {
-                  scheduledDeparture
-                }
-                pattern {
-                  ...RouteLine_pattern
-                  code
-                }
-                stoptimes {
-                  pickupType
-                  realtimeState
-                  stop {
-                    gtfsId
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    `;
-
-    fetchQuery(this.props.relayEnvironment, query, tunedParams).then(
-      ({ plan: result }) => {
-        if (reversed) {
-          const reversedItineraries = result.itineraries.slice().reverse(); // Need to copy because result is readonly
-          this.props.addEarlierItineraries(reversedItineraries);
-          this.setState({
-            loadingMoreItineraries: undefined,
-          });
-          this.context.router.replace({
-            ...this.context.match.location,
-            state: {
-              ...this.context.match.location.state,
-              summaryPageSelected: undefined,
-            },
-          });
-        } else {
-          this.props.addLaterItineraries(result.itineraries);
-          this.setState({
-            loadingMoreItineraries: undefined,
-          });
-        }
-        /*
-          const max = result.itineraries.reduce(
-            (previous, { endTime }) =>
-              endTime > previous ? endTime : previous,
-            Number.MIN_VALUE,
-          );
-
-          // OTP can't always find later routes. This leads to a situation where
-          // new search is done without increasing time, and nothing seems to happen
-          let newTime;
-          if (this.props.plan.date >= max) {
-            newTime = moment(this.props.plan.date).add(5, 'minutes');
-          } else {
-            newTime = moment(max).add(1, 'minutes');
-          }
-          */
-        // this.props.setLoading(false);
-        /* replaceQueryParams(this.context.router, this.context.match, {
-            time: newTime.unix(),
-          }); */
-      },
-    );
-    // }
-  };
-
-  onEarlier = reversed => {
-    addAnalyticsEvent({
-      event: 'sendMatomoEvent',
-      category: 'Itinerary',
-      action: 'ShowEarlierItineraries',
-      name: null,
-    });
-    this.setState({ loadingMoreItineraries: reversed ? 'bottom' : 'top' });
-    const combinedItineraries = [
-      ...(this.props.earlierItineraries || []),
-      ...(this.props.itineraries || []),
-      ...(this.props.laterItineraries || []),
-    ];
-
-    const start = moment.unix(this.props.serviceTimeRange.start);
-    const earliestArrivalTime = combinedItineraries.reduce(
-      (previous, current) => {
-        const endTime = moment(current.endTime);
-        if (previous == null) {
-          return endTime;
-        }
-        if (endTime.isBefore(previous)) {
-          return endTime;
-        }
-        return previous;
-      },
-      null,
-    );
-
-    earliestArrivalTime.subtract(1, 'minutes');
-    if (earliestArrivalTime <= start) {
-      this.props.setError('no-route-start-date-too-early');
-      this.props.setLoading(false);
-      return;
-    }
-
-    const params = preparePlanParams(this.props.config)(
-      this.context.match.params,
-      this.context.match,
-    );
-
-    const tunedParams = {
-      wheelchair: null,
-      ...params,
-      numItineraries: 5,
-      arriveBy: true,
-      date: earliestArrivalTime.format('YYYY-MM-DD'),
-      time: earliestArrivalTime.format('HH:mm'),
-    };
-
-    const query = graphql`
-      query SummaryPlanContainer_earlier_Query(
-        $fromPlace: String!
-        $toPlace: String!
-        $intermediatePlaces: [InputCoordinates!]
-        $numItineraries: Int!
-        $modes: [TransportMode!]
-        $date: String!
-        $time: String!
-        $walkReluctance: Float
-        $walkBoardCost: Int
-        $minTransferTime: Int
-        $walkSpeed: Float
-        $maxWalkDistance: Float
-        $wheelchair: Boolean
-        $ticketTypes: [String]
-        $disableRemainingWeightHeuristic: Boolean
-        $arriveBy: Boolean
-        $transferPenalty: Int
-        $bikeSpeed: Float
-        $optimize: OptimizeType
-        $itineraryFiltering: Float
-        $unpreferred: InputUnpreferred
-        $allowedBikeRentalNetworks: [String]
-        $locale: String
-      ) {
-        plan(
-          fromPlace: $fromPlace
-          toPlace: $toPlace
-          intermediatePlaces: $intermediatePlaces
-          numItineraries: $numItineraries
-          transportModes: $modes
-          date: $date
-          time: $time
-          walkReluctance: $walkReluctance
-          walkBoardCost: $walkBoardCost
-          minTransferTime: $minTransferTime
-          walkSpeed: $walkSpeed
-          maxWalkDistance: $maxWalkDistance
-          wheelchair: $wheelchair
-          allowedTicketTypes: $ticketTypes
-          disableRemainingWeightHeuristic: $disableRemainingWeightHeuristic
-          arriveBy: $arriveBy
-          transferPenalty: $transferPenalty
-          bikeSpeed: $bikeSpeed
-          optimize: $optimize
-          itineraryFiltering: $itineraryFiltering
-          unpreferred: $unpreferred
-          allowedBikeRentalNetworks: $allowedBikeRentalNetworks
-          locale: $locale
-        ) {
-          ...ItineraryTab_plan
-          itineraries {
-            ...ItinerarySummaryListContainer_itineraries
-            walkDistance
-            duration
-            startTime
-            endTime
-            elevationGained
-            elevationLost
-            fares {
-              cents
-              components {
-                cents
-                fareId
-                routes {
-                  agency {
-                    gtfsId
-                    fareUrl
-                    name
-                  }
-                  gtfsId
-                }
-              }
-              type
-            }
-            legs {
-              mode
-              ...ItineraryLine_legs
-              ...LegAgencyInfo_leg
-              from {
-                lat
-                lon
-                name
-                vertexType
-                bikeRentalStation {
-                  networks
-                  bikesAvailable
-                  lat
-                  lon
-                  stationId
-                }
-                stop {
-                  gtfsId
-                  code
-                  platformCode
-                  zoneId
-                }
-              }
-              to {
-                lat
-                lon
-                name
-                vertexType
-                bikeRentalStation {
-                  lat
-                  lon
-                  stationId
-                  networks
-                  bikesAvailable
-                }
-                stop {
-                  gtfsId
-                  code
-                  platformCode
-                  zoneId
-                }
-                bikePark {
-                  bikeParkId
-                  name
-                }
-              }
-              legGeometry {
-                length
-                points
-              }
-              intermediatePlaces {
-                arrivalTime
-                stop {
-                  gtfsId
-                  lat
-                  lon
-                  name
-                  code
-                  platformCode
-                  zoneId
-                }
-              }
-              realTime
-              realtimeState
-              transitLeg
-              rentedBike
-              startTime
-              endTime
-              mode
-              interlineWithPreviousLeg
-              distance
-              duration
-              intermediatePlace
-              route {
-                shortName
-                color
-                gtfsId
-                longName
-                desc
-                agency {
-                  gtfsId
-                  fareUrl
-                  name
-                  phone
-                }
-              }
-              trip {
-                directionId
-                gtfsId
-                tripHeadsign
-                stoptimesForDate {
-                  scheduledDeparture
-                }
-                pattern {
-                  ...RouteLine_pattern
-                  code
-                }
-                stoptimes {
-                  pickupType
-                  realtimeState
-                  stop {
-                    gtfsId
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    `;
-
-    fetchQuery(this.props.relayEnvironment, query, tunedParams).then(
-      ({ plan: result }) => {
-        if (result.itineraries.length === 0) {
-          // Could not find routes arriving at original departure time
-          // --> cannot calculate earlier start time
-          this.props.setError('no-route-start-date-too-early');
-        }
-
-        if (reversed) {
-          this.props.updateSeparatorPosition(
-            this.props.separatorPosition
-              ? this.props.separatorPosition + result.itineraries.length
-              : result.itineraries.length,
-          );
-          this.setState({
-            loadingMoreItineraries: undefined,
-          });
-          this.props.addLaterItineraries(result.itineraries);
-        } else {
-          // Reverse the results so that route suggestions are in ascending order
-          const reversedItineraries = result.itineraries.slice().reverse(); // Need to copy because result is readonly
-          this.props.addEarlierItineraries(reversedItineraries);
-          this.props.updateSeparatorPosition(
-            this.props.separatorPosition
-              ? this.props.separatorPosition + reversedItineraries.length
-              : reversedItineraries.length,
-          );
-          this.setState({
-            loadingMoreItineraries: undefined,
-          });
-          this.context.router.replace({
-            ...this.context.match.location,
-            state: {
-              ...this.context.match.location.state,
-              summaryPageSelected: undefined,
-            },
-          });
-        }
-      },
-    );
-  };
-
   onNow = () => {
     addAnalyticsEvent({
       event: 'sendMatomoEvent',
@@ -744,7 +156,7 @@ class SummaryPlanContainer extends React.Component {
           className={`time-navigation-btn ${
             reversed ? 'top-btn' : 'bottom-btn'
           }`}
-          onClick={() => this.onLater(reversed)}
+          onClick={() => this.props.onLater(this.props.itineraries, reversed)}
         >
           <Icon
             img="icon-icon_arrow-collapse"
@@ -772,7 +184,7 @@ class SummaryPlanContainer extends React.Component {
           className={`time-navigation-btn ${
             reversed ? 'bottom-btn' : 'top-btn'
           }`}
-          onClick={() => this.onEarlier(reversed)}
+          onClick={() => this.props.onEarlier(this.props.itineraries, reversed)}
         >
           <Icon
             img="icon-icon_arrow-collapse"
@@ -795,9 +207,7 @@ class SummaryPlanContainer extends React.Component {
       activeIndex,
       currentTime,
       locationState,
-      earlierItineraries,
       itineraries,
-      laterItineraries,
       bikeAndPublicItinerariesToShow,
       bikeAndParkItinerariesToShow,
       walking,
@@ -805,20 +215,15 @@ class SummaryPlanContainer extends React.Component {
       showAlternativePlan,
       separatorPosition,
       loading,
+      loadingMoreItineraries,
     } = this.props;
-    const combinedItineraries = [
-      ...(earlierItineraries || []),
-      ...(itineraries || []),
-      ...(laterItineraries || []),
-    ];
     const searchTime =
       this.props.plan.date ||
       (location.query &&
         location.query.time &&
         moment.unix(location.query.time).valueOf()) ||
       currentTime;
-    const disableButtons =
-      !combinedItineraries || combinedItineraries.length === 0;
+    const disableButtons = !itineraries || itineraries.length === 0;
     const arriveBy = this.context.match.location.query.arriveBy === 'true';
 
     return (
@@ -843,7 +248,7 @@ class SummaryPlanContainer extends React.Component {
           error={this.props.error}
           from={otpToLocation(from)}
           intermediatePlaces={getIntermediatePlaces(location.query)}
-          itineraries={combinedItineraries}
+          itineraries={itineraries}
           onSelect={this.onSelectActive}
           onSelectImmediately={this.onSelectImmediately}
           searchTime={searchTime}
@@ -854,7 +259,7 @@ class SummaryPlanContainer extends React.Component {
           biking={biking}
           showAlternativePlan={showAlternativePlan}
           separatorPosition={separatorPosition}
-          loadingMoreItineraries={this.state.loadingMoreItineraries}
+          loadingMoreItineraries={loadingMoreItineraries}
           loading={loading}
         >
           {this.props.children}


### PR DESCRIPTION
## Proposed Changes

  - fix: filter out only walking suggestions from earlier/later itineraries
  - Refactor earlier/later itineraries logic to be more clear: data now flows from parent to child and child component does not update parents state, also itineraries are now combined into one only once in summaryPage

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
