### PR TITLE
DT-4157: Favorite stops are available in itinerary page mobile search

### DIFF
--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -145,6 +145,13 @@ class IndexPage extends React.Component {
     }${this.context.config.trafficNowLink[lang]}`;
   };
 
+  filterMobileFavouriteStops = (results, type) => {
+    const filteredResults = results.filter(
+      res => !res.properties.layer.includes('favourite'),
+    );
+    return type === 'Stops' ? filteredResults : results;
+  };
+
   /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
   render() {
     const { intl, config } = this.context;
@@ -311,7 +318,9 @@ class IndexPage extends React.Component {
                 'CurrentPosition',
                 'MapPosition',
                 'FutureRoutes',
+                'Stops',
               ]}
+              filterResults={this.filterMobileFavouriteStops}
               disableAutoFocus
               isMobile
               breakpoint="small"

--- a/app/component/OriginDestinationBar.js
+++ b/app/component/OriginDestinationBar.js
@@ -120,6 +120,13 @@ class OriginDestinationBar extends React.Component {
     }
   };
 
+  filterMobileFavouriteStops = (results, type) => {
+    const filteredResults = results.filter(
+      res => !res.properties.layer.includes('favourite'),
+    );
+    return type === 'Stops' ? filteredResults : results;
+  };
+
   swapEndpoints = () => {
     const { location } = this.context.match;
     const intermediatePlaces = getIntermediatePlaces(location.query);
@@ -171,6 +178,7 @@ class OriginDestinationBar extends React.Component {
             this.props.isMobile ? 'MapPosition' : '',
             'Stops',
           ]}
+          filterResults={this.filterMobileFavouriteStops}
           lang={this.props.language}
           disableAutoFocus={this.props.isMobile}
           isMobile={this.props.isMobile}

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "digitransit-component autosuggest-panel module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/src/index.js
@@ -156,6 +156,7 @@ class DTAutosuggestPanel extends React.Component {
     disableAutoFocus: PropTypes.bool,
     sources: PropTypes.arrayOf(PropTypes.string),
     targets: PropTypes.arrayOf(PropTypes.string),
+    filterResults: PropTypes.func,
     isMobile: PropTypes.bool,
     color: PropTypes.string,
     hoverColor: PropTypes.string,
@@ -171,6 +172,7 @@ class DTAutosuggestPanel extends React.Component {
     lang: 'fi',
     sources: [],
     targets: [],
+    filterResults: undefined,
     disableAutoFocus: false,
     isMobile: false,
     handleViaPointLocationSelected: undefined,
@@ -406,6 +408,7 @@ class DTAutosuggestPanel extends React.Component {
             lang={this.props.lang}
             sources={this.props.sources}
             targets={this.props.targets}
+            filterResults={this.props.filterResults}
             isMobile={this.props.isMobile}
             color={this.props.color}
             hoverColor={this.props.hoverColor}
@@ -480,6 +483,7 @@ class DTAutosuggestPanel extends React.Component {
                       lang={this.props.lang}
                       sources={this.props.sources}
                       targets={this.props.targets}
+                      filterResults={this.props.filterResults}
                       isMobile={this.props.isMobile}
                       color={this.props.color}
                       hoverColor={this.props.hoverColor}
@@ -578,6 +582,7 @@ class DTAutosuggestPanel extends React.Component {
             lang={this.props.lang}
             sources={this.props.sources}
             targets={this.props.targets}
+            filterResults={this.props.filterResults}
             isMobile={this.props.isMobile}
             color={this.props.color}
             hoverColor={this.props.hoverColor}


### PR DESCRIPTION
## Proposed Changes

  - FilteredResults function was available in StopsNearYou. Added that to AutosuggestPanel as well
  - Added stops to mobile front page
  - Added filter to remove favouriteStops in mobile.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
