### PR TITLE
Fix some geolocation related bugs

### DIFF
--- a/app/component/WithSearchContext.js
+++ b/app/component/WithSearchContext.js
@@ -97,12 +97,7 @@ export default function withSearchContext(WrappedComponent) {
             gid: locState.gid,
             name: locState.name,
             layer: locState.layer,
-            address:
-              locState.address ||
-              this.context.intl.formatMessage({
-                id: 'own-position',
-                defaultMessage: 'Own Location',
-              }),
+            address: locState.address,
           };
           this.onSuggestionSelected(
             location,
@@ -156,6 +151,12 @@ export default function withSearchContext(WrappedComponent) {
               this.props.onGeolocationStart(item, id);
             }
             return;
+          }
+          if (!location.address) {
+            location.address = this.context.intl.formatMessage({
+              id: 'own-position',
+              defaultMessage: 'Own Location',
+            });
           }
         } else {
           location = suggestionToLocation(item);

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "digitransit-component autosuggest module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -241,7 +241,6 @@ class DTAutosuggest extends React.Component {
       suggestions: [],
       editing: false,
       valid: true,
-      pendingCurrentLocation: false,
       renderMobileSearch: false,
       sources: props.sources,
       ownPlaces: false,
@@ -731,9 +730,6 @@ class DTAutosuggest extends React.Component {
   };
 
   render() {
-    if (this.state.pendingCurrentLocation) {
-      return <Loading />;
-    }
     const {
       value,
       suggestions,

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -711,12 +711,15 @@ class DTAutosuggest extends React.Component {
   onFocus = () => {
     const positions = [
       'Valittu sijainti',
+      'Nykyinen sijaintisi',
       'Current position',
       'Selected location',
       'Vald position',
       'Använd min position',
+      'Min position',
       'Käytä nykyistä sijaintia',
       'Use current location',
+      'Your current location',
     ];
     if (positions.includes(this.state.value)) {
       this.clearInput();


### PR DESCRIPTION
- 'Nykyinen sijaintisi' was not cleared from search input at activation
- If reverse geocoding failed,  search assigned default address 'Nykyinen sijaintisi' only at first selection. Next time user applied current location during the same session, the address (and search input) was left empty, which appeared quite confusing.
- Some old dead state management code removed