### PR TITLE
DT-4138 Configured transit modes should be taken into account when fetching with all modes

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -670,7 +670,7 @@ class SummaryPage extends React.Component {
       }
     `;
 
-    const planParams = preparePlanParams(this.context.config)(
+    const planParams = preparePlanParams(this.context.config, false)(
       this.context.match.params,
       this.context.match,
     );
@@ -778,22 +778,11 @@ class SummaryPage extends React.Component {
       }
     `;
 
-    const planParams = preparePlanParams(this.context.config)(
+    const planParams = preparePlanParams(this.context.config, true)(
       this.context.match.params,
       this.context.match,
     );
-    const variables = {
-      ...planParams,
-      modes: [
-        { mode: 'WALK' },
-        { mode: 'BUS' },
-        { mode: 'TRAM' },
-        { mode: 'SUBWAY' },
-        { mode: 'RAIL' },
-        { mode: 'FERRY' },
-      ],
-    };
-    fetchQuery(this.props.relayEnvironment, query, variables).then(
+    fetchQuery(this.props.relayEnvironment, query, planParams).then(
       ({ plan: results }) => {
         this.setState({ alternativePlan: results }, () => {
           this.setLoading(false);
@@ -835,7 +824,7 @@ class SummaryPage extends React.Component {
       return;
     }
 
-    const params = preparePlanParams(this.context.config)(
+    const params = preparePlanParams(this.context.config, false)(
       this.context.match.params,
       this.context.match,
     );
@@ -1031,7 +1020,7 @@ class SummaryPage extends React.Component {
       return;
     }
 
-    const params = preparePlanParams(this.context.config)(
+    const params = preparePlanParams(this.context.config, false)(
       this.context.match.params,
       this.context.match,
     );
@@ -1722,7 +1711,7 @@ class SummaryPage extends React.Component {
             },
             // eslint-disable-next-line func-names
             function () {
-              const planParams = preparePlanParams(this.context.config)(
+              const planParams = preparePlanParams(this.context.config, false)(
                 this.context.match.params,
                 this.context.match,
               );

--- a/app/routes.js
+++ b/app/routes.js
@@ -210,7 +210,7 @@ export default config => {
                 ).then(getDefault)
               }
               query={planQuery}
-              prepareVariables={preparePlanParams(config)}
+              prepareVariables={preparePlanParams(config, false)}
               render={({ Component, props, error, match }) => {
                 if (Component) {
                   return props ? (

--- a/app/util/modeUtils.js
+++ b/app/util/modeUtils.js
@@ -202,6 +202,18 @@ export const getDefaultModes = config => [
 ];
 
 /**
+ * Retrieves all default transport modes that are
+ * both available and marked as default and adds WALK mode.
+ *
+ * @param {*} config The configuration for the software installation
+ * @returns {String[]} an array of modes
+ */
+export const getDefaultModesWithWalk = config => [
+  ...getDefaultTransportModes(config),
+  'WALK',
+];
+
+/**
  * Retrieves all modes (as in both transport and street modes)
  * from either the localStorage or the default configuration.
  * If modes include CAR, BICYCLE or WALK modes use default instead

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -2,7 +2,12 @@ import omitBy from 'lodash/omitBy';
 import moment from 'moment';
 import cookie from 'react-cookie';
 
-import { filterModes, getDefaultModes, getModes } from './modeUtils';
+import {
+  filterModes,
+  getDefaultModes,
+  getDefaultModesWithWalk,
+  getModes,
+} from './modeUtils';
 import { otpToLocation, getIntermediatePlaces } from './otpStrings';
 import { getDefaultNetworks } from './citybikes';
 import { getCustomizedSettings } from '../store/localStorage';
@@ -141,7 +146,7 @@ export const getSettings = config => {
   };
 };
 
-export const preparePlanParams = config => (
+export const preparePlanParams = (config, useDefaultModes) => (
   { from, to },
   {
     location: {
@@ -155,13 +160,15 @@ export const preparePlanParams = config => (
   const intermediatePlaceLocations = getIntermediatePlaces({
     intermediatePlaces,
   });
-  const modesOrDefault = filterModes(
-    config,
-    getModes(config),
-    fromLocation,
-    toLocation,
-    intermediatePlaceLocations,
-  );
+  const modesOrDefault = useDefaultModes
+    ? getDefaultModesWithWalk(config).join(',')
+    : filterModes(
+        config,
+        getModes(config),
+        fromLocation,
+        toLocation,
+        intermediatePlaceLocations,
+      );
   const defaultSettings = { ...getDefaultSettings(config) };
   const allowedBikeRentalNetworksMapped =
     settings.allowedBikeRentalNetworks ||


### PR DESCRIPTION
## Proposed Changes

  - Refactor itinerary request with all modes to use default modes from config and to already take these modes into account in planParamUtil

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
