### PR TITLE
DT-4127: The Show more button works strangely on The closest ferry piers near you view

### DIFF
--- a/app/component/map/StopsNearYouMap.js
+++ b/app/component/map/StopsNearYouMap.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connectToStores } from 'fluxible-addons-react';
 import { matchShape } from 'found';
-import { createRefetchContainer, graphql, fetchQuery } from 'react-relay';
+import { graphql, fetchQuery, createPaginationContainer } from 'react-relay';
 import moment from 'moment';
 import uniqBy from 'lodash/uniqBy';
 import compact from 'lodash/compact';
@@ -145,10 +145,13 @@ function StopsNearYouMap(
   const { mode } = match.params;
   const walkRoutingThreshold =
     mode === 'RAIL' || mode === 'SUBWAY' || mode === 'FERRY' ? 3000 : 1500;
+  const activeStops = stops.nearest.edges
+    .slice()
+    .filter(stop => stop.node.place.stoptimesWithoutPatterns.length);
   const sortedStopEdges =
     mode === 'CITYBIKE'
-      ? stops.nearest.edges.slice().sort(sortNearbyRentalStations(favouriteIds))
-      : stops.nearest.edges
+      ? activeStops.slice().sort(sortNearbyRentalStations(favouriteIds))
+      : activeStops
           .slice()
           .sort(sortNearbyStops(favouriteIds, walkRoutingThreshold));
   let useFitBounds = true;
@@ -222,7 +225,7 @@ function StopsNearYouMap(
   };
 
   useEffect(() => {
-    relay.refetch(oldVariables => {
+    relay.refetchConnection(5, null, oldVariables => {
       return {
         ...oldVariables,
         lat: position.lat,
@@ -238,11 +241,14 @@ function StopsNearYouMap(
     };
   }, []);
 
-  if (loading) {
-    return <Loading />;
-  }
-
   useEffect(() => {
+    const active = stops.nearest.edges
+      .slice()
+      .filter(stop => stop.node.place.stoptimesWithoutPatterns.length);
+    if (!active.length && relay.hasMore()) {
+      relay.loadMore(5);
+      return;
+    }
     if (Array.isArray(stopsAndStations)) {
       if (stopsAndStations.length > 0) {
         const firstStop = stopsAndStations[0];
@@ -268,6 +274,10 @@ function StopsNearYouMap(
       }
     }
   }, [favouriteIds, stops]);
+
+  if (loading || relay.isLoading()) {
+    return <Loading />;
+  }
 
   const routeLines = [];
   const realtimeTopics = [];
@@ -414,7 +424,9 @@ StopsNearYouMap.propTypes = {
   breakpoint: PropTypes.string.isRequired,
   language: PropTypes.string.isRequired,
   relay: PropTypes.shape({
-    refetch: PropTypes.func.isRequired,
+    refetchConnection: PropTypes.func.isRequired,
+    hasMore: PropTypes.func.isRequired,
+    loadMore: PropTypes.func.isRequired,
   }).isRequired,
 };
 
@@ -453,7 +465,7 @@ const StopsNearYouMapWithStores = connectToStores(
   },
 );
 
-const containerComponent = createRefetchContainer(
+const containerComponent = createPaginationContainer(
   StopsNearYouMapWithStores,
   {
     stops: graphql`
@@ -466,6 +478,7 @@ const containerComponent = createRefetchContainer(
         filterByPlaceTypes: { type: "[FilterPlaceType]", defaultValue: null }
         filterByModes: { type: "[Mode]", defaultValue: null }
         first: { type: "Int!", defaultValue: 5 }
+        after: { type: "String" }
         maxResults: { type: "Int" }
         maxDistance: { type: "Int" }
       ) {
@@ -475,9 +488,10 @@ const containerComponent = createRefetchContainer(
           filterByPlaceTypes: $filterByPlaceTypes
           filterByModes: $filterByModes
           first: $first
+          after: $after
           maxResults: $maxResults
           maxDistance: $maxDistance
-        ) {
+        ) @connection(key: "StopsNearYouMap_nearest") {
           edges {
             node {
               distance
@@ -511,6 +525,12 @@ const containerComponent = createRefetchContainer(
                       points
                     }
                   }
+                  stoptimesWithoutPatterns(
+                    startTime: $startTime
+                    omitNonPickups: $omitNonPickups
+                  ) {
+                    scheduledArrival
+                  }
                 }
               }
             }
@@ -519,34 +539,55 @@ const containerComponent = createRefetchContainer(
       }
     `,
   },
-  graphql`
-    query StopsNearYouMapRefetchQuery(
-      $lat: Float!
-      $lon: Float!
-      $filterByPlaceTypes: [FilterPlaceType]
-      $filterByModes: [Mode]
-      $first: Int!
-      $maxResults: Int!
-      $maxDistance: Int!
-      $startTime: Long!
-      $omitNonPickups: Boolean!
-    ) {
-      viewer {
-        ...StopsNearYouMap_stops
-        @arguments(
-          startTime: $startTime
-          omitNonPickups: $omitNonPickups
-          lat: $lat
-          lon: $lon
-          filterByPlaceTypes: $filterByPlaceTypes
-          filterByModes: $filterByModes
-          first: $first
-          maxResults: $maxResults
-          maxDistance: $maxDistance
-        )
+  {
+    direction: 'forward',
+    getConnectionFromProps(props) {
+      return props.stops && props.stops.nearest;
+    },
+    getFragmentVariables(prevVars, totalCount) {
+      return {
+        ...prevVars,
+        first: totalCount,
+      };
+    },
+    getVariables(_, pagevars, fragmentVariables) {
+      return {
+        ...fragmentVariables,
+        first: pagevars.count,
+        after: pagevars.cursor,
+      };
+    },
+    query: graphql`
+      query StopsNearYouMapRefetchQuery(
+        $lat: Float!
+        $lon: Float!
+        $filterByPlaceTypes: [FilterPlaceType]
+        $filterByModes: [Mode]
+        $first: Int!
+        $after: String
+        $maxResults: Int!
+        $maxDistance: Int!
+        $startTime: Long!
+        $omitNonPickups: Boolean!
+      ) {
+        viewer {
+          ...StopsNearYouMap_stops
+          @arguments(
+            startTime: $startTime
+            omitNonPickups: $omitNonPickups
+            lat: $lat
+            lon: $lon
+            filterByPlaceTypes: $filterByPlaceTypes
+            filterByModes: $filterByModes
+            first: $first
+            after: $after
+            maxResults: $maxResults
+            maxDistance: $maxDistance
+          )
+        }
       }
-    }
-  `,
+    `,
+  },
 );
 
 export {

--- a/app/component/map/StopsNearYouMap.js
+++ b/app/component/map/StopsNearYouMap.js
@@ -275,7 +275,7 @@ function StopsNearYouMap(
     }
   }, [favouriteIds, stops]);
 
-  if (loading || relay.isLoading()) {
+  if (loading) {
     return <Loading />;
   }
 

--- a/app/component/map/tile-layer/Stops.js
+++ b/app/component/map/tile-layer/Stops.js
@@ -86,9 +86,18 @@ class Stops {
 
           this.features = [];
 
+          // draw highlighted stops on lower zoom levels on near you page
+          const hasHilightedNearyouStops = !!(
+            this.stopsNearYouMode &&
+            this.tile.hilightedStops &&
+            this.tile.hilightedStops.length &&
+            this.tile.hilightedStops[0]
+          );
+
           if (
             vt.layers.stops != null &&
-            this.tile.coords.z >= this.config.stopsMinZoom
+            (this.tile.coords.z >= this.config.stopsMinZoom ||
+              hasHilightedNearyouStops)
           ) {
             const featureByCode = {};
             const hybridGtfsIdByCode = {};
@@ -105,6 +114,17 @@ class Stops {
               ) {
                 [[feature.geom]] = feature.loadGeometry();
                 const f = pick(feature, ['geom', 'properties']);
+
+                if (
+                  // if under zoom level limit, only draw highlighted stops on near you page
+                  this.tile.coords.z < this.config.stopsMinZoom &&
+                  !(
+                    hasHilightedNearyouStops &&
+                    this.tile.hilightedStops.includes(f.properties.gtfsId)
+                  )
+                ) {
+                  continue; // eslint-disable-line no-continue
+                }
                 if (
                   f.properties.code &&
                   this.config.mergeStopsByCode &&


### PR DESCRIPTION
## Proposed Changes

  - Hide stops with no upcoming traffic from stops near you map
  - This causes map to zoom farther away to see nearest stop, especially on ferry page
  - Also draw the icon for highlighted nearest stops on smaller zoom levels than before
  - At or below zoom level 12 icon is still hidden because map service does not return stops data at that level

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
