### PR TITLE
DT-4338: Street mode selector area remains in loading state even after queries fail

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -260,7 +260,6 @@ class SummaryPage extends React.Component {
     super(props, context);
     this.isFetching = false;
     this.secondQuerySent = false;
-    this.isFetchingWalkAndBike = true;
     this.setParamsAndQuery();
     this.originalPlan = this.props.viewer && this.props.viewer.plan;
     // *** TODO: Hotfix variables for temporary use only
@@ -302,6 +301,7 @@ class SummaryPage extends React.Component {
       scrolled: false,
       loadingMoreItineraries: undefined,
       zoomLevel: -1,
+      isFetchingWalkAndBike: true,
     };
     if (this.props.match.params.hash === 'walk') {
       this.selectedPlan = this.state.walkPlan;
@@ -713,20 +713,25 @@ class SummaryPage extends React.Component {
       this.context.match,
     );
 
-    fetchQuery(this.props.relayEnvironment, query, planParams).then(result => {
-      this.isFetchingWalkAndBike = false;
-      this.setState(
-        {
-          walkPlan: result.walkPlan,
-          bikePlan: result.bikePlan,
-          bikeAndPublicPlan: result.bikeAndPublicPlan,
-          bikeParkPlan: result.bikeParkPlan,
-        },
-        () => {
-          this.makeWeatherQuery();
-        },
-      );
-    });
+    fetchQuery(this.props.relayEnvironment, query, planParams)
+      .then(result => {
+        this.setState(
+          {
+            isFetchingWalkAndBike: false,
+            isFetchingWeather: true,
+            walkPlan: result.walkPlan,
+            bikePlan: result.bikePlan,
+            bikeAndPublicPlan: result.bikeAndPublicPlan,
+            bikeParkPlan: result.bikeParkPlan,
+          },
+          () => {
+            this.makeWeatherQuery();
+          },
+        );
+      })
+      .catch(() => {
+        this.setState({ isFetchingWalkAndBike: false });
+      });
   };
 
   makeQueryWithAllModes = () => {
@@ -1185,13 +1190,13 @@ class SummaryPage extends React.Component {
       ) &&
       this.paramsOrQueryHaveChanged() &&
       this.secondQuerySent &&
-      !this.isFetchingWalkAndBike
+      !this.state.isFetchingWalkAndBike
     ) {
       this.setParamsAndQuery();
       this.secondQuerySent = false;
-      this.isFetchingWalkAndBike = true;
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
+        isFetchingWalkAndBike: true,
         walkPlan: undefined,
         bikePlan: undefined,
         bikeAndPublicPlan: undefined,
@@ -1222,7 +1227,8 @@ class SummaryPage extends React.Component {
       ) {
         this.makeWalkAndBikeQueries();
       } else {
-        this.isFetchingWalkAndBike = false;
+        // eslint-disable-next-line react/no-did-update-set-state
+        this.setState({ isFetchingWalkAndBike: false });
       }
     }
 
@@ -1370,12 +1376,12 @@ class SummaryPage extends React.Component {
                   ),
                 };
               }
-              this.setState({ weatherData });
+              this.setState({ isFetchingWeather: false, weatherData });
             }
           })
           .catch(err => {
             this.pendingWeatherHash = undefined;
-            this.setState({ weatherData: { err } });
+            this.setState({ isFetchingWeather: false, weatherData: { err } });
           });
       }
     }
@@ -1686,9 +1692,9 @@ class SummaryPage extends React.Component {
           ) ||
           getIntermediatePlaces(this.context.match.location.query).length > 0
         ) {
-          this.isFetchingWalkAndBike = true;
           this.setState(
             {
+              isFetchingWalkAndBike: true,
               loading: true,
             },
             // eslint-disable-next-line func-names
@@ -1795,7 +1801,7 @@ class SummaryPage extends React.Component {
     ) {
       this.originalPlan = this.props.viewer.plan;
       this.isFetching = true;
-      this.isFetchingWalkAndBike = true;
+      this.setState({ isFetchingWalkAndBike: true });
       this.makeQueryWithAllModes();
       this.makeWalkAndBikeQueries();
     }
@@ -2073,7 +2079,7 @@ class SummaryPage extends React.Component {
 
     const loadingStreeModeSelector =
       this.props.loading ||
-      this.isFetchingWalkAndBike ||
+      this.state.isFetchingWalkAndBike ||
       (!this.state.weatherData.temperature && !this.state.weatherData.err);
 
     const screenReaderWalkAndBikeUpdateAlert = (
@@ -2195,7 +2201,7 @@ class SummaryPage extends React.Component {
                 planHasNoItineraries && hasAlternativeItineraries
               }
               separatorPosition={this.state.separatorPosition}
-              loading={this.isFetchingWalkAndBike && !error}
+              loading={this.state.isFetchingWalkAndBike && !error}
               onLater={this.onLater}
               onEarlier={this.onEarlier}
               loadingMoreItineraries={this.state.loadingMoreItineraries}
@@ -2269,7 +2275,7 @@ class SummaryPage extends React.Component {
                 toggleSettings={this.toggleCustomizeSearchOffcanvas}
               />
               {error ||
-              (!this.isFetchingWalkAndBike &&
+              (!this.state.isFetchingWalkAndBike &&
                 !showStreetModeSelector) ? null : (
                 <StreetModeSelector
                   showWalkOptionButton={showWalkOptionButton}
@@ -2284,9 +2290,8 @@ class SummaryPage extends React.Component {
                   bikeParkPlan={bikeParkPlan}
                   loading={
                     this.props.loading ||
-                    this.isFetchingWalkAndBike ||
-                    (!this.state.weatherData.temperature &&
-                      !this.state.weatherData.err)
+                    this.state.isFetchingWalkAndBike ||
+                    this.state.isFetchingWeather
                   }
                 />
               )}
@@ -2390,7 +2395,7 @@ class SummaryPage extends React.Component {
                 planHasNoItineraries && hasAlternativeItineraries
               }
               separatorPosition={this.state.separatorPosition}
-              loading={this.isFetchingWalkAndBike && !error}
+              loading={this.state.isFetchingWalkAndBike && !error}
               onLater={this.onLater}
               onEarlier={this.onEarlier}
               loadingMoreItineraries={this.state.loadingMoreItineraries}
@@ -2418,7 +2423,7 @@ class SummaryPage extends React.Component {
                 toggleSettings={this.toggleCustomizeSearchOffcanvas}
               />
               {error ||
-              (!this.isFetchingWalkAndBike &&
+              (!this.state.isFetchingWalkAndBike &&
                 !showStreetModeSelector) ? null : (
                 <StreetModeSelector
                   showWalkOptionButton={showWalkOptionButton}
@@ -2433,9 +2438,8 @@ class SummaryPage extends React.Component {
                   bikeParkPlan={bikeParkPlan}
                   loading={
                     this.props.loading ||
-                    this.isFetchingWalkAndBike ||
-                    (!this.state.weatherData.temperature &&
-                      !this.state.weatherData.err)
+                    this.state.isFetchingWalkAndBike ||
+                    this.state.isFetchingWeather
                   }
                 />
               )}


### PR DESCRIPTION
## Proposed Changes

  - Hide street mode selector after loading fails

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
