### PR TITLE
DT-4092: disruption info to itinerary view

### DIFF
--- a/app/component/ItineraryTab.js
+++ b/app/component/ItineraryTab.js
@@ -257,6 +257,11 @@ const withRelay = createFragmentContainer(ItineraryTab, {
             code
             platformCode
             zoneId
+            alerts {
+              alertSeverityLevel
+              effectiveEndDate
+              effectiveStartDate
+            }
           }
           bikePark {
             bikeParkId
@@ -277,6 +282,11 @@ const withRelay = createFragmentContainer(ItineraryTab, {
             code
             platformCode
             zoneId
+            alerts {
+              alertSeverityLevel
+              effectiveEndDate
+              effectiveStartDate
+            }
           }
         }
         realTime
@@ -301,6 +311,11 @@ const withRelay = createFragmentContainer(ItineraryTab, {
             fareUrl
             name
             phone
+          }
+          alerts {
+            alertSeverityLevel
+            effectiveEndDate
+            effectiveStartDate
           }
         }
         trip {

--- a/app/component/ItineraryTab.js
+++ b/app/component/ItineraryTab.js
@@ -237,6 +237,21 @@ const withRelay = createFragmentContainer(ItineraryTab, {
               alertSeverityLevel
               effectiveEndDate
               effectiveStartDate
+              trip {
+                pattern {
+                  code
+                }
+              }
+              alertHeaderText
+              alertHeaderTextTranslations {
+                text
+                language
+              }
+              alertUrl
+              alertUrlTranslations {
+                text
+                language
+              }
             }
           }
         }
@@ -261,6 +276,24 @@ const withRelay = createFragmentContainer(ItineraryTab, {
               alertSeverityLevel
               effectiveEndDate
               effectiveStartDate
+              alertSeverityLevel
+              effectiveEndDate
+              effectiveStartDate
+              trip {
+                pattern {
+                  code
+                }
+              }
+              alertHeaderText
+              alertHeaderTextTranslations {
+                text
+                language
+              }
+              alertUrl
+              alertUrlTranslations {
+                text
+                language
+              }
             }
           }
           bikePark {
@@ -286,6 +319,21 @@ const withRelay = createFragmentContainer(ItineraryTab, {
               alertSeverityLevel
               effectiveEndDate
               effectiveStartDate
+              trip {
+                pattern {
+                  code
+                }
+              }
+              alertHeaderText
+              alertHeaderTextTranslations {
+                text
+                language
+              }
+              alertUrl
+              alertUrlTranslations {
+                text
+                language
+              }
             }
           }
         }
@@ -316,6 +364,21 @@ const withRelay = createFragmentContainer(ItineraryTab, {
             alertSeverityLevel
             effectiveEndDate
             effectiveStartDate
+            trip {
+              pattern {
+                code
+              }
+            }
+            alertHeaderText
+            alertHeaderTextTranslations {
+              text
+              language
+            }
+            alertUrl
+            alertUrlTranslations {
+              text
+              language
+            }
           }
         }
         trip {

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
 import Link from 'found/Link';
+import connectToStores from 'fluxible-addons-react/connectToStores';
 
 import ExternalLink from './ExternalLink';
 import LegAgencyInfo from './LegAgencyInfo';
@@ -16,9 +17,9 @@ import ServiceAlertIcon from './ServiceAlertIcon';
 import StopCode from './StopCode';
 import {
   getActiveAlertSeverityLevel,
-  getActiveLegAlertSeverityLevel,
   legHasCancelation,
   tripHasCancelationForStop,
+  getActiveLegAlerts,
 } from '../util/alertUtils';
 import { PREFIX_ROUTES, PREFIX_STOPS } from '../util/path';
 import { durationToString } from '../util/timeUtils';
@@ -146,7 +147,7 @@ class TransitLeg extends React.Component {
   }
 
   renderMain = () => {
-    const { children, focusAction, index, leg, mode } = this.props;
+    const { children, focusAction, index, leg, mode, lang } = this.props;
     const { config, intl } = this.context;
     const originalTime = leg.realTime &&
       leg.departureDelay &&
@@ -251,11 +252,16 @@ class TransitLeg extends React.Component {
       />
     );
 
-    const alert = getActiveLegAlertSeverityLevel(leg);
-    let alertDescription = null;
-    if (alert) {
+    const alerts = getActiveLegAlerts(leg, leg.startTime / 1000, lang); // legStartTime converted to ms format
+    const alert = alerts && alerts.length > 0 ? alerts[0] : undefined;
+    const alertSeverityLevel = getActiveAlertSeverityLevel(
+      alerts,
+      leg.startTime / 1000,
+    );
+    let alertSeverityDescription = null;
+    if (alertSeverityLevel) {
       let id;
-      switch (alert) {
+      switch (alertSeverityLevel) {
         case AlertSeverityLevelType.Info:
           id = 'itinerary-details.route-has-info-alert';
           break;
@@ -270,7 +276,7 @@ class TransitLeg extends React.Component {
           id = 'itinerary-details.route-has-unknown-alert';
           break;
       }
-      alertDescription = <FormattedMessage id={id} />;
+      alertSeverityDescription = <FormattedMessage id={id} />;
     }
     const zoneIcons = this.getZoneChange();
     // Checks if route only has letters without identifying numbers and
@@ -420,7 +426,7 @@ class TransitLeg extends React.Component {
             >
               <RouteNumber
                 mode={mode.toLowerCase()}
-                alertSeverityLevel={getActiveLegAlertSeverityLevel(leg)}
+                alertSeverityLevel={alertSeverityLevel}
                 color={leg.route ? `#${leg.route.color}` : 'currentColor'}
                 text={leg.route && leg.route.shortName}
                 realtime={false}
@@ -430,6 +436,25 @@ class TransitLeg extends React.Component {
             </Link>
             <div className="headsign">{leg.trip.tripHeadsign}</div>
           </div>
+          {(alertSeverityLevel === AlertSeverityLevelType.Warning ||
+            alertSeverityLevel === AlertSeverityLevelType.Severe) && (
+            <div className="disruption">
+              <ExternalLink className="disruption-link" href={alert.url}>
+                <div className="disruption-icon">
+                  <ServiceAlertIcon
+                    className="inline-icon"
+                    severityLevel={alertSeverityLevel}
+                  />
+                </div>
+                <div className="description">{alert.header}</div>
+                <Icon
+                  img="icon-icon_arrow-collapse--right"
+                  className="disruption-link-arrow"
+                  color={config.colors.primary}
+                />
+              </ExternalLink>
+            </div>
+          )}
           <LegAgencyInfo leg={leg} />
           <div>
             <StopInfo
@@ -465,7 +490,7 @@ class TransitLeg extends React.Component {
             </div>
           )}
         </div>
-        <span className="sr-only">{alertDescription}</span>
+        <span className="sr-only">{alertSeverityDescription}</span>
       </div>
     );
   };
@@ -541,6 +566,7 @@ TransitLeg.propTypes = {
   interliningWait: PropTypes.number,
   focusAction: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
+  lang: PropTypes.string.isRequired,
 };
 
 TransitLeg.contextTypes = {
@@ -555,4 +581,12 @@ TransitLeg.contextTypes = {
   intl: intlShape.isRequired,
 };
 
-export default TransitLeg;
+const connectedComponent = connectToStores(
+  TransitLeg,
+  ['PreferencesStore'],
+  context => ({
+    lang: context.getStore('PreferencesStore').getLanguage(),
+  }),
+);
+
+export { connectedComponent as default, TransitLeg as Component };

--- a/app/component/itinerary.scss
+++ b/app/component/itinerary.scss
@@ -898,7 +898,7 @@ $itinerary-tab-switch-height: 48px;
       display: flex;
       background-color: #f4f4f5;
       border-radius: 5px;
-      margin-bottom: 10px;
+      margin-bottom: 2px;
       &.long-name {
         display: block;
         .headsign {
@@ -966,6 +966,55 @@ $itinerary-tab-switch-height: 48px;
       font-weight: normal;
       display: flex;
       align-items: center;
+    }
+
+    .disruption {
+      border-radius: 5px;
+      border: solid 1px #dddddd;
+      margin-bottom: 10px;
+
+      .disruption-icon {
+        width: 18px;
+        height: 18px;
+        font-size: 18px;
+        margin: 3px 0px 8px 0;
+        .inline-icon {
+          margin-left: 0px;
+        }
+      }
+
+      .description {
+        flex: 1;
+        font-size: $font-size-xsmall;
+        color: #333333;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        margin: 0 4px 0 8px;
+        line-height: 1.23;
+        letter-spacing: -0.43px;
+      }
+
+      .disruption-link-arrow {
+        margin-top: 5px;
+        font-size: 18px;
+        height: 18px
+      }
+
+      .external-link-container {
+        border: none;
+        width: 100%;
+        padding: 0px;
+      }
+
+      .external-link {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 6px 15px 8px 12px;
+      }
     }
 
     .itinerary-leg-action {

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -575,6 +575,35 @@ export const getActiveLegAlertSeverityLevel = leg => {
 };
 
 /**
+ * Returns an array of currently active alerts for the legs' route and stops
+ *
+ * @param {*} leg the itinerary leg to check.
+ * @param {*} legStartTime the reference unix time stamp (in seconds).
+ * @param {*} locale the locale to use, defaults to 'en'.
+ */
+export const getActiveLegAlerts = (leg, legStartTime, locale = 'en') => {
+  if (!leg) {
+    return undefined;
+  }
+  const serviceAlerts = [
+    ...getServiceAlertsForRoute(
+      leg.route,
+      leg.trip && leg.trip.pattern && leg.trip.pattern.code,
+      locale,
+    ),
+    ...getServiceAlertsForStop(leg.from && leg.from.stop, locale),
+    ...getServiceAlertsForStop(leg.to && leg.to.stop, locale),
+    ...(Array.isArray(leg.intermediatePlaces)
+      ? leg.intermediatePlaces
+          .map(place => getServiceAlertsForStop(place.stop, locale))
+          .reduce((a, b) => a.concat(b), [])
+      : []),
+  ].filter(alert => isAlertActive([{}], alert, legStartTime) !== false);
+
+  return serviceAlerts;
+};
+
+/**
  * Compares the given alerts in order to sort them.
  *
  * @param {*} a the first alert to compare.


### PR DESCRIPTION
## Proposed Changes

  - feat: disruption info to itinerary view
  - Note: testing this might be difficult so I included a testLeg with alert which can be used to replace the leg on line 255 in TransitLeg.js, alternatively one can somehow edit the data that graphQL provides

[testLeg.txt](https://github.com/HSLdevcom/digitransit-ui/files/5603512/testLeg.txt)



## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
