### PR TITLE
DT-4266 Mismatch between summary and itinerary page route alerts and DT-4249 Change disruption link of itineraries to point to route page/disruptions tab

### DIFF
--- a/app/component/ItinerarySummaryListContainer.js
+++ b/app/component/ItinerarySummaryListContainer.js
@@ -399,6 +399,11 @@ const containerComponent = createFragmentContainer(
               gtfsId
               zoneId
               platformCode
+              alerts {
+                alertSeverityLevel
+                effectiveEndDate
+                effectiveStartDate
+              }
             }
             bikeRentalStation {
               bikesAvailable
@@ -409,6 +414,11 @@ const containerComponent = createFragmentContainer(
             stop {
               gtfsId
               zoneId
+              alerts {
+                alertSeverityLevel
+                effectiveEndDate
+                effectiveStartDate
+              }
             }
             bikePark {
               bikeParkId

--- a/app/component/ItineraryTab.js
+++ b/app/component/ItineraryTab.js
@@ -315,26 +315,6 @@ const withRelay = createFragmentContainer(ItineraryTab, {
             code
             platformCode
             zoneId
-            alerts {
-              alertSeverityLevel
-              effectiveEndDate
-              effectiveStartDate
-              trip {
-                pattern {
-                  code
-                }
-              }
-              alertHeaderText
-              alertHeaderTextTranslations {
-                text
-                language
-              }
-              alertUrl
-              alertUrlTranslations {
-                text
-                language
-              }
-            }
           }
         }
         realTime

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -20,6 +20,7 @@ import {
   legHasCancelation,
   tripHasCancelationForStop,
   getActiveLegAlerts,
+  alertSeverityCompare,
 } from '../util/alertUtils';
 import { PREFIX_ROUTES, PREFIX_STOPS } from '../util/path';
 import { durationToString } from '../util/timeUtils';
@@ -257,7 +258,10 @@ class TransitLeg extends React.Component {
     );
 
     const alerts = getActiveLegAlerts(leg, leg.startTime / 1000, lang); // legStartTime converted to ms format
-    const alert = alerts && alerts.length > 0 ? alerts[0] : undefined;
+    const alert =
+      alerts && alerts.length > 0
+        ? alerts.sort(alertSeverityCompare)[0]
+        : undefined;
     const alertSeverityLevel = getActiveAlertSeverityLevel(
       alerts,
       leg.startTime / 1000,

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -23,7 +23,7 @@ import {
   alertSeverityCompare,
   getActiveLegAlertSeverityLevel,
 } from '../util/alertUtils';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../util/path';
+import { PREFIX_ROUTES, PREFIX_STOPS, PREFIX_DISRUPTION } from '../util/path';
 import { durationToString } from '../util/timeUtils';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
 import { getZoneLabel } from '../util/legUtils';
@@ -448,20 +448,32 @@ class TransitLeg extends React.Component {
             alertSeverityLevel === AlertSeverityLevelType.Severe ||
             alertSeverityLevel === AlertSeverityLevelType.Unknown) && (
             <div className="disruption">
-              <ExternalLink className="disruption-link" href={alert.url}>
-                <div className="disruption-icon">
-                  <ServiceAlertIcon
-                    className="inline-icon"
-                    severityLevel={alertSeverityLevel}
+              <div className="disruption-link-container">
+                <Link
+                  to={
+                    (alert.route &&
+                      alert.route.gtfsId &&
+                      `/${PREFIX_ROUTES}/${leg.route.gtfsId}/${PREFIX_DISRUPTION}/`) ||
+                    (alert.stop &&
+                      alert.stop.gtfsId &&
+                      `/${PREFIX_STOPS}/${alert.stop.gtfsId}/${PREFIX_DISRUPTION}/`)
+                  }
+                  className="disruption-link"
+                >
+                  <div className="disruption-icon">
+                    <ServiceAlertIcon
+                      className="inline-icon"
+                      severityLevel={alertSeverityLevel}
+                    />
+                  </div>
+                  <div className="description">{alert.header}</div>
+                  <Icon
+                    img="icon-icon_arrow-collapse--right"
+                    className="disruption-link-arrow"
+                    color={config.colors.primary}
                   />
-                </div>
-                <div className="description">{alert.header}</div>
-                <Icon
-                  img="icon-icon_arrow-collapse--right"
-                  className="disruption-link-arrow"
-                  color={config.colors.primary}
-                />
-              </ExternalLink>
+                </Link>
+              </div>
             </div>
           )}
           <LegAgencyInfo leg={leg} />

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -21,6 +21,7 @@ import {
   tripHasCancelationForStop,
   getActiveLegAlerts,
   alertSeverityCompare,
+  getActiveLegAlertSeverityLevel,
 } from '../util/alertUtils';
 import { PREFIX_ROUTES, PREFIX_STOPS } from '../util/path';
 import { durationToString } from '../util/timeUtils';
@@ -262,10 +263,7 @@ class TransitLeg extends React.Component {
       alerts && alerts.length > 0
         ? alerts.sort(alertSeverityCompare)[0]
         : undefined;
-    const alertSeverityLevel = getActiveAlertSeverityLevel(
-      alerts,
-      leg.startTime / 1000,
-    );
+    const alertSeverityLevel = getActiveLegAlertSeverityLevel(leg);
     let alertSeverityDescription = null;
     if (alertSeverityLevel) {
       let id;

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -21,7 +21,7 @@ import {
   tripHasCancelationForStop,
   getActiveLegAlerts,
   alertSeverityCompare,
-  getActiveLegAlertSeverityLevel,
+  getMaximumAlertSeverityLevel,
 } from '../util/alertUtils';
 import { PREFIX_ROUTES, PREFIX_STOPS, PREFIX_DISRUPTION } from '../util/path';
 import { durationToString } from '../util/timeUtils';
@@ -263,7 +263,7 @@ class TransitLeg extends React.Component {
       alerts && alerts.length > 0
         ? alerts.sort(alertSeverityCompare)[0]
         : undefined;
-    const alertSeverityLevel = getActiveLegAlertSeverityLevel(leg);
+    const alertSeverityLevel = getMaximumAlertSeverityLevel(alerts);
     let alertSeverityDescription = null;
     if (alertSeverityLevel) {
       let id;

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -445,7 +445,8 @@ class TransitLeg extends React.Component {
             <div className="headsign">{leg.trip.tripHeadsign}</div>
           </div>
           {(alertSeverityLevel === AlertSeverityLevelType.Warning ||
-            alertSeverityLevel === AlertSeverityLevelType.Severe) && (
+            alertSeverityLevel === AlertSeverityLevelType.Severe ||
+            alertSeverityLevel === AlertSeverityLevelType.Unknown) && (
             <div className="disruption">
               <ExternalLink className="disruption-link" href={alert.url}>
                 <div className="disruption-icon">

--- a/app/component/itinerary.scss
+++ b/app/component/itinerary.scss
@@ -1025,17 +1025,18 @@ $itinerary-tab-switch-height: 48px;
         height: 18px
       }
 
-      .external-link-container {
+      .disruption-link-container {
         border: none;
         width: 100%;
         padding: 0px;
       }
 
-      .external-link {
+      .disruption-link {
         display: flex;
         align-items: center;
         justify-content: space-between;
         padding: 6px 15px 8px 12px;
+        text-decoration: none;
       }
     }
 

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -349,7 +349,7 @@ export const getServiceAlertsForRoute = (
         patternIdPredicate(alert, patternId),
       ),
     },
-    { ...route, routeGtfsId: route.gtfsId },
+    { ...route, routeGtfsId: route && route.gtfsId },
     locale,
   );
 };
@@ -362,7 +362,7 @@ export const getServiceAlertsForRoute = (
  * @param {*} locale the locale to use, defaults to 'en'.
  */
 export const getServiceAlertsForStop = (stop, locale = 'en') =>
-  getServiceAlerts(stop, { stopGtfsId: stop.gtfsId }, locale);
+  getServiceAlerts(stop, { stopGtfsId: stop && stop.gtfsId }, locale);
 
 /**
  * Retrieves OTP-style Service Alerts from the given Terminal stop's stops  and

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -570,7 +570,7 @@ export const getActiveLegAlertSeverityLevel = leg => {
 };
 
 /**
- * Returns an array of currently active alerts for the legs' route and stops
+ * Returns an array of currently active alerts for the legs' route and origin/destination stops
  *
  * @param {*} leg the itinerary leg to check.
  * @param {*} legStartTime the reference unix time stamp (in seconds).
@@ -588,11 +588,6 @@ export const getActiveLegAlerts = (leg, legStartTime, locale = 'en') => {
     ),
     ...getServiceAlertsForStop(leg.from && leg.from.stop, locale),
     ...getServiceAlertsForStop(leg.to && leg.to.stop, locale),
-    ...(Array.isArray(leg.intermediatePlaces)
-      ? leg.intermediatePlaces
-          .map(place => getServiceAlertsForStop(place.stop, locale))
-          .reduce((a, b) => a.concat(b), [])
-      : []),
   ].filter(alert => isAlertActive([{}], alert, legStartTime) !== false);
 
   return serviceAlerts;

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -562,11 +562,6 @@ export const getActiveLegAlertSeverityLevel = leg => {
     ),
     ...getServiceAlertsForStop(leg.from && leg.from.stop),
     ...getServiceAlertsForStop(leg.to && leg.to.stop),
-    ...(Array.isArray(leg.intermediatePlaces)
-      ? leg.intermediatePlaces
-          .map(place => getServiceAlertsForStop(place.stop))
-          .reduce((a, b) => a.concat(b), [])
-      : []),
   ];
   return getActiveAlertSeverityLevel(
     serviceAlerts,

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -305,7 +305,7 @@ export const getServiceAlertMetadata = (alert = {}) => ({
 
 const getServiceAlerts = (
   { alerts } = {},
-  { color, mode, shortName } = {},
+  { color, mode, shortName, routeGtfsId, stopGtfsId } = {},
   locale = 'en',
 ) =>
   Array.isArray(alerts)
@@ -318,6 +318,10 @@ const getServiceAlerts = (
           color,
           mode,
           shortName,
+          gtfsId: routeGtfsId,
+        },
+        stop: {
+          gtfsId: stopGtfsId,
         },
         url: getServiceAlertUrl(alert, locale),
       }))
@@ -345,7 +349,7 @@ export const getServiceAlertsForRoute = (
         patternIdPredicate(alert, patternId),
       ),
     },
-    route,
+    { ...route, routeGtfsId: route.gtfsId },
     locale,
   );
 };
@@ -358,7 +362,7 @@ export const getServiceAlertsForRoute = (
  * @param {*} locale the locale to use, defaults to 'en'.
  */
 export const getServiceAlertsForStop = (stop, locale = 'en') =>
-  getServiceAlerts(stop, {}, locale);
+  getServiceAlerts(stop, { stopGtfsId: stop.gtfsId }, locale);
 
 /**
  * Retrieves OTP-style Service Alerts from the given Terminal stop's stops  and

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -635,6 +635,27 @@ export const alertCompare = (a, b) => {
 };
 
 /**
+ * Compares the given alerts in order to sort them based on severity level.
+ * The most severe alerts are sorted first.
+ *
+ * @param {*} a the first alert to compare.
+ * @param {*} b the second alert to compare.
+ */
+export const alertSeverityCompare = (a, b) => {
+  const severityLevels = [
+    AlertSeverityLevelType.Info,
+    AlertSeverityLevelType.Unknown,
+    AlertSeverityLevelType.Warning,
+    AlertSeverityLevelType.Severe,
+  ];
+
+  return (
+    severityLevels.indexOf(b.severityLevel) -
+    severityLevels.indexOf(a.severityLevel)
+  );
+};
+
+/**
  * Creates a list of unique alerts grouped under one header
  *@param {*} serviceAlerts The list of Service alerts to be mapped and filtered,
   @param {*} cancelations The list of Cancelations to be mapped and filtered,

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -629,8 +629,9 @@ export const alertCompare = (a, b) => {
 };
 
 /**
- * Compares the given alerts in order to sort them based on severity level.
- * The most severe alerts are sorted first.
+ * Compares the given alerts in order to sort them based on severity level and affected entity.
+ * The most severe alerts are sorted first, and alerts that affect routes are sorted before alerts
+ * that don't affect a route.
  *
  * @param {*} a the first alert to compare.
  * @param {*} b the second alert to compare.
@@ -643,10 +644,19 @@ export const alertSeverityCompare = (a, b) => {
     AlertSeverityLevelType.Severe,
   ];
 
-  return (
+  const severityLevelDifference =
     severityLevels.indexOf(b.severityLevel) -
-    severityLevels.indexOf(a.severityLevel)
-  );
+    severityLevels.indexOf(a.severityLevel);
+
+  if (severityLevelDifference === 0) {
+    if (a.route && a.route.gtfsId) {
+      return -1;
+    }
+    if (b.route && b.route.gtfsId) {
+      return 1;
+    }
+  }
+  return severityLevelDifference;
 };
 
 /**

--- a/test/unit/component/SummaryRow.test.js
+++ b/test/unit/component/SummaryRow.test.js
@@ -430,7 +430,7 @@ describe('<SummaryRow />', () => {
     ).to.equal(AlertSeverityLevelType.Warning);
   });
 
-  it('should indicate that there is a disruption due to a stop alert at an intermediate stop', () => {
+  it('should not indicate that there is a disruption due to a stop alert at an intermediate stop', () => {
     const props = {
       ...defaultProps,
       data: {
@@ -474,6 +474,6 @@ describe('<SummaryRow />', () => {
     });
     expect(
       wrapper.find(RouteNumberContainer).props().alertSeverityLevel,
-    ).to.equal(AlertSeverityLevelType.Warning);
+    ).to.equal(undefined);
   });
 });

--- a/test/unit/component/TransitLeg.test.js
+++ b/test/unit/component/TransitLeg.test.js
@@ -588,7 +588,7 @@ describe('<TransitLeg />', () => {
     );
   });
 
-  it('should apply alertSeverityLevel due to a stop alert at an intermediate stop', () => {
+  it('should not apply alertSeverityLevel due to a stop alert at an intermediate stop', () => {
     const props = {
       ...defaultProps,
       leg: {
@@ -638,7 +638,7 @@ describe('<TransitLeg />', () => {
       },
     });
     expect(wrapper.find(RouteNumber).props().alertSeverityLevel).to.equal(
-      AlertSeverityLevelType.Warning,
+      undefined,
     );
   });
 

--- a/test/unit/component/TransitLeg.test.js
+++ b/test/unit/component/TransitLeg.test.js
@@ -814,10 +814,10 @@ describe('<TransitLeg />', () => {
           gtfsId: 'A1234',
           alerts: [
             {
-              alertSeverityLevel: AlertSeverityLevelType.Info,
+              alertSeverityLevel: AlertSeverityLevelType.Unknown,
               effectiveEndDate: startTime + 1,
               effectiveStartDate: startTime - 1,
-              alertHeaderText: 'info header',
+              alertHeaderText: 'unkown header',
             },
             {
               alertSeverityLevel: AlertSeverityLevelType.Severe,
@@ -858,5 +858,54 @@ describe('<TransitLeg />', () => {
       },
     });
     expect(wrapper.find('.description').text()).to.equal('severe header');
+  });
+
+  it('should show header of unknown severity alerts if there is not alert more severe', () => {
+    const startTime = 123456789;
+    const props = {
+      ...defaultProps,
+      leg: {
+        from: {
+          name: 'Test',
+          stop: {},
+        },
+        duration: 10000,
+        intermediatePlaces: [],
+        route: {
+          gtfsId: 'A1234',
+          alerts: [
+            {
+              alertSeverityLevel: AlertSeverityLevelType.Unknown,
+              effectiveEndDate: startTime + 1,
+              effectiveStartDate: startTime - 1,
+              alertHeaderText: 'unknown header',
+            },
+          ],
+        },
+        startTime: startTime * 1000,
+        to: {
+          name: 'Testitie',
+          stop: {},
+        },
+        trip: {
+          gtfsId: 'A1234:01',
+          pattern: {
+            code: 'A',
+          },
+          tripHeadsign: 'foo - bar',
+        },
+        interlineWithPreviousLeg: false,
+      },
+      mode: 'BUS',
+    };
+
+    const wrapper = shallowWithIntl(<TransitLeg {...props} />, {
+      context: {
+        ...mockContext,
+        config: { itinerary: {}, colors: { primary: '#007ac9' } },
+        focusFunction: () => () => {},
+      },
+    });
+    expect(wrapper.find('.description').text()).to.equal('unknown header');
   });
 });

--- a/test/unit/component/TransitLeg.test.js
+++ b/test/unit/component/TransitLeg.test.js
@@ -798,4 +798,65 @@ describe('<TransitLeg />', () => {
       AlertSeverityLevelType.Info,
     );
   });
+
+  it('should show header of the most severe alert', () => {
+    const startTime = 123456789;
+    const props = {
+      ...defaultProps,
+      leg: {
+        from: {
+          name: 'Test',
+          stop: {},
+        },
+        duration: 10000,
+        intermediatePlaces: [],
+        route: {
+          gtfsId: 'A1234',
+          alerts: [
+            {
+              alertSeverityLevel: AlertSeverityLevelType.Info,
+              effectiveEndDate: startTime + 1,
+              effectiveStartDate: startTime - 1,
+              alertHeaderText: 'info header',
+            },
+            {
+              alertSeverityLevel: AlertSeverityLevelType.Severe,
+              effectiveEndDate: startTime + 1,
+              effectiveStartDate: startTime - 1,
+              alertHeaderText: 'severe header',
+            },
+            {
+              alertSeverityLevel: AlertSeverityLevelType.Warning,
+              effectiveEndDate: startTime + 1,
+              effectiveStartDate: startTime - 1,
+              alertHeaderText: 'warning header',
+            },
+          ],
+        },
+        startTime: startTime * 1000,
+        to: {
+          name: 'Testitie',
+          stop: {},
+        },
+        trip: {
+          gtfsId: 'A1234:01',
+          pattern: {
+            code: 'A',
+          },
+          tripHeadsign: 'foo - bar',
+        },
+        interlineWithPreviousLeg: false,
+      },
+      mode: 'BUS',
+    };
+
+    const wrapper = shallowWithIntl(<TransitLeg {...props} />, {
+      context: {
+        ...mockContext,
+        config: { itinerary: {}, colors: { primary: '#007ac9' } },
+        focusFunction: () => () => {},
+      },
+    });
+    expect(wrapper.find('.description').text()).to.equal('severe header');
+  });
 });

--- a/test/unit/util/alertUtils.test.js
+++ b/test/unit/util/alertUtils.test.js
@@ -1289,4 +1289,32 @@ describe('alertUtils', () => {
       ).to.equal(11);
     });
   });
+  describe('alertSeverityCompare', () => {
+    it('should sort alerts SEVERE alerts first', () => {
+      const alerts = [
+        { severityLevel: AlertSeverityLevelType.Warning },
+        { severityLevel: AlertSeverityLevelType.Severe },
+        { severityLevel: AlertSeverityLevelType.Info },
+        { severityLevel: AlertSeverityLevelType.Severe },
+        { severityLevel: 'foo' },
+      ];
+      const sortedAlerts = alerts.sort(utils.alertSeverityCompare);
+      expect(sortedAlerts[0].severityLevel).to.equal(
+        AlertSeverityLevelType.Severe,
+      );
+    });
+
+    it('should sort alerts WARNING alerts first if there are no SEVERE alerts', () => {
+      const alerts = [
+        { severityLevel: AlertSeverityLevelType.Unknown },
+        { severityLevel: AlertSeverityLevelType.Warning },
+        { severityLevel: AlertSeverityLevelType.Info },
+        { severityLevel: 'foo' },
+      ];
+      const sortedAlerts = alerts.sort(utils.alertSeverityCompare);
+      expect(sortedAlerts[0].severityLevel).to.equal(
+        AlertSeverityLevelType.Warning,
+      );
+    });
+  });
 });

--- a/test/unit/util/alertUtils.test.js
+++ b/test/unit/util/alertUtils.test.js
@@ -492,6 +492,7 @@ describe('alertUtils', () => {
         color: 'pink',
         mode: 'BUS',
         shortName: 'foobar',
+        gtfsId: 'foo: 1',
       };
       expect(utils.getServiceAlertsForRoute(route)).to.deep.equal([
         {
@@ -503,6 +504,10 @@ describe('alertUtils', () => {
             color: 'pink',
             mode: 'BUS',
             shortName: 'foobar',
+            gtfsId: 'foo: 1',
+          },
+          stop: {
+            gtfsId: undefined,
           },
           severityLevel: 'foo',
           url: 'https://www.hsl.fi/en',

--- a/test/unit/util/alertUtils.test.js
+++ b/test/unit/util/alertUtils.test.js
@@ -1138,7 +1138,7 @@ describe('alertUtils', () => {
       );
     });
 
-    it('should return "WARNING" if there is an active stop alert at an intermediate stop', () => {
+    it('should not return "WARNING" if there is an active stop alert at an intermediate stop', () => {
       const leg = {
         intermediatePlaces: [
           {
@@ -1155,9 +1155,7 @@ describe('alertUtils', () => {
         ],
         startTime: 1553769600000,
       };
-      expect(utils.getActiveLegAlertSeverityLevel(leg)).to.equal(
-        AlertSeverityLevelType.Warning,
-      );
+      expect(utils.getActiveLegAlertSeverityLevel(leg)).to.equal(undefined);
     });
 
     it('should return the given alertSeverityLevel', () => {

--- a/test/unit/util/alertUtils.test.js
+++ b/test/unit/util/alertUtils.test.js
@@ -1314,5 +1314,35 @@ describe('alertUtils', () => {
         AlertSeverityLevelType.Warning,
       );
     });
+
+    it('should sort alert that affects a route before a route that affects a stop if severity level is the same', () => {
+      const alerts = [
+        {
+          severityLevel: AlertSeverityLevelType.Severe,
+          stop: { gtfsId: 'foo:1' },
+        },
+        {
+          severityLevel: AlertSeverityLevelType.Severe,
+          route: { gtfsId: 'foo:1' },
+        },
+      ];
+      const sortedAlerts = alerts.sort(utils.alertSeverityCompare);
+      expect(sortedAlerts[0].route.gtfsId).to.equal('foo:1');
+    });
+
+    it('should not sort alert that affects a route before a route that affects a stop if route alert is less severe', () => {
+      const alerts = [
+        {
+          severityLevel: AlertSeverityLevelType.Severe,
+          stop: { gtfsId: 'foo:1' },
+        },
+        {
+          severityLevel: AlertSeverityLevelType.Warning,
+          route: { gtfsId: 'foo:1' },
+        },
+      ];
+      const sortedAlerts = alerts.sort(utils.alertSeverityCompare);
+      expect(sortedAlerts[0].stop.gtfsId).to.equal('foo:1');
+    });
   });
 });


### PR DESCRIPTION
## Proposed Changes

  - Display alert icon in summary page if it is shown in itinerary page
  - Ignore alerts that affect intermediate stops
  - Show alert header text from the alert that is the most severe
    - If two alerts are as severe, prefer alerts that affect a route
  - Link from alert header text to route or stop page disruptions tab

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
