### PR TITLE
fix: resolve itinerary searches of type /POS/POS/ properly

### DIFF
--- a/app/component/Geolocator.js
+++ b/app/component/Geolocator.js
@@ -23,10 +23,10 @@ const GeolocatorWithPosition = connectToStores(
       const locationForUrl = addressToItinerarySearch(locationState);
       const newFrom = from === undefined ? locationForUrl : from;
       let newTo;
-      if (locationForUrl && isEqual(locationForUrl, newFrom)) {
-        newTo = to === undefined || to === 'POS' ? '-' : to;
+      if (to === 'POS' || (from !== undefined && to === undefined)) {
+        newTo = locationForUrl;
       } else {
-        newTo = to === undefined || to === 'POS' ? locationForUrl : to;
+        newTo = to === undefined ? '-' : to;
       }
       const returnPath = createReturnPath(path, newFrom, newTo);
 


### PR DESCRIPTION
Location resolver no longer removes destination POS from url, if origin is also POS. 