### PR TITLE
DT-4590: extra whitespace for safari

### DIFF
--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -21,6 +21,7 @@ import { getSummaryPath } from '../util/path';
 import { replaceQueryParams } from '../util/queryUtils';
 import withBreakpoint from '../util/withBreakpoint';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
+import { isIOS, isSafari } from '../util/browser';
 
 class SummaryPlanContainer extends React.Component {
   static propTypes = {
@@ -156,7 +157,7 @@ class SummaryPlanContainer extends React.Component {
           })}
           className={`time-navigation-btn ${
             reversed ? 'top-btn' : 'bottom-btn'
-          }`}
+          } ${!reversed && isIOS && isSafari ? 'extra-whitespace' : ''} `}
           onClick={() => this.props.onLater(this.props.itineraries, reversed)}
         >
           <Icon
@@ -184,7 +185,7 @@ class SummaryPlanContainer extends React.Component {
           })}
           className={`time-navigation-btn ${
             reversed ? 'bottom-btn' : 'top-btn'
-          }`}
+          } ${reversed && isIOS && isSafari ? 'extra-whitespace' : ''}`}
           onClick={() => this.props.onEarlier(this.props.itineraries, reversed)}
         >
           <Icon

--- a/app/component/summary.scss
+++ b/app/component/summary.scss
@@ -406,6 +406,10 @@
 
 .mobile .time-navigation-btn {
   padding-left: 28px;
+  &.extra-whitespace {
+    height: 120px;
+    padding-bottom: 60px;
+  }
 }
 
 .summary-list-separator {


### PR DESCRIPTION
## Proposed Changes

  - Add extra whitespace to later departures button on ios safari (affects other ios browsers as well)
  - Tested on iPhone 12 through localtunnel

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
