### PR TITLE
DT-4619: Show default focus outlines for keyboard navigation only

### DIFF
--- a/app/component/toggle.scss
+++ b/app/component/toggle.scss
@@ -76,7 +76,7 @@
     background-color: $primary-color;
   }
 
-  input:focus + .slider {
+  input:focus-visible + .slider {
     box-shadow: 0 0 0 2px black;
   }
 


### PR DESCRIPTION
## Proposed Changes

  - Fix focus being always visible for settings panel toggles

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
