### PR TITLE
DT-4537: Add header to disruption banner alert

### DIFF
--- a/app/component/DisruptionBanner.js
+++ b/app/component/DisruptionBanner.js
@@ -7,6 +7,7 @@ import {
   isAlertValid,
   getServiceAlertDescription,
   getServiceAlertMetadata,
+  getServiceAlertHeader,
 } from '../util/alertUtils';
 import DisruptionBannerAlert from './DisruptionBannerAlert';
 
@@ -54,12 +55,17 @@ class DisruptionBanner extends React.Component {
     return getServiceAlertDescription(alert, this.props.language);
   }
 
+  createAlertHeader(alert) {
+    return getServiceAlertHeader(alert, this.props.language);
+  }
+
   render() {
     const activeAlerts = this.getAlerts();
     if (activeAlerts.length > 0) {
       return activeAlerts.map(alert => (
         <DisruptionBannerAlert
           key={alert.id}
+          header={this.createAlertHeader(alert)}
           message={this.createAlertText(alert)}
           language={this.props.language}
         />
@@ -87,6 +93,10 @@ const containerComponent = createFragmentContainer(
         alertEffect
         alertCause
         alertDescriptionText
+        alertHeaderTextTranslations {
+          text
+          language
+        }
         alertDescriptionTextTranslations {
           text
           language

--- a/app/component/DisruptionBannerAlert.js
+++ b/app/component/DisruptionBannerAlert.js
@@ -6,8 +6,12 @@ import { intlShape } from 'react-intl';
 import Icon from './Icon';
 import TruncatedMessage from './TruncatedMessage';
 
-const DisruptionBannerAlert = ({ message, language }, { intl, config }) => {
+const DisruptionBannerAlert = (
+  { message, header, language },
+  { intl, config },
+) => {
   const [isOpen, setOpen] = useState(true);
+  const useHeader = header && header.length <= 120 && !message.includes(header);
   return (
     isOpen && (
       <div className="disruption-banner-container">
@@ -15,10 +19,11 @@ const DisruptionBannerAlert = ({ message, language }, { intl, config }) => {
           <Icon img="icon-icon_disruption-banner-alert" />
         </div>
         <div className="disruption-info-container">
+          {useHeader && <h3 className="disruption-info-header">{header}</h3>}
           {(!config.URL.ROOTLINK || !config.trafficNowLink) && (
             <TruncatedMessage
               className="disruption-show-more"
-              lines={3}
+              lines={useHeader ? 2 : 3}
               message={message}
             />
           )}
@@ -56,7 +61,12 @@ const DisruptionBannerAlert = ({ message, language }, { intl, config }) => {
 
 DisruptionBannerAlert.propTypes = {
   message: PropTypes.string.isRequired,
+  header: PropTypes.string,
   language: PropTypes.string.isRequired,
+};
+
+DisruptionBannerAlert.defaultProps = {
+  header: null,
 };
 
 DisruptionBannerAlert.contextTypes = {

--- a/app/component/stops-near-you.scss
+++ b/app/component/stops-near-you.scss
@@ -284,9 +284,14 @@
     .disruption-info-container {
         line-height: 1.2;
         flex: 1;
+        .disruption-info-header {
+          color: inherit;
+          margin-bottom: 2px;
+        }
         .disruption-info-content {
           color: inherit;
           text-decoration: none;
+          font-size: $font-size-normal;
         }
         .disruption-show-more {
           font-weight: $font-weight-medium;


### PR DESCRIPTION
## Proposed Changes

  - Add header to disruption banner alert.
  - Header is shown if alert's header text is shorter than 120 characters and alert description text doesn't include header text.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
