### PR TITLE
DT-4596: Add Start using citybike link instead of buy link in Waltti configs in stops near you page

### DIFF
--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -35,6 +35,10 @@ import SwipeableTabs from './SwipeableTabs';
 import StopsNearYouFavorites from './StopsNearYouFavorites';
 import StopsNearYouMapContainer from './StopsNearYouMapContainer';
 import StopsNearYouFavoritesMapContainer from './StopsNearYouFavoritesMapContainer';
+import {
+  getCityBikeNetworkConfig,
+  getCityBikeNetworkId,
+} from '../util/citybikes';
 
 // component initialization phases
 const PH_START = 'start';
@@ -436,7 +440,13 @@ class StopsNearYouPage extends React.Component {
             variables={this.getQueryVariables(nearByStopMode)}
             environment={this.props.relayEnvironment}
             render={({ props }) => {
-              const cityBikeBuyUrl = this.context.config.cityBike.buyUrl;
+              const { cityBike } = this.context.config;
+              // Use buy instructions if available, otherwise use general instructions.
+              const cityBikeBuyUrl = cityBike.buyUrl;
+              const cityBikeNetworkUrl = getCityBikeNetworkConfig(
+                getCityBikeNetworkId(Object.keys(cityBike.networks)),
+                this.context.config,
+              ).url;
               return (
                 <div className="stops-near-you-page">
                   {renderDisruptionBanner && (
@@ -454,7 +464,8 @@ class StopsNearYouPage extends React.Component {
                     />
                   )}
                   {this.state.showCityBikeTeaser &&
-                    nearByStopMode === 'CITYBIKE' && (
+                    nearByStopMode === 'CITYBIKE' &&
+                    (cityBikeBuyUrl || cityBikeNetworkUrl) && (
                       <div className="citybike-use-disclaimer">
                         <div className="disclaimer-header">
                           <FormattedMessage id="citybike-start-using" />
@@ -479,9 +490,18 @@ class StopsNearYouPage extends React.Component {
                             />
                           </div>
                         </div>
-                        {cityBikeBuyUrl && (
-                          <div className="disclaimer-content">
+                        <div className="disclaimer-content">
+                          {cityBikeBuyUrl ? (
                             <FormattedMessage id="citybike-buy-season" />
+                          ) : (
+                            <a
+                              className="external-link-citybike"
+                              href={cityBikeNetworkUrl[this.props.lang]}
+                            >
+                              <FormattedMessage id="citybike-start-using-info" />{' '}
+                            </a>
+                          )}
+                          {cityBikeBuyUrl && (
                             <a
                               href={cityBikeBuyUrl[this.props.lang]}
                               className="disclaimer-close-button-container"
@@ -504,8 +524,8 @@ class StopsNearYouPage extends React.Component {
                                 <FormattedMessage id="buy" />
                               </div>
                             </a>
-                          </div>
-                        )}
+                          )}
+                        </div>
                       </div>
                     )}
 

--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -441,12 +441,16 @@ class StopsNearYouPage extends React.Component {
             environment={this.props.relayEnvironment}
             render={({ props }) => {
               const { cityBike } = this.context.config;
-              // Use buy instructions if available, otherwise use general instructions.
+              // Use buy instructions if available
               const cityBikeBuyUrl = cityBike.buyUrl;
-              const cityBikeNetworkUrl = getCityBikeNetworkConfig(
-                getCityBikeNetworkId(Object.keys(cityBike.networks)),
-                this.context.config,
-              ).url;
+              let cityBikeNetworkUrl;
+              // Use general information about using city bike, if one network config is available
+              if (Object.keys(cityBike.networks).length === 1) {
+                cityBikeNetworkUrl = getCityBikeNetworkConfig(
+                  getCityBikeNetworkId(Object.keys(cityBike.networks)),
+                  this.context.config,
+                ).url;
+              }
               return (
                 <div className="stops-near-you-page">
                   {renderDisruptionBanner && (

--- a/app/configurations/config.lappeenranta.js
+++ b/app/configurations/config.lappeenranta.js
@@ -56,8 +56,8 @@ export default configMerger(walttiConfig, {
         type: 'citybike',
         url: {
           fi: 'https://kaakau.fi/lappeenranta/',
-          sv: 'https://kaakau.fi/lappeenranta/?lang=en',
-          en: 'https://kaakau.fi/lappeenranta/?lang=sv',
+          sv: 'https://kaakau.fi/lappeenranta/?lang=sv',
+          en: 'https://kaakau.fi/lappeenranta/?lang=en',
         },
       },
     },

--- a/app/translations.js
+++ b/app/translations.js
@@ -3577,7 +3577,7 @@ const translations = {
     'citybike-return-full-link':
       'Så här återlämnar du cykeln till en fullsatt cykelstation ›',
     'citybike-start-using': 'Ta stadscyklar i bruk',
-    'citybike-start-using-info': 'tilläggsinformation',
+    'citybike-start-using-info': 'Tilläggsinformation',
     'citybike-station': 'Stadscykelstation {stationId}',
     'citybike-station-no-id': 'Stadscykelstation',
     'clear-button-label': 'Töm',

--- a/app/translations.js
+++ b/app/translations.js
@@ -925,6 +925,7 @@ const translations = {
     'citybike-return-full-link':
       'How to return a bike when a bike station is full ›',
     'citybike-start-using': 'Start using city bikes',
+    'citybike-start-using-info': 'More information',
     'citybike-station': 'Bike station {stationId}',
     'citybike-station-no-id': 'Bike station',
     'clear-button-label': 'Clear',
@@ -1865,6 +1866,7 @@ const translations = {
     'citybike-return-full-link':
       'Näin palautat pyörän, kun pyöräasema on täynnä ›',
     'citybike-start-using': 'Ota kaupunkipyörät käyttöön',
+    'citybike-start-using-info': 'Lisätietoja',
     'citybike-station': 'Kaupunkipyöräasema {stationId}',
     'citybike-station-no-id': 'Kaupunkipyöräasema',
     'clear-button-label': 'Tyhjennä',
@@ -3575,6 +3577,7 @@ const translations = {
     'citybike-return-full-link':
       'Så här återlämnar du cykeln till en fullsatt cykelstation ›',
     'citybike-start-using': 'Ta stadscyklar i bruk',
+    'citybike-start-using-info': 'tilläggsinformation',
     'citybike-station': 'Stadscykelstation {stationId}',
     'citybike-station-no-id': 'Stadscykelstation',
     'clear-button-label': 'Töm',


### PR DESCRIPTION
## Proposed Changes

  - General start using citybike information POC for Waltti cities in stops near you page
  - Lappeenranta's city bike url languages was mixed up: sv pointed to english site and vice versa.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
