### PR TITLE
DT-4487: Favourite bike rental stations are broken in search

### DIFF
--- a/app/util/path.js
+++ b/app/util/path.js
@@ -104,7 +104,7 @@ export const getStopRoutePath = searchObj => {
     case 'favouriteBikestation':
     case 'favouriteBikeRentalStation':
       path = `/${PREFIX_BIKESTATIONS}/`;
-      id = searchObj.properties.id;
+      id = searchObj.properties.labelId;
       break;
     default:
       path = `/${PREFIX_STOPS}/`;

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -29,7 +29,7 @@
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {},
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "1.7.2",
+    "@digitransit-component/digitransit-component-autosuggest": "1.7.3",
     "@digitransit-component/digitransit-component-icon": "^0.1.3",
     "@hsl-fi/sass": "^0.1.1",
     "classnames": "2.2.6",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "digitransit-component autosuggest module",
   "main": "lib/index.js",
   "files": [
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@digitransit-component/digitransit-component-dialog-modal": "^0.3.2",
     "@digitransit-component/digitransit-component-icon": "^0.1.3",
-    "@digitransit-component/digitransit-component-suggestion-item": "^0.2.5",
+    "@digitransit-component/digitransit-component-suggestion-item": "^0.2.6",
     "@hsl-fi/sass": "^0.1.1",
     "classnames": "2.2.6",
     "i18next": "^19.3.3",

--- a/digitransit-component/packages/digitransit-component-favourite-bar/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-bar",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "digitransit-component favourite-bar module",
   "main": "lib/index.js",
   "files": [
@@ -30,7 +30,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@digitransit-component/digitransit-component-icon": "^0.1.3",
-    "@digitransit-component/digitransit-component-suggestion-item": "^0.2.5",
+    "@digitransit-component/digitransit-component-suggestion-item": "^0.2.6",
     "@hsl-fi/sass": "^0.1.1",
     "@hsl-fi/shimmer": "0.1.0",
     "classnames": "2.2.6",

--- a/digitransit-component/packages/digitransit-component-suggestion-item/package.json
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-suggestion-item",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "digitransit-component suggestion-item module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
@@ -139,7 +139,9 @@ const SuggestionItem = pure(
         item.properties.layer === 'favouriteBikeRentalStation' ||
         item.properties.layer === 'bikestation');
     const cityBikeLabel = isBikeRentalStation
-      ? suggestionType.concat(', ').concat(item.properties.localadmin)
+      ? suggestionType.concat(
+          item.properties.localadmin ? `, ${item.properties.localadmin}` : '',
+        )
       : label;
     const ri = (
       <div


### PR DESCRIPTION
## Proposed Changes

  - Use labelId when selecting favourite bike rental station, instead of id
  - If no localadmin is present in data, don't show anything about it. (Was showing undefined in label)
  - Corresponding package updates

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
