### PR TITLE
DT-4218: Add property to define mobile search label

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "digitransit-component autosuggest-panel module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/src/index.js
@@ -137,6 +137,8 @@ ItinerarySearchControl.propTypes = {
  *    sources={sources}
  *    targets={targets}
  *    isMobile  // Optional. Defaults to false. Whether to use mobile search.
+ *    originMobileLabel="Origin label" // Optional. Custom label text for origin field on mobile.
+ *    destinationMobileLabel="Destination label" // Optional. Custom label text for destination field on mobile.
  */
 class DTAutosuggestPanel extends React.Component {
   static propTypes = {
@@ -163,6 +165,8 @@ class DTAutosuggestPanel extends React.Component {
     isMobile: PropTypes.bool,
     color: PropTypes.string,
     hoverColor: PropTypes.string,
+    originMobileLabel: PropTypes.string,
+    destinationMobileLabel: PropTypes.string,
   };
 
   static defaultProps = {
@@ -181,6 +185,8 @@ class DTAutosuggestPanel extends React.Component {
     handleViaPointLocationSelected: undefined,
     color: '#007ac9',
     hoverColor: '#0062a1',
+    originMobileLabel: null,
+    destinationMobileLabel: null,
   };
 
   constructor(props) {
@@ -365,6 +371,8 @@ class DTAutosuggestPanel extends React.Component {
       searchContext,
       disableAutoFocus,
       viaPoints,
+      originMobileLabel,
+      destinationMobileLabel,
     } = this.props;
     const { activeSlackInputs } = this.state;
     const slackTime = this.getSlackTimeOptions();
@@ -418,6 +426,7 @@ class DTAutosuggestPanel extends React.Component {
             isMobile={this.props.isMobile}
             color={this.props.color}
             hoverColor={this.props.hoverColor}
+            mobileLabel={originMobileLabel}
           />
           <ItinerarySearchControl
             className={styles.opposite}
@@ -592,6 +601,7 @@ class DTAutosuggestPanel extends React.Component {
             isMobile={this.props.isMobile}
             color={this.props.color}
             hoverColor={this.props.hoverColor}
+            mobileLabel={destinationMobileLabel}
           />
           <ItinerarySearchControl
             className={cx(styles['add-via-point'], styles.more, {

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "digitransit-component autosuggest module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -172,6 +172,7 @@ function translateFutureRouteSuggestionTime(item) {
  *    sources={sources}
  *    targets={targets}
  *    isMobile  // Optional. Defaults to false. Whether to use mobile search.
+ *    mobileLabel="Custom label" // Optional. Custom label text for autosuggest field on mobile.
  */
 class DTAutosuggest extends React.Component {
   static propTypes = {
@@ -203,6 +204,7 @@ class DTAutosuggest extends React.Component {
       routesPrefix: PropTypes.string,
       stopsPrefix: PropTypes.string,
     }),
+    mobileLabel: PropTypes.string,
   };
 
   static defaultProps = {
@@ -221,6 +223,7 @@ class DTAutosuggest extends React.Component {
       routesPrefix: 'linjat',
       stopsPrefix: 'pysakit',
     },
+    mobileLabel: undefined,
   };
 
   constructor(props) {
@@ -793,7 +796,11 @@ class DTAutosuggest extends React.Component {
               )
             }
             ariaLabel={SearchBarId.concat(' ').concat(ariaLabelText)}
-            label={i18next.t(this.props.id)}
+            label={
+              this.props.mobileLabel
+                ? this.props.mobileLabel
+                : i18next.t(this.props.id)
+            }
             onSuggestionSelected={this.onSelected}
             onKeyDown={this.keyDown}
             dialogHeaderText={i18next.t('delete-old-searches-header')}


### PR DESCRIPTION
## Proposed Changes

  - Add mobileLabel property to digitransit-component-autosuggest.
  - Add originMobileLabel and destinationMobileLabel properties to digitransit-component-autosuggest-panel.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
