### PR TITLE
Allow time zone to be passed to components as props

### DIFF
--- a/app/component/DatetimepickerContainer.js
+++ b/app/component/DatetimepickerContainer.js
@@ -85,6 +85,7 @@ function DatetimepickerContainer(
       embedWhenClosed={embedWhenClosed}
       lang={lang}
       color={color}
+      timeZone={context.config.timezoneData.split('|')[0]}
     />
   );
 }

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -20,8 +20,6 @@ import translations from './helpers/translations';
 import styles from './helpers/styles.scss';
 import MobileSearch from './helpers/MobileSearch';
 
-moment.tz.setDefault('Europe/Helsinki');
-
 i18next.init({ lng: 'fi', resources: {} });
 
 Object.keys(translations).forEach(lang => {
@@ -196,6 +194,7 @@ class DTAutosuggest extends React.Component {
     isMobile: PropTypes.bool,
     color: PropTypes.string,
     hoverColor: PropTypes.string,
+    timeZone: PropTypes.string,
   };
 
   static defaultProps = {
@@ -210,11 +209,13 @@ class DTAutosuggest extends React.Component {
     isMobile: false,
     color: '#007ac9',
     hoverColor: '#0062a1',
+    timeZone: 'Europe/Helsinki',
   };
 
   constructor(props) {
     super(props);
     i18next.changeLanguage(props.lang);
+    moment.tz.setDefault(props.timeZone);
     this.state = {
       value: props.value,
       suggestions: [],

--- a/digitransit-component/packages/digitransit-component-datetimepicker/README.md
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/README.md
@@ -19,6 +19,8 @@ This component renders an input to choose a date and time. Renders separate inpu
     -   `props.onNowClick` **[function][4]** Called when "depart now" button is clicked. time is current input value in seconds
     -   `props.embedWhenClosed` **[node][5]** JSX element to render in the corner when input is closed
     -   `props.lang` **[string][6]** Language selection. Default 'en'
+    -   `props.color`  
+    -   `props.timeZone`  
 
 ### Examples
 

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
@@ -13,7 +13,6 @@ import styles from './styles.scss';
 import { isMobile, isAndroid } from './mobileDetection';
 import dateTimeInputIsSupported from './dateTimeInputIsSupported';
 
-moment.tz.setDefault('Europe/Helsinki');
 moment.locale('en');
 i18next.init({ lng: 'en', resources: {} });
 Object.keys(translations).forEach(lang =>
@@ -59,7 +58,10 @@ function Datetimepicker({
   embedWhenClosed,
   lang,
   color,
+  timeZone,
 }) {
+  moment.tz.setDefault(timeZone);
+
   const [isOpen, changeOpen] = useState(false);
   const [displayTimestamp, changeDisplayTimestamp] = useState(
     timestamp || moment().valueOf(),
@@ -364,6 +366,7 @@ function Datetimepicker({
                       </span>
                     }
                     dateTimeCombined={useDateTimeCombined}
+                    timeZone={timeZone}
                   />
                 </span>
                 <span
@@ -383,6 +386,7 @@ function Datetimepicker({
                       </span>
                     }
                     dateTimeCombined={useDateTimeCombined}
+                    timeZone={timeZone}
                   />
                 </span>
               </>
@@ -407,6 +411,7 @@ function Datetimepicker({
                     id={`${htmlId}-date`}
                     label={i18next.t('date', translationSettings)}
                     disableTyping
+                    timeZone={timeZone}
                   />
                 </span>
                 <span>
@@ -427,6 +432,7 @@ function Datetimepicker({
                     }
                     id={`${htmlId}-time`}
                     label={i18next.t('time', translationSettings)}
+                    timeZone={timeZone}
                   />
                 </span>
               </>
@@ -440,6 +446,7 @@ function Datetimepicker({
 
 Datetimepicker.propTypes = {
   timestamp: PropTypes.number,
+  timeZone: PropTypes.string,
   onTimeChange: PropTypes.func.isRequired,
   onDateChange: PropTypes.func.isRequired,
   departureOrArrival: PropTypes.oneOf(['departure', 'arrival']).isRequired,
@@ -455,6 +462,7 @@ Datetimepicker.defaultProps = {
   timestamp: null,
   embedWhenClosed: null,
   color: '#007ac9',
+  timeZone: 'Europe/Helsinki',
 };
 
 export default Datetimepicker;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
@@ -4,8 +4,6 @@ import moment from 'moment-timezone';
 import Autosuggest from 'react-autosuggest';
 import styles from './styles.scss';
 
-moment.tz.setDefault('Europe/Helsinki');
-
 /**
  * Component to display a date or time input on desktop.
  *
@@ -41,7 +39,9 @@ function DesktopDatetimepicker({
   label,
   icon,
   disableTyping,
+  timeZone,
 }) {
+  moment.tz.setDefault(timeZone);
   const [displayValue, changeDisplayValue] = useState(getDisplay(value));
 
   useEffect(() => changeDisplayValue(getDisplay(value)), [value]);
@@ -199,10 +199,12 @@ DesktopDatetimepicker.propTypes = {
   label: PropTypes.node.isRequired,
   icon: PropTypes.node.isRequired,
   disableTyping: PropTypes.bool,
+  timeZone: PropTypes.string,
 };
 
 DesktopDatetimepicker.defaultProps = {
   disableTyping: false,
+  timeZone: 'Europe/Helsinki',
 };
 
 export default DesktopDatetimepicker;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
@@ -3,8 +3,6 @@ import React from 'react';
 import moment from 'moment-timezone';
 import styles from './styles.scss';
 
-moment.tz.setDefault('Europe/Helsinki');
-
 /**
  * Component to display a date input on mobile
  */
@@ -18,7 +16,9 @@ function MobileDatepicker({
   label,
   icon,
   dateTimeCombined,
+  timeZone,
 }) {
+  moment.tz.setDefault(timeZone);
   const startFormatted = moment(startTime).format('YYYY-MM-DD');
   const endFormatted = moment(startTime)
     .add(itemCount, 'day')
@@ -83,11 +83,13 @@ MobileDatepicker.propTypes = {
   label: PropTypes.string.isRequired,
   icon: PropTypes.node,
   dateTimeCombined: PropTypes.bool,
+  timeZone: PropTypes.string,
 };
 
 MobileDatepicker.defaultProps = {
   icon: null,
   dateTimeCombined: false,
+  timeZone: 'Europe/Helsinki',
 };
 
 export default MobileDatepicker;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
@@ -3,8 +3,6 @@ import React from 'react';
 import moment from 'moment-timezone';
 import styles from './styles.scss';
 
-moment.tz.setDefault('Europe/Helsinki');
-
 /**
  * Component to display a time input on mobile
  */
@@ -16,7 +14,9 @@ function MobileTimepicker({
   label,
   icon,
   dateTimeCombined,
+  timeZone,
 }) {
+  moment.tz.setDefault(timeZone);
   const inputId = `${id}-input`;
   const labelId = `${id}-label`;
   return (
@@ -69,11 +69,13 @@ MobileTimepicker.propTypes = {
   label: PropTypes.string.isRequired,
   icon: PropTypes.node,
   dateTimeCombined: PropTypes.bool,
+  timeZone: PropTypes.string,
 };
 
 MobileTimepicker.defaultProps = {
   icon: null,
   dateTimeCombined: false,
+  timeZone: 'Europe/Helsinki',
 };
 
 export default MobileTimepicker;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/index.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/index.js
@@ -4,8 +4,6 @@ import moment from 'moment-timezone';
 import debounce from 'lodash/debounce';
 import Datetimepicker from './helpers/Datetimepicker';
 
-moment.tz.setDefault('Europe/Helsinki');
-
 /**
  * This component renders an input to choose a date and time. Renders separate input fields for date and time selection. Values for timestamp and arriveBy correspond to Digitransit query params time and arriveBy. This component will display a native date input on mobile and a custom one for desktop. Mobile detection is done by parsing user agent.
  *
@@ -50,7 +48,9 @@ function DatetimepickerStateContainer({
   embedWhenClosed,
   lang,
   color,
+  timeZone,
 }) {
+  moment.tz.setDefault(timeZone);
   const initialNow = realtime ? null : moment().valueOf();
   const [timestamp, changeTimestampState] = useState(
     initialTimestamp ? initialTimestamp * 1000 : initialNow,
@@ -160,6 +160,7 @@ function DatetimepickerStateContainer({
       embedWhenClosed={embedWhenClosed}
       lang={lang}
       color={color}
+      timeZone={timeZone}
     />
   );
 }
@@ -176,6 +177,7 @@ DatetimepickerStateContainer.propTypes = {
   embedWhenClosed: PropTypes.node,
   lang: PropTypes.string,
   color: PropTypes.string,
+  timeZone: PropTypes.string,
 };
 
 DatetimepickerStateContainer.defaultProps = {
@@ -185,6 +187,7 @@ DatetimepickerStateContainer.defaultProps = {
   embedWhenClosed: null,
   lang: 'en',
   color: '#007ac9',
+  timeZone: 'Europe/Helsinki',
 };
 
 export default DatetimepickerStateContainer;

--- a/digitransit-component/packages/digitransit-component-dialog-modal/README.md
+++ b/digitransit-component/packages/digitransit-component-dialog-modal/README.md
@@ -21,7 +21,7 @@ General component description in JSDoc format. Markdown is _supported_.
     -   `$0.appElement`  
     -   `$0.isModalOpen`  
     -   `$0.modalAriaLabel`  
-    -   `$0.normalColor`  
+    -   `$0.color`  
     -   `$0.hoverColor`  
 
 ### Examples

--- a/digitransit-component/packages/digitransit-component-favourite-bar/README.md
+++ b/digitransit-component/packages/digitransit-component-favourite-bar/README.md
@@ -71,6 +71,10 @@ Optional. Language, fi, en or sv.
 
 Optional. Whether to show loading animation, true or false.
 
+## color
+
+Optional. Default value is '#007ac9'.
+
 [1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
 [2]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object


### PR DESCRIPTION
## Proposed Changes

Since we operate in a different time zone the hardcoded `Europe/Helsinki` is causing the date time picker to display the incorrect time. This PR allows users of the component to set the time zone via props. As requested in #3747, it is completely backwards-compatible and defaults to the Finnish time zone.

I have some reservations about calling `setDefault` over and over (as it is effectively a global variable), but it was the least painful change I could make. It also allows for easier review.

### Existing timezone problem not tackled by this PR

While checking if this works as expected I noticed a weirdness in the current implementation that existed before this pull request.

When using the `hsl` config with a timezone other than `Europe/Helsinki` (I'm on `Europe/Berlin`) and selecting a time, the component correctly interprets "now" as meaning the Finnish timezone. 

However, the itinerary times are displayed in UTC, so (currently) one hour _before_ `Europe/Berlin`.

![Screenshot from 2020-11-24 11-11-26](https://user-images.githubusercontent.com/151346/100080797-89d5a300-2e46-11eb-96e7-66752a48f75a.png)

Not sure it is a supported use case but I'm speculating that digitransit tries to use my current time zone to format the itinerary results, cannot find any data on it and falls back to UTC. After having thought through a few possibilities of what I would expect to happen, I think that it should disregard the user's timezone and always use `Europe/Helsinki`.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
