### PR TITLE
Dt 4173

### DIFF
--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -162,7 +162,6 @@ class IndexPage extends React.Component {
       'Locations',
       'CurrentPosition',
       'FutureRoutes',
-      'SelectFromOwnLocations',
       'Stops',
     ];
     const stopAndRouteSearchTargets =

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -145,13 +145,6 @@ class IndexPage extends React.Component {
     }${this.context.config.trafficNowLink[lang]}`;
   };
 
-  filterMobileFavouriteStops = (results, type) => {
-    const filteredResults = results.filter(
-      res => !res.properties.layer.includes('favourite'),
-    );
-    return type === 'Stops' ? filteredResults : results;
-  };
-
   /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
   render() {
     const { intl, config } = this.context;
@@ -320,7 +313,6 @@ class IndexPage extends React.Component {
                 'FutureRoutes',
                 'Stops',
               ]}
-              filterResults={this.filterMobileFavouriteStops}
               disableAutoFocus
               isMobile
               breakpoint="small"

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -153,10 +153,7 @@ class IndexPage extends React.Component {
     const hoverColor = colors.hover || LightenDarkenColor(colors.primary, -20);
     const { breakpoint, destination, origin, lang } = this.props;
     const queryString = this.context.match.location.search;
-    const searchSources =
-      breakpoint !== 'large'
-        ? ['Favourite', 'History', 'Datasource']
-        : ['History', 'Datasource'];
+    const searchSources = ['Favourite', 'History', 'Datasource'];
     const stopAndRouteSearchSources = ['Favourite', 'History', 'Datasource'];
     const locationSearchTargets = [
       'Locations',

--- a/app/component/OriginDestinationBar.js
+++ b/app/component/OriginDestinationBar.js
@@ -120,13 +120,6 @@ class OriginDestinationBar extends React.Component {
     }
   };
 
-  filterMobileFavouriteStops = (results, type) => {
-    const filteredResults = results.filter(
-      res => !res.properties.layer.includes('favourite'),
-    );
-    return type === 'Stops' ? filteredResults : results;
-  };
-
   swapEndpoints = () => {
     const { location } = this.context.match;
     const intermediatePlaces = getIntermediatePlaces(location.query);
@@ -167,18 +160,14 @@ class OriginDestinationBar extends React.Component {
           sources={[
             'History',
             'Datasource',
-            this.props.isMobile && this.props.showFavourites ? 'Favourite' : '',
+            this.props.showFavourites ? 'Favourite' : '',
           ]}
           targets={[
             'Locations',
             'CurrentPosition',
-            !this.props.isMobile && this.props.showFavourites
-              ? 'SelectFromOwnLocations'
-              : '',
             this.props.isMobile ? 'MapPosition' : '',
             'Stops',
           ]}
-          filterResults={this.filterMobileFavouriteStops}
           lang={this.props.language}
           disableAutoFocus={this.props.isMobile}
           isMobile={this.props.isMobile}

--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -371,26 +371,14 @@ class StopsNearYouPage extends React.Component { // eslint-disable-line
     });
   };
 
-  filterMobileFavouriteStops = (results, type) => {
-    const filteredResults = results.filter(
-      res => !res.properties.layer.includes('favourite'),
-    );
-    return type === 'Stops' ? filteredResults : results;
-  };
-
   renderAutoSuggestField = () => {
     const isMobile = this.props.breakpoint !== 'large';
     return (
       <DTAutoSuggestWithSearchContext
         appElement="#app"
         icon="search"
-        sources={['History', 'Datasource', isMobile ? 'Favourite' : '']}
-        targets={[
-          'Locations',
-          !isMobile ? 'SelectFromOwnLocations' : '',
-          'Stops',
-        ]}
-        filterResults={this.filterMobileFavouriteStops}
+        sources={['History', 'Datasource', 'Favourite']}
+        targets={['Locations', 'Stops']}
         id="origin-stop-near-you"
         placeholder="origin"
         value=""

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/README.md
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/README.md
@@ -63,7 +63,7 @@ const destination = {
 onSelect() {
  return null;  // Define what to do when a suggestion is being selected. None by default.
  }
-const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, BikeRentalStations, FutureRoutes, SelectFromOwnLocations, MapPosition and CurrentPosition. Leave empty to search all targets.
+const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, BikeRentalStations, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
 const sources = ['Favourite', 'History', 'Datasource'] // Defines where you are searching. all available are: Favourite, History (previously searched searches), and Datasource. Leave empty to use all sources.
 <DTAutosuggestPanel
    appElement={appElement} // Required. Root element's id. Needed for react-modal component.

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "digitransit-component autosuggest-panel module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "1.3.2",
+    "@digitransit-component/digitransit-component-autosuggest": "1.3.3",
     "@digitransit-component/digitransit-component-icon": "0.0.14"
   },
   "peerDependencies": {

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/src/index.js
@@ -113,7 +113,7 @@ ItinerarySearchControl.propTypes = {
  * onSelect() {
  *  return null;  // Define what to do when a suggestion is being selected. None by default.
  *  }
- * const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, BikeRentalStations, FutureRoutes, SelectFromOwnLocations, MapPosition and CurrentPosition. Leave empty to search all targets.
+ * const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, BikeRentalStations, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
  * const sources = ['Favourite', 'History', 'Datasource'] // Defines where you are searching. all available are: Favourite, History (previously searched searches), and Datasource. Leave empty to use all sources.
  * <DTAutosuggestPanel
  *    appElement={appElement} // Required. Root element's id. Needed for react-modal component.

--- a/digitransit-component/packages/digitransit-component-autosuggest/README.md
+++ b/digitransit-component/packages/digitransit-component-autosuggest/README.md
@@ -53,7 +53,7 @@ const onClear = () => {
 };
 const transportMode = undefined;
 const placeholder = "stop-near-you";
-const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, BikeRentalStations, FutureRoutes, SelectFromOwnLocations, MapPosition and CurrentPosition. Leave empty to search all targets.
+const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, BikeRentalStations, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
 const sources = ['Favourite', 'History', 'Datasource'] // Defines where you are searching. all available are: Favourite, History (previously searched searches) and Datasource. Leave empty to use all sources.
 return (
  <DTAutosuggest

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "digitransit-component autosuggest module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -146,7 +146,7 @@ function translateFutureRouteSuggestionTime(item) {
  * };
  * const transportMode = undefined;
  * const placeholder = "stop-near-you";
- * const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, BikeRentalStations, FutureRoutes, SelectFromOwnLocations, MapPosition and CurrentPosition. Leave empty to search all targets.
+ * const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, BikeRentalStations, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
  * const sources = ['Favourite', 'History', 'Datasource'] // Defines where you are searching. all available are: Favourite, History (previously searched searches) and Datasource. Leave empty to use all sources.
  * return (
  *  <DTAutosuggest

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
@@ -231,9 +231,13 @@ function getOldSearches(oldSearches, input, dropLayers) {
   );
 }
 
-function hasFavourites(context, locations) {
+function hasFavourites(context, locations, stops) {
   const favouriteLocations = locations(context);
-  return favouriteLocations && favouriteLocations.length > 0;
+  if (favouriteLocations && favouriteLocations.length > 0) {
+    return true;
+  }
+  const favouriteStops = stops(context);
+  return favouriteStops && favouriteStops.length > 0;
 }
 
 const routeLayers = [
@@ -314,7 +318,7 @@ export function getSearchResults(
   }
   if (
     targets.includes('SelectFromOwnLocations') &&
-    hasFavourites(context, locations)
+    hasFavourites(context, locations, stops)
   ) {
     searchComponents.push(selectFromOwnLocations(input));
   }

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
@@ -39,11 +39,15 @@ function getStopsFromGeocoding(stops, URL_PELIAS_PLACE) {
       const favourite = {
         type: 'FavouriteStop',
         properties: {
-          ...stopStationMap[stop.properties.gid],
+          gid: stopStationMap[stop.properties.gid].gid,
+          code: stopStationMap[stop.properties.gid].code,
+          gtfsId: stopStationMap[stop.properties.gid].gtfsId,
+          lastUpdated: stopStationMap[stop.properties.gid].lastUpdated,
+          favouriteId: stopStationMap[stop.properties.gid].favouriteId,
           address: stop.properties.label,
           layer: isStop(stop.properties) ? 'favouriteStop' : 'favouriteStation',
         },
-        ...stop.geometry,
+        geometry: stop.geometry,
       };
       return favourite;
     });

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-execute-search-immidiate",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "digitransit-search-util execute-search-immidiate module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/index.js
@@ -300,6 +300,7 @@ export const filterStopsAndStationsByMode = (stopsToFilter, mode) => {
     .filter(
       item =>
         item.properties.layer === 'station' ||
+        item.properties.layer === 'favouriteStation' ||
         item.properties.type === 'station',
     )
     .map(item => item.gtfsId);
@@ -307,7 +308,9 @@ export const filterStopsAndStationsByMode = (stopsToFilter, mode) => {
   const stopIds = stopsToFilter
     .filter(
       item =>
-        item.properties.layer === 'stop' || item.properties.type === 'stop',
+        item.properties.layer === 'stop' ||
+        item.properties.layer === 'favouriteStop' ||
+        item.properties.type === 'stop',
     )
     .map(item => item.gtfsId);
 

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-query-utils",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "digitransit-search-util query-utils module",
   "main": "index.generated",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1380,6 +1380,18 @@
     "@digitransit-search-util/digitransit-search-util-uniq-by-label" "0.0.4"
     lodash "4.17.14"
 
+"@digitransit-search-util/digitransit-search-util-execute-search-immidiate@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@digitransit-search-util/digitransit-search-util-execute-search-immidiate/-/digitransit-search-util-execute-search-immidiate-0.2.4.tgz#dbacbbefea821a3977c20efda63a2d81e95f5879"
+  integrity sha512-O41J0VZSRk0hy2VJbLOD+GNU8WHyE/4txsq5AhZZDBmO4FOenVNfHCBo8UdhlaBLZHviX5PN92a5/lNEirMAgw==
+  dependencies:
+    "@digitransit-search-util/digitransit-search-util-filter-matching-to-input" "0.0.1"
+    "@digitransit-search-util/digitransit-search-util-get-geocoding-results" "0.0.3"
+    "@digitransit-search-util/digitransit-search-util-get-json" "0.0.2"
+    "@digitransit-search-util/digitransit-search-util-helpers" "0.0.11"
+    "@digitransit-search-util/digitransit-search-util-uniq-by-label" "0.0.5"
+    lodash "4.17.14"
+
 "@digitransit-search-util/digitransit-search-util-get-label@0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@digitransit-search-util/digitransit-search-util-get-label/-/digitransit-search-util-get-label-0.0.3.tgz#e769e9b401b78e1183b3cd0ff1faa8b0266f6693"


### PR DESCRIPTION
- Remove complicated external stop filtering logic
- Fix faulty favorite stop enrichment with geocoder, it produced object structure different from everything else
- Move the tricky logic which presents favorites in desktop as sub selection into search component itself
- Allow favorite stops consistently in location search (because old search stops are also visible)


