### PR TITLE
DT-4313 Citybikes should not be used for bike park itineraries

### DIFF
--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -266,6 +266,9 @@ export const preparePlanParams = (config, useDefaultModes) => (
       { mode: 'BICYCLE' },
       ...modesAsOTPModes(getBicycleCompatibleModes(config, modesOrDefault)),
     ],
-    bikeParkModes: [{ mode: 'BICYCLE', qualifier: 'PARK' }, ...formattedModes],
+    bikeParkModes: [
+      { mode: 'BICYCLE', qualifier: 'PARK' },
+      ...formattedModes,
+    ].filter(mode => mode.qualifier !== 'RENT'), // BIKE_RENT can't be used together with BICYCLE_PARK
   };
 };

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -269,6 +269,6 @@ export const preparePlanParams = (config, useDefaultModes) => (
     bikeParkModes: [
       { mode: 'BICYCLE', qualifier: 'PARK' },
       ...formattedModes,
-    ].filter(mode => mode.qualifier !== 'RENT'), // BIKE_RENT can't be used together with BICYCLE_PARK
+    ].filter(mode => mode.qualifier !== 'RENT'), // BICYCLE_RENT can't be used together with BICYCLE_PARK
   };
 };

--- a/test/unit/util/planParamUtil.test.js
+++ b/test/unit/util/planParamUtil.test.js
@@ -295,6 +295,29 @@ describe('planParamUtil', () => {
       expect(disableRemainingWeightHeuristic).to.equal(false);
     });
 
+    it('should not include CITYBIKE in bikepark modes', () => {
+      setCustomizedSettings({
+        modes: ['CITYBIKE', 'BUS'],
+      });
+      const params = utils.preparePlanParams(defaultConfig, false)(
+        {
+          from,
+          to,
+        },
+        {
+          location: {
+            query: {},
+          },
+        },
+      );
+      const { bikeParkModes } = params;
+      expect(bikeParkModes).to.deep.equal([
+        { mode: 'BICYCLE', qualifier: 'PARK' },
+        { mode: 'BUS' },
+        { mode: 'WALK' },
+      ]);
+    });
+
     it('should have disableRemainingWeightHeuristic as true when CITYBIKE is selected', () => {
       setCustomizedSettings({
         modes: ['CITYBIKE', 'BUS', 'TRAM', 'FERRY', 'SUBWAY', 'RAIL'],


### PR DESCRIPTION
## Proposed Changes

  - Make sure citybike (BICYCLE_RENT) mode is not in bikepark modes as currently they can't be used together and currently the citybike could be used instead of bikepark in results

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
