### PR TITLE
DT-4655: Tampere calendar should be 60 days ahead

### DIFF
--- a/app/component/DatetimepickerContainer.js
+++ b/app/component/DatetimepickerContainer.js
@@ -81,6 +81,7 @@ function DatetimepickerContainer(
       lang={lang}
       color={color}
       timeZone={context.config.timezoneData.split('|')[0]}
+      serviceTimeRange={context.config.itinerary.serviceTimeRange}
     />
   );
 }

--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "digitransit-component datetimepicker module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
@@ -36,6 +36,7 @@ i18next.init({
  * @param {node} props.embedWhenClosed        JSX element to render in the corner when input is closed
  * @param {node} props.embedWhenOpen          JSX element to render when input is open
  * @param {string} props.lang                 Language selection
+ * @param {number} props.serviceTimeRange           Determine number of days shown in timepicker. Optional. default is 30.
  *
  *
  * @example
@@ -49,6 +50,7 @@ i18next.init({
  *   onArrivalClick={() => arrivalClicked()}
  *   embedWhenClosed={<button />}
  *   lang={'en'}
+ *   serviceTimeRange={15}
  * />
  */
 function Datetimepicker({
@@ -66,6 +68,7 @@ function Datetimepicker({
   timeZone,
   onModalSubmit,
   fontWeights,
+  serviceTimeRange,
 }) {
   moment.tz.setDefault(timeZone);
   const [isOpen, changeOpen] = useState(false);
@@ -210,13 +213,12 @@ function Datetimepicker({
     timeChoices = Array.from(new Set(timeChoices)); // remove duplicates
   }
 
-  const dateSelectItemCount = 30;
   const dateSelectStartTime = moment()
     .startOf('day')
     .hour(selectedMoment.hour())
     .minute(selectedMoment.minute())
     .valueOf();
-  const dateChoices = Array(dateSelectItemCount)
+  const dateChoices = Array(serviceTimeRange)
     .fill()
     .map((_, i) => moment(dateSelectStartTime).add(i, 'day').valueOf());
 
@@ -246,7 +248,7 @@ function Datetimepicker({
             getTimeDisplay={getTimeDisplay}
             timestamp={displayTimestamp}
             getDateDisplay={getDateDisplay}
-            dateSelectItemCount={dateSelectItemCount}
+            dateSelectItemCount={serviceTimeRange}
             getDisplay={getTimeDisplay}
             validateTime={validateTime}
             fontWeights={fontWeights}
@@ -499,6 +501,7 @@ Datetimepicker.propTypes = {
   fontWeights: PropTypes.shape({
     medium: PropTypes.number.isRequired,
   }).isRequired,
+  serviceTimeRange: PropTypes.number,
 };
 
 Datetimepicker.defaultProps = {
@@ -507,6 +510,7 @@ Datetimepicker.defaultProps = {
   embedWhenOpen: null,
   color: '#007ac9',
   timeZone: 'Europe/Helsinki',
+  serviceTimeRange: 30,
 };
 
 export default Datetimepicker;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/index.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/index.js
@@ -22,6 +22,7 @@ import Datetimepicker from './helpers/Datetimepicker';
  * @param {node} props.embedWhenClosed              JSX element to render in the corner when input is closed
  * @param {node} props.embedWhenOpen                JSX element to render when input is open
  * @param {string} props.lang                       Language selection. Default 'en'
+ * @param {number} props.serviceTimeRange           Determine number of days shown in timepicker. Optional. default is 30.
  *
  * @example
  * <Datetimepicker
@@ -35,6 +36,7 @@ import Datetimepicker from './helpers/Datetimepicker';
  *   onArrivalClick={(time) => changeUrl(time, undefined)}
  *   embedWhenClosed={<button />}
  *   lang={'en'}
+ *   serviceTimeRange={15}
  * />
  */
 function DatetimepickerStateContainer({
@@ -52,6 +54,7 @@ function DatetimepickerStateContainer({
   color,
   timeZone,
   fontWeights,
+  serviceTimeRange,
 }) {
   moment.tz.setDefault(timeZone);
   const initialNow = realtime ? null : moment().valueOf();
@@ -172,6 +175,7 @@ function DatetimepickerStateContainer({
       timeZone={timeZone}
       onModalSubmit={onModalSubmit}
       fontWeights={fontWeights}
+      serviceTimeRange={serviceTimeRange}
     />
   );
 }
@@ -193,6 +197,7 @@ DatetimepickerStateContainer.propTypes = {
   fontWeights: PropTypes.shape({
     medium: PropTypes.number,
   }),
+  serviceTimeRange: PropTypes.number,
 };
 
 DatetimepickerStateContainer.defaultProps = {


### PR DESCRIPTION
## Proposed Changes

  - DateTimePicker has now serviceTimeRange prop that determines time range of the calendar. This is optional and it defaults to 30 days as it was before this change.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
