### PR TITLE
DT-4332 Route page pattern redirects

### DIFF
--- a/app/component/DepartureListContainer.js
+++ b/app/component/DepartureListContainer.js
@@ -253,11 +253,10 @@ class DepartureListContainer extends Component {
         />
       );
 
-      // DT-3331: added query string sort=no to Link's to
       if (this.props.routeLinks) {
         departureObjs.push(
           <Link
-            to={`/${PREFIX_ROUTES}/${departure.pattern.route.gtfsId}/${PREFIX_STOPS}/${departure.pattern.code}?sort=no`}
+            to={`/${PREFIX_ROUTES}/${departure.pattern.route.gtfsId}/${PREFIX_STOPS}/${departure.pattern.code}`}
             key={id}
             onClick={() => {
               addAnalyticsEvent({

--- a/app/component/PatternLink.js
+++ b/app/component/PatternLink.js
@@ -45,10 +45,9 @@ function PatternLink({
     }
   });
 
-  // DT-3331: added query string sort=no to Link's to
   const icon = (
     <Link
-      to={`/${PREFIX_ROUTES}/${route}/${PREFIX_STOPS}/${pattern}?sort=no`}
+      to={`/${PREFIX_ROUTES}/${route}/${PREFIX_STOPS}/${pattern}`}
       className="route-now-content"
     >
       <VehicleIcon

--- a/app/component/PatternRedirector.js
+++ b/app/component/PatternRedirector.js
@@ -29,7 +29,7 @@ const PatternRedirector = ({ router, match, route }) => {
 
   const path = `/${PREFIX_ROUTES}/${match.params.routeId}/${
     match.params.type || PREFIX_STOPS
-  }/${pattern ? pattern.code : `${match.params.routeId}:0/01`}`;
+  }/${pattern ? pattern.code : `${match.params.routeId}:0:01`}`;
   if (isBrowser) {
     router.replace(path);
   } else {

--- a/app/component/PatternRedirector.js
+++ b/app/component/PatternRedirector.js
@@ -1,0 +1,61 @@
+import PropTypes from 'prop-types';
+import { createFragmentContainer, graphql } from 'react-relay';
+import sortBy from 'lodash/sortBy';
+import { matchShape, routerShape, RedirectException } from 'found';
+import { PREFIX_ROUTES, PREFIX_STOPS } from '../util/path';
+import { isBrowser } from '../util/browser';
+
+const PatternRedirector = ({ router, match, route }) => {
+  let sortedPatternsByCountOfTrips;
+  const tripsExists = route.patterns ? 'trips' in route.patterns[0] : false;
+  if (tripsExists) {
+    sortedPatternsByCountOfTrips = sortBy(
+      sortBy(route.patterns, 'code').reverse(),
+      'trips.length',
+    ).reverse();
+  }
+  let pattern;
+  if (
+    Array.isArray(sortedPatternsByCountOfTrips) &&
+    sortedPatternsByCountOfTrips.length > 0
+  ) {
+    [pattern] = sortedPatternsByCountOfTrips;
+  } else {
+    pattern =
+      Array.isArray(route.patterns) && route.patterns.length > 0
+        ? route.patterns[0]
+        : undefined;
+  }
+
+  const path = `/${PREFIX_ROUTES}/${match.params.routeId}/${
+    match.params.type || PREFIX_STOPS
+  }/${pattern ? pattern.code : `${match.params.routeId}:0/01`}`;
+  if (isBrowser) {
+    router.replace(path);
+  } else {
+    throw new RedirectException(path);
+  }
+  return null;
+};
+
+PatternRedirector.propTypes = {
+  router: routerShape.isRequired,
+  match: matchShape.isRequired,
+  route: PropTypes.object.isRequired,
+};
+
+const containerComponent = createFragmentContainer(PatternRedirector, {
+  route: graphql`
+    fragment PatternRedirector_route on Route
+    @argumentDefinitions(date: { type: "String" }) {
+      patterns {
+        code
+        trips: tripsForDate(serviceDate: $date) {
+          gtfsId
+        }
+      }
+    }
+  `,
+});
+
+export default containerComponent;

--- a/app/component/RouteAlertsRow.js
+++ b/app/component/RouteAlertsRow.js
@@ -68,7 +68,7 @@ export default function RouteAlertsRow(
       ? entityIdentifier.split(',').map((identifier, i) => (
           <Link
             key={gtfsIdList[i]}
-            to={`/${PREFIX_ROUTES}/${gtfsIdList[i]}/${PREFIX_STOPS}/${gtfsIdList[i]}:0:01`}
+            to={`/${PREFIX_ROUTES}/${gtfsIdList[i]}/${PREFIX_STOPS}`}
             className="route-alert-row-link"
             style={{ color }}
           >

--- a/app/component/RouteHeader.js
+++ b/app/component/RouteHeader.js
@@ -20,11 +20,10 @@ export default function RouteHeader(props) {
 
   const routeLineText = ` ${props.route.shortName || ''}`;
 
-  // DT-3331: added query string sort=no to Link's to
   const routeLine =
     props.trip && props.pattern ? (
       <Link
-        to={`/${PREFIX_ROUTES}/${props.route.gtfsId}/${PREFIX_STOPS}/${props.pattern.code}?sort=no`}
+        to={`/${PREFIX_ROUTES}/${props.route.gtfsId}/${PREFIX_STOPS}/${props.pattern.code}`}
       >
         {routeLineText}
       </Link>

--- a/app/component/RoutePageControlPanel.js
+++ b/app/component/RoutePageControlPanel.js
@@ -99,20 +99,6 @@ class RoutePageControlPanel extends React.Component {
       });
     }
 
-    const lengthPathName =
-      location !== undefined ? location.pathname.length : 0; // DT-3331
-    const lengthIndexOfPattern =
-      location !== undefined
-        ? location.pathname.indexOf(match.params.patternId) +
-          match.params.patternId.length
-        : 0; // DT-3331
-    const noSortFound =
-      location !== undefined
-        ? location.search.indexOf('sort=no') !== -1
-        : false; // DT-3331
-    const reRouteAllowed =
-      lengthPathName === lengthIndexOfPattern && !noSortFound; // DT-3331
-
     let sortedPatternsByCountOfTrips;
     const tripsExists = route.patterns ? 'trips' in route.patterns[0] : false;
 
@@ -130,7 +116,8 @@ class RoutePageControlPanel extends React.Component {
     if (!pattern) {
       return;
     }
-    let selectedPattern = sortedPatternsByCountOfTrips?.find(
+
+    const selectedPattern = sortedPatternsByCountOfTrips?.find(
       sorted => sorted.code === match.params.patternId,
     );
 
@@ -165,23 +152,6 @@ class RoutePageControlPanel extends React.Component {
           );
         }
       }
-    }
-    // DT-3182: call this only 1st time for changing URL to wanted route (most trips)
-    // DT-3331: added reRouteAllowed
-    if (
-      location !== undefined &&
-      location.action === 'PUSH' &&
-      match.params.patternId !== pattern.code &&
-      reRouteAllowed
-    ) {
-      // DT-4161: When user comes from first time, sortedPatterns aren't in sync with routePatternSelect
-      selectedPattern = pattern;
-      router.replace(
-        decodeURIComponent(location.pathname).replace(
-          new RegExp(`${match.params.patternId}(.*)`),
-          pattern.code,
-        ),
-      );
     }
 
     const { realTime } = config;

--- a/app/routeRoutes.js
+++ b/app/routeRoutes.js
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import Route from 'found/Route';
-import Redirect from 'found/Redirect';
 import { graphql } from 'react-relay';
 
 import Error404 from './component/404';
@@ -23,21 +22,25 @@ import prepareRouteScheduleParams from './util/routeScheduleParamUtils';
 export default (
   <Route path={`/${PREFIX_ROUTES}`}>
     <Route Component={Error404} />
-    <Redirect
-      from=":routeId"
-      to={`:routeId/${PREFIX_STOPS}/:routeId%3A0%3A01`}
-    />
-    <Redirect
-      from={`:routeId/${PREFIX_STOPS}`}
-      to={`${PREFIX_STOPS}/:routeId%3A0%3A01`}
-    />
-    <Redirect
-      from={`:routeId/${PREFIX_TIMETABLE}`}
-      to={`${PREFIX_TIMETABLE}/:routeId%3A0%3A01`}
-    />
-    <Redirect
-      from={`:routeId/${PREFIX_DISRUPTION}`}
-      to={`${PREFIX_DISRUPTION}/:routeId%3A0%3A01`}
+    <Route
+      path=":routeId/:type?"
+      getComponent={() =>
+        import(
+          /* webpackChunkName: "route" */ './component/PatternRedirector'
+        ).then(getDefault)
+      }
+      query={graphql`
+        query routeRoutes_PatternRedirector_Query(
+          $routeId: String!
+          $date: String!
+        ) {
+          route(id: $routeId) {
+            ...PatternRedirector_route @arguments(date: $date)
+          }
+        }
+      `}
+      prepareVariables={prepareServiceDay}
+      render={getComponentOrLoadingRenderer}
     />
     <Route path=":routeId">
       {{

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "digitransit-component autosuggest-panel module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "description": "digitransit-component autosuggest module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-execute-search-immidiate",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "digitransit-search-util execute-search-immidiate module",
   "main": "index.js",
   "publishConfig": {
@@ -24,7 +24,7 @@
     "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "0.0.3",
     "@digitransit-search-util/digitransit-search-util-get-geocoding-results": "0.0.4",
     "@digitransit-search-util/digitransit-search-util-get-json": "0.0.3",
-    "@digitransit-search-util/digitransit-search-util-helpers": "^0.1.4",
+    "@digitransit-search-util/digitransit-search-util-helpers": "0.1.5",
     "@digitransit-search-util/digitransit-search-util-uniq-by-label": "0.1.1",
     "lodash": "4.17.21"
   }

--- a/digitransit-search-util/packages/digitransit-search-util-helpers/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-helpers/index.js
@@ -49,9 +49,7 @@ export const mapRoute = (item, pathOpts) => {
   const routesPrefix = opts.routesPrefix || DEFAULT_ROUTES_PREFIX;
   const stopsPrefix = opts.stopsPrefix || DEFAULT_STOPS_PREFIX;
 
-  const link = `/${routesPrefix}/${item.gtfsId}/${stopsPrefix}/${
-    orderBy(item.patterns, 'code', ['asc'])[0].code
-  }`;
+  const link = `/${routesPrefix}/${item.gtfsId}/${stopsPrefix}`;
 
   return {
     type: 'Route',

--- a/digitransit-search-util/packages/digitransit-search-util-helpers/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-helpers",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "digitransit-search-util helpers module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-query-utils",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "digitransit-search-util query-utils module",
   "main": "index.generated",
   "publishConfig": {
@@ -24,7 +24,7 @@
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
     "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "0.0.3",
-    "@digitransit-search-util/digitransit-search-util-helpers": "0.1.4",
+    "@digitransit-search-util/digitransit-search-util-helpers": "0.1.5",
     "@digitransit-search-util/digitransit-search-util-route-name-compare": "0.0.2",
     "@digitransit-search-util/digitransit-search-util-suggestion-to-location": "0.1.2",
     "babel-plugin-relay": "10.0.1",

--- a/test/unit/component/RouteAlertsRow.test.js
+++ b/test/unit/component/RouteAlertsRow.test.js
@@ -123,7 +123,7 @@ describe('<RouteAlertsRow />', () => {
     };
     const wrapper = shallowWithIntl(<RouteAlertsRow {...props} />);
     expect(wrapper.find('.route-alert-row-link').get(0).props.to).to.equal(
-      `/${PREFIX_ROUTES}/HSL:2097N/${PREFIX_STOPS}/HSL:2097N:0:01`,
+      `/${PREFIX_ROUTES}/HSL:2097N/${PREFIX_STOPS}`,
     );
   });
 


### PR DESCRIPTION
## Proposed Changes

  - Refactored route page entry so that instead of using sort=no, giving a pattern in the URL now means that no sort should happen. Leaving out the "pattern", i.e. the `routeId:0:01` means that the best fit pattern will be picked. It's also possible to leave out the tab name.
  - Updated route page links to use the new logic

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
