### PR TITLE
fix: read location state from location state

### DIFF
--- a/app/util/otpStrings.js
+++ b/app/util/otpStrings.js
@@ -41,7 +41,10 @@ export const otpToLocation = otpString => {
 };
 
 export const addressToItinerarySearch = location => {
-  if (location.type === 'CurrentLocation' && !location.lat) {
+  if (
+    location.type === 'CurrentLocation' &&
+    location.status === 'no-location'
+  ) {
     return 'POS';
   }
   if (!location.lat) {


### PR DESCRIPTION
In the past, existence of key value locationState.type === 'CurrentLocation' was used
(for some obscure reason) to decide if locationing was already attempted.
So, recent addition of that key to location state at store initialization
broke geolocationing process. Now, the decision is made using the location status key,
which obviously makes sense.

