### PR TITLE
DT-4505: Different amounts of stops in stops near you page in different configs

### DIFF
--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -107,7 +107,7 @@ export default {
   },
 
   omitNonPickups: true,
-  maxNearbyStopAmount: 50,
+  maxNearbyStopAmount: 5,
   maxNearbyStopDistance: 2000,
 
   defaultSettings: {


### PR DESCRIPTION
## Proposed Changes

  - Set maxNearbyStopAmount to 5 for default configs so 5 stops are fetched initially at stop near you page.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
