### PR TITLE
fix: no login if it is doomed to fail

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -121,6 +121,12 @@ export function getNamedConfiguration(configName) {
 
     configs[configName] = config;
   }
+  if (!process.env.OIDC_CLIENT_ID && configs[configName].allowLogin) {
+    return {
+      ...configs[configName],
+      allowLogin: false,
+    };
+  }
   return configs[configName];
 }
 


### PR DESCRIPTION
Do not show login menu when login is not possible