### PR TITLE
DT-4287 Walking/cycling suggestions are not updated after via point is added

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -261,8 +261,7 @@ class SummaryPage extends React.Component {
     this.isFetching = false;
     this.secondQuerySent = false;
     this.isFetchingWalkAndBike = true;
-    this.params = this.context.match.params;
-    this.query = this.context.match.location.query;
+    this.setParamsAndQuery();
     this.originalPlan = this.props.viewer && this.props.viewer.plan;
     // *** TODO: Hotfix variables for temporary use only
     this.justMounted = true;
@@ -476,6 +475,11 @@ class SummaryPage extends React.Component {
       !isEqual(this.params, this.context.match.params) ||
       !isEqual(this.query, this.context.match.location.query)
     );
+  };
+
+  setParamsAndQuery = () => {
+    this.params = this.context.match.params;
+    this.query = this.context.match.location.query;
   };
 
   resetSummaryPageSelection = () => {
@@ -829,8 +833,7 @@ class SummaryPage extends React.Component {
         () => {
           this.setLoading(false);
           this.isFetching = false;
-          this.params = this.context.match.params;
-          this.query = this.context.match.location.query;
+          this.setParamsAndQuery();
         },
       );
     });
@@ -1182,8 +1185,7 @@ class SummaryPage extends React.Component {
       this.secondQuerySent &&
       !this.isFetchingWalkAndBike
     ) {
-      this.params = this.context.match.params;
-      this.query = this.context.match.location.query;
+      this.setParamsAndQuery();
       this.secondQuerySent = false;
       this.isFetchingWalkAndBike = true;
       // eslint-disable-next-line react/no-did-update-set-state

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -262,6 +262,7 @@ class SummaryPage extends React.Component {
     this.secondQuerySent = false;
     this.isFetchingWalkAndBike = true;
     this.params = this.context.match.params;
+    this.query = this.context.match.location.query;
     this.originalPlan = this.props.viewer && this.props.viewer.plan;
     // *** TODO: Hotfix variables for temporary use only
     this.justMounted = true;
@@ -470,8 +471,11 @@ class SummaryPage extends React.Component {
     }
   };
 
-  paramsHaveChanged = () => {
-    return !isEqual(this.params, this.context.match.params);
+  paramsOrQueryHaveChanged = () => {
+    return (
+      !isEqual(this.params, this.context.match.params) ||
+      !isEqual(this.query, this.context.match.location.query)
+    );
   };
 
   resetSummaryPageSelection = () => {
@@ -826,6 +830,7 @@ class SummaryPage extends React.Component {
           this.setLoading(false);
           this.isFetching = false;
           this.params = this.context.match.params;
+          this.query = this.context.match.location.query;
         },
       );
     });
@@ -1173,11 +1178,12 @@ class SummaryPage extends React.Component {
         this.props.viewer && this.props.viewer.plan,
         this.originalPlan,
       ) &&
-      this.paramsHaveChanged() &&
+      this.paramsOrQueryHaveChanged() &&
       this.secondQuerySent &&
       !this.isFetchingWalkAndBike
     ) {
       this.params = this.context.match.params;
+      this.query = this.context.match.location.query;
       this.secondQuerySent = false;
       this.isFetchingWalkAndBike = true;
       // eslint-disable-next-line react/no-did-update-set-state


### PR DESCRIPTION
## Proposed Changes

  - Refetch walking and cycling suggestions when query parameters change

<b>There is still an issue where these suggestions fetched from cache show no itineraries error instead of the itineraries. This can be replicated for example by doing an itinerary search and then adding and removing a viapoint and clicking one of these suggestions. That issue should be fixed in some future pull request that probably should do a bit more refactoring as well</b>

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
