### PR TITLE
fix: working link to route disruptions

### DIFF
--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -456,7 +456,7 @@ class TransitLeg extends React.Component {
                   to={
                     (alert.route &&
                       alert.route.gtfsId &&
-                      `/${PREFIX_ROUTES}/${leg.route.gtfsId}/${PREFIX_DISRUPTION}/`) ||
+                      `/${PREFIX_ROUTES}/${leg.route.gtfsId}/${PREFIX_DISRUPTION}/${leg.trip.pattern.code}`) ||
                     (alert.stop &&
                       alert.stop.gtfsId &&
                       `/${PREFIX_STOPS}/${alert.stop.gtfsId}/${PREFIX_DISRUPTION}/`)


### PR DESCRIPTION
The original link caused redirect which added doubled path ../hairiot/hairiot/... .Removing / from the link end fixed this, and correct URL was created, but redirect still rendered white page although the path was correct.

The only way to the the link working was to set exactly correct url which does not need redirects.