### PR TITLE
DT-4501: Stops near you swiping is unreliable in iPhone + Safari

### DIFF
--- a/app/component/SwipeableTabs.js
+++ b/app/component/SwipeableTabs.js
@@ -281,9 +281,12 @@ export default class SwipeableTabs extends React.Component {
               swipeOptions={{
                 startSlide: this.props.tabIndex,
                 continuous: false,
-                transitionEnd: e => {
-                  this.setState({ tabIndex: e });
-                  this.props.onSwipe(e);
+                callback: i => {
+                  // force transition after animation should be over because animation can randomly fail sometimes
+                  setTimeout(() => {
+                    this.setState({ tabIndex: i });
+                    this.props.onSwipe(i);
+                  }, 300);
                 },
               }}
               childCount={tabs.length}


### PR DESCRIPTION
## Proposed Changes

  - Fix a bug where swiping in stops near you page sometimes fails to change the page. Happens on iOS and Android
  - I did not find the root cause, but this fixes the biggest problem.
  - This might be a bug in the react-swipe library or it might be caused by some weird rendering bugs in the stops near you page
  - The swipe animation still randomly fails sometimes but now the tab will always be changed correctly

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
