### PR TITLE
DT-4503-master Tampere tram color and realtime

### DIFF
--- a/app/util/gtfsRtParser.js
+++ b/app/util/gtfsRtParser.js
@@ -1,7 +1,7 @@
 import ceil from 'lodash/ceil';
 import Pbf from 'pbf';
 // eslint-disable-next-line import/prefer-default-export
-export const parseFeedMQTT = (feedParser, data, topic, agency, mode) => {
+export const parseFeedMQTT = (feedParser, data, topic, agency) => {
   const pbf = new Pbf(data);
   const feed = feedParser(pbf);
 
@@ -13,7 +13,7 @@ export const parseFeedMQTT = (feedParser, data, topic, agency, mode) => {
     ,
     ,
     ,
-    ,
+    mode,
     routeId,
     directionId,
     headsign,
@@ -41,7 +41,7 @@ export const parseFeedMQTT = (feedParser, data, topic, agency, mode) => {
           tripStartTime:
             startTime === '' ? undefined : startTime.replace(/:/g, ''),
           operatingDay: trip.start_date,
-          mode: mode || 'bus',
+          mode: mode === '' ? 'bus' : mode.toLowerCase(),
           next_stop: stopId === '' ? undefined : `${agency}:${stopId}`,
           timestamp: vehiclePos.timestamp || feed.header.timestamp,
           lat: ceil(position.latitude, 5),

--- a/app/util/mqttClient.js
+++ b/app/util/mqttClient.js
@@ -39,7 +39,7 @@ function getTopic(options, settings) {
     direction,
     tripStartTime,
     headsign,
-    settings.agency,
+    settings.topicFeedId || settings.agency, // TODO topicFeedId can be removed once testing with alternative tampere trams is done
     tripId,
     geoHash,
   );

--- a/app/util/mqttClient.js
+++ b/app/util/mqttClient.js
@@ -115,7 +115,6 @@ export function changeTopics(settings, actionContext) {
 export function startMqttClient(settings, actionContext) {
   const options = settings.options || [{}];
   const topics = options.map(option => getTopic(option, settings));
-  const mode = options.length && options[0].mode ? options[0].mode : 'bus';
 
   return import(/* webpackChunkName: "mqtt" */ 'mqtt').then(mqtt => {
     if (settings.gtfsrt) {
@@ -132,7 +131,6 @@ export function startMqttClient(settings, actionContext) {
               messages,
               topic,
               settings.agency,
-              mode,
             );
             parsedMessages.forEach(message => {
               actionContext.dispatch('RealTimeClientMessage', message);

--- a/sass/themes/tampere/_theme.scss
+++ b/sass/themes/tampere/_theme.scss
@@ -6,6 +6,7 @@ $secondary-color: darken($primary-color, 20%);
 $hilight-color: $primary-color;
 $action-color: $primary-color;
 $bus-color: $primary-color;
+$tram-color: #da2128;
 $viewpoint-marker-color: $primary-color;
 $current-location-color: $primary-color;
 $selected-lang-background: #1a4a8f;

--- a/test/unit/util/gtfsRtParser.test.js
+++ b/test/unit/util/gtfsRtParser.test.js
@@ -16,9 +16,8 @@ describe('gtfsRtParser', () => {
       const result = parseFeedMQTT(
         bindings.FeedMessage.read,
         arrayBuffer,
-        '/gtfsrt/vp/tampere////8/1/Atala/5645934646/123456/14:35/130210/61;23/47/62/47/8/',
+        '/gtfsrt/vp/tampere///TRAM/8/1/Atala/5645934646/123456/14:35/130210/61;23/47/62/47/8/',
         'tampere',
-        'bus',
       );
 
       expect(result).to.deep.equal([
@@ -28,7 +27,7 @@ describe('gtfsRtParser', () => {
           direction: 1,
           tripStartTime: '1435',
           operatingDay: '20190326',
-          mode: 'bus',
+          mode: 'tram',
           next_stop: 'tampere:123456',
           timestamp: 1553604421,
           lat: 61.50812,
@@ -42,43 +41,12 @@ describe('gtfsRtParser', () => {
       ]);
     });
 
-    it('GTFS RT vehicle position data for a tram route should be parsed correctly', () => {
-      const result = parseFeedMQTT(
-        bindings.FeedMessage.read,
-        arrayBuffer,
-        '/gtfsrt/vp/tampere////15/0/Petsamo/5660364646/123456/14:30/TKL_23/61;23/47/62/47/15/',
-        'tampere',
-        'tram',
-      );
-
-      expect(result).to.deep.equal([
-        {
-          id: 'tampere:TKL_23',
-          route: 'tampere:15',
-          direction: 0,
-          tripStartTime: '1430',
-          operatingDay: '20190326',
-          mode: 'tram',
-          next_stop: 'tampere:123456',
-          timestamp: 1553604421,
-          lat: 61.50812,
-          long: 23.66348,
-          heading: 55,
-          headsign: 'Petsamo',
-          tripId: 'tampere:5660364646',
-          geoHash: ['61;23', '47', '62', '47'],
-          shortName: '15',
-        },
-      ]);
-    });
-
     it('GTFS RT vehicle position data for a topic with no directionId, startime, stopId, headsign or shortName', () => {
       const result = parseFeedMQTT(
         bindings.FeedMessage.read,
         arrayBuffer,
         '/gtfsrt/vp/tampere////15//////TKL_23/61;23/47/62/47/',
         'tampere',
-        'bus',
       );
 
       expect(result).to.deep.equal([


### PR DESCRIPTION
## Proposed Changes

  - Use custom color for trams in Tampere config
  - Parse mode from gtfsrt mqtt topic
  - Override normal feedId in mqtt subscription topics with topicFeedId
     - Its purpose is to allow different mqtt topic for Tampere's tram testing while the regular uses normal realtime data
     - Can be tested by adding env `REALTIME_PATCH="{\"tampere\": {\"topicFeedId\": \"tampereTram\"}}"`

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
