### PR TITLE
DT-4304: Enable localStorage favorites for unlogged users 

### DIFF
--- a/app/action/FavouriteActions.js
+++ b/app/action/FavouriteActions.js
@@ -9,10 +9,13 @@ export function saveFavourite(actionContext, data) {
   actionContext.dispatch('SaveFavourite', {
     ...data,
     onFail: () => {
-      actionContext.executeAction(
-        addMessage,
-        failedFavouriteMessage(favouriteType, true),
-      );
+      // This if statement should be removed when backend service is added for waltti
+      if (!actionContext.config.allowFavouritesFromLocalstorage) {
+        actionContext.executeAction(
+          addMessage,
+          failedFavouriteMessage(favouriteType, true),
+        );
+      }
     },
   });
 }
@@ -28,10 +31,13 @@ export function updateFavourites(actionContext, data) {
   actionContext.dispatch('UpdateFavourites', {
     newFavourites: data,
     onFail: () => {
-      actionContext.executeAction(
-        addMessage,
-        failedFavouriteMessage(favouriteType, true),
-      );
+      // This if statement should be removed when backend service is added for waltti
+      if (!actionContext.config.allowFavouritesFromLocalstorage) {
+        actionContext.executeAction(
+          addMessage,
+          failedFavouriteMessage(favouriteType, true),
+        );
+      }
     },
   });
 }
@@ -44,10 +50,13 @@ export function deleteFavourite(actionContext, data) {
   actionContext.dispatch('DeleteFavourite', {
     ...data,
     onFail: () => {
-      actionContext.executeAction(
-        addMessage,
-        failedFavouriteMessage(favouriteType, false),
-      );
+      // This if statement should be removed when backend service is added for waltti
+      if (!actionContext.config.allowFavouritesFromLocalstorage) {
+        actionContext.executeAction(
+          addMessage,
+          failedFavouriteMessage(favouriteType, false),
+        );
+      }
     },
   });
 }

--- a/app/component/AppBar.js
+++ b/app/component/AppBar.js
@@ -15,7 +15,7 @@ import UserMenu from './UserMenu';
 
 const AppBar = (
   { showLogo, title, homeUrl, logo, user, breakpoint, titleClicked },
-  { config, intl, match },
+  { config, intl, match, getStore },
 ) => {
   const { location } = match;
   const url = encodeURI(`${window.location?.origin || ''}${location.pathname}`);
@@ -60,6 +60,7 @@ const AppBar = (
                     href: '/logout',
                     onClick: event => {
                       event.preventDefault();
+                      getStore('FavouriteStore').storeFavourites();
                       window.location.href = '/logout';
                     },
                   },

--- a/app/component/Favourite.js
+++ b/app/component/Favourite.js
@@ -16,7 +16,7 @@ const Favourite = (
     favourite,
     isFetching = false,
     className,
-    allowLogin,
+    requireLoggedIn,
     isLoggedIn,
     language,
   },
@@ -89,7 +89,7 @@ const Favourite = (
   };
 
   const onClick = () => {
-    if (!allowLogin || isLoggedIn) {
+    if (!requireLoggedIn || isLoggedIn) {
       if (!disable) {
         handleDisable(true);
         if (favourite) {
@@ -109,7 +109,7 @@ const Favourite = (
       className={cx('cursor-pointer favourite-icon', className)}
       onClick={onClick}
       aria-label={
-        favourite && (!allowLogin || isLoggedIn)
+        favourite && (!requireLoggedIn || isLoggedIn)
           ? context.intl.formatMessage({
               id: 'remove-favourite',
               defautlMessage: 'Remove favourite selection',
@@ -122,10 +122,10 @@ const Favourite = (
     >
       <Icon
         className={cx('favourite', {
-          selected: favourite && (!allowLogin || isLoggedIn),
+          selected: favourite && (!requireLoggedIn || isLoggedIn),
         })}
         img={
-          favourite && (!allowLogin || isLoggedIn)
+          favourite && (!requireLoggedIn || isLoggedIn)
             ? 'icon-icon_star-with-circle'
             : 'icon-icon_star-unselected'
         }
@@ -146,7 +146,7 @@ Favourite.propTypes = {
   favourite: PropTypes.bool,
   isFetching: PropTypes.bool,
   className: PropTypes.string,
-  allowLogin: PropTypes.bool.isRequired,
+  requireLoggedIn: PropTypes.bool.isRequired,
   isLoggedIn: PropTypes.bool,
   language: PropTypes.string,
 };

--- a/app/component/FavouriteBikeRentalStationContainer.js
+++ b/app/component/FavouriteBikeRentalStationContainer.js
@@ -54,7 +54,7 @@ const FavouriteBikeRentalStationContainer = connectToStores(
           ),
       });
     },
-    allowLogin: context.config.allowLogin,
+    requireLoggedIn: !context.config.allowFavouritesFromLocalstorage,
     isLoggedIn:
       context.config.allowLogin &&
       context.getStore('UserStore').getUser().sub !== undefined,

--- a/app/component/FavouriteRouteContainer.js
+++ b/app/component/FavouriteRouteContainer.js
@@ -29,7 +29,7 @@ const FavouriteRouteContainer = connectToStores(
         name: !context.getStore('FavouriteStore').isFavourite(gtfsId, 'route'),
       });
     },
-    allowLogin: context.config.allowLogin,
+    requireLoggedIn: !context.config.allowFavouritesFromLocalstorage,
     isLoggedIn:
       context.config.allowLogin &&
       context.getStore('UserStore').getUser().sub !== undefined,

--- a/app/component/FavouriteStopContainer.js
+++ b/app/component/FavouriteStopContainer.js
@@ -97,7 +97,7 @@ const FavouriteStopContainer = connectToStores(
           .isFavourite(stop.gtfsId, isTerminal ? 'station' : 'stop'),
       });
     },
-    allowLogin: context.config.allowLogin,
+    requireLoggedIn: !context.config.allowFavouritesFromLocalstorage,
     isLoggedIn:
       context.config.allowLogin &&
       context.getStore('UserStore').getUser().sub !== undefined,

--- a/app/component/FavouritesContainer.js
+++ b/app/component/FavouritesContainer.js
@@ -49,7 +49,7 @@ class FavouritesContainer extends React.Component {
     isMobile: PropTypes.bool,
     favouriteStatus: PropTypes.string,
     favouriteModalAction: PropTypes.string,
-    allowLogin: PropTypes.bool,
+    requireLoggedIn: PropTypes.bool,
     isLoggedIn: PropTypes.bool,
     color: PropTypes.string,
     hoverColor: PropTypes.string,
@@ -59,7 +59,7 @@ class FavouritesContainer extends React.Component {
     favourites: [],
     isMobile: false,
     favouriteStatus: FavouriteStore.STATUS_FETCHING,
-    allowLogin: false,
+    requireLoggedIn: false,
     isLoggedIn: false,
   };
 
@@ -76,7 +76,7 @@ class FavouritesContainer extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (
-      this.context.config.allowLogin &&
+      this.context.config.requireLoggedIn &&
       this.props.isLoggedIn &&
       !prevProps.isLoggedIn
     ) {
@@ -316,7 +316,7 @@ class FavouritesContainer extends React.Component {
   render() {
     const isLoading =
       this.props.favouriteStatus === FavouriteStore.STATUS_FETCHING_OR_UPDATING;
-    const { allowLogin, isLoggedIn } = this.props;
+    const { requireLoggedIn, isLoggedIn } = this.props;
     const targets = ['Locations', 'CurrentPosition'];
     const { fontWeights } = this.context.config;
     if (
@@ -331,22 +331,22 @@ class FavouritesContainer extends React.Component {
           favourites={this.props.favourites}
           onClickFavourite={this.props.onClickFavourite}
           onAddPlace={() =>
-            !allowLogin || isLoggedIn
+            !requireLoggedIn || isLoggedIn
               ? this.setState({ addModalOpen: true })
               : this.setState({ loginModalOpen: true, modalAction: 'AddPlace' })
           }
           onEdit={() =>
-            !allowLogin || isLoggedIn
+            !requireLoggedIn || isLoggedIn
               ? this.setState({ editModalOpen: true })
               : this.setState({ loginModalOpen: true, modalAction: 'Edit' })
           }
           onAddHome={() =>
-            !allowLogin || isLoggedIn
+            !requireLoggedIn || isLoggedIn
               ? this.addHome()
               : this.setState({ loginModalOpen: true, modalAction: 'AddHome' })
           }
           onAddWork={() =>
-            !allowLogin || isLoggedIn
+            !requireLoggedIn || isLoggedIn
               ? this.addWork()
               : this.setState({ loginModalOpen: true, modalAction: 'AddWork' })
           }
@@ -415,6 +415,7 @@ const connectedComponent = connectToStores(
   context => ({
     favourites:
       !context.config.allowLogin ||
+      context.config.allowFavouritesFromLocalstorage ||
       context.getStore('UserStore').getUser().sub !== undefined
         ? context
             .getStore('FavouriteStore')
@@ -422,7 +423,7 @@ const connectedComponent = connectToStores(
             .filter(item => item.type === 'place')
         : [],
     favouriteStatus: context.getStore('FavouriteStore').getStatus(),
-    allowLogin: context.config.allowLogin,
+    requireLoggedIn: !context.config.allowFavouritesFromLocalstorage,
     isLoggedIn:
       context.config.allowLogin &&
       context.getStore('UserStore').getUser().sub !== undefined,

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -161,6 +161,8 @@ export default {
     'Europe/Helsinki|EET EEST|-20 -30|0101010101010101010101010101010101010|22k10 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00|12e5',
 
   allowLogin: false,
+  allowFavouritesFromLocalstorage: true,
+
   mainMenu: {
     // Whether to show the left menu toggle button at all
     show: true,

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -52,6 +52,7 @@ export default {
 
   showHSLTracking: false,
   allowLogin: true,
+  allowFavouritesFromLocalstorage: false,
 
   defaultMapCenter: {
     lat: 60.1710688,

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -130,7 +130,6 @@ export default {
 
   showNearYouButtons: true,
   allowLogin: true,
-  allowFavouritesFromLocalstorage: true,
 
   messageBarAlerts: true,
 

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -130,6 +130,7 @@ export default {
 
   showNearYouButtons: true,
   allowLogin: true,
+  allowFavouritesFromLocalstorage: true,
 
   messageBarAlerts: true,
 

--- a/app/store/FavouriteStore.js
+++ b/app/store/FavouriteStore.js
@@ -4,7 +4,6 @@ import find from 'lodash/find';
 import findIndex from 'lodash/findIndex';
 import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
-import uniqBy from 'lodash/uniqBy';
 import isEmpty from 'lodash/isEmpty';
 import moment from 'moment';
 import { v4 as uuid } from 'uuid';
@@ -184,22 +183,10 @@ export default class FavouriteStore extends Store {
       this.fetchComplete();
       return;
     }
-    const merged = sortBy(
-      arrayOfFavourites.concat(storage),
-      'lastUpdated',
-    ).reverse();
-    const uniqsByFavId = uniqBy(merged, 'favouriteId');
-    const uniqs = [];
-    uniqsByFavId.forEach(u => {
-      if (!u.gtfsId || uniqs.every(item => item?.gtfsId !== u?.gtfsId)) {
-        uniqs.push(u);
-      }
-    });
 
-    updateFavourites(uniqs)
-      .then(() => {
-        this.favourites = uniqs;
-        clearFavouriteStorage();
+    updateFavourites(storage)
+      .then(res => {
+        this.favourites = res;
         this.fetchComplete();
       })
       .catch(() => {
@@ -244,8 +231,8 @@ export default class FavouriteStore extends Store {
     if (this.config.allowLogin) {
       // Update favourites to backend service
       updateFavourites(newFavourites)
-        .then(() => {
-          this.favourites = newFavourites;
+        .then(res => {
+          this.favourites = res;
           this.fetchComplete();
         })
         .catch(() => {
@@ -281,8 +268,8 @@ export default class FavouriteStore extends Store {
     if (this.config.allowLogin) {
       // Update favourites to backend service
       updateFavourites(newFavourites)
-        .then(() => {
-          this.favourites = newFavourites;
+        .then(res => {
+          this.favourites = res;
           this.fetchComplete();
         })
         .catch(() => {
@@ -319,8 +306,8 @@ export default class FavouriteStore extends Store {
     if (this.config.allowLogin) {
       // Delete favourite from backend service
       deleteFavourites([data.favouriteId])
-        .then(() => {
-          this.favourites = newFavourites;
+        .then(res => {
+          this.favourites = res;
           this.fetchComplete();
         })
         .catch(() => {

--- a/app/store/FavouriteStore.js
+++ b/app/store/FavouriteStore.js
@@ -4,6 +4,7 @@ import find from 'lodash/find';
 import findIndex from 'lodash/findIndex';
 import isEqual from 'lodash/isEqual';
 import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
 import moment from 'moment';
 import { v4 as uuid } from 'uuid';
 import getGeocodingResults from '@digitransit-search-util/digitransit-search-util-get-geocoding-results';
@@ -159,6 +160,28 @@ export default class FavouriteStore extends Store {
     return this.favourites.filter(
       favourite => favourite.type === 'bikeStation',
     );
+  }
+
+  /**
+   * Merges array of favourites with favourites in localstorage and stores them there.
+   * @param {array} arrayOfFavourites array of favourites
+   */
+  mergeToLocalstorage(arrayOfFavourites) {
+    const storage = getFavouriteStorage();
+    const merged = sortBy(
+      arrayOfFavourites.concat(storage),
+      'lastUpdated',
+    ).reverse();
+    const uniqsByFavId = uniqBy(merged, 'favouriteId');
+    const uniqs = [];
+    uniqsByFavId.forEach(u => {
+      if (!u.gtfsId || uniqs.every(item => item?.gtfsId !== u?.gtfsId)) {
+        uniqs.push(u);
+      }
+    });
+
+    this.storeFavourites();
+    this.emitChange();
   }
 
   /**
@@ -345,5 +368,6 @@ export default class FavouriteStore extends Store {
     SaveFavourite: 'saveFavourite',
     UpdateFavourites: 'updateFavourites',
     DeleteFavourite: 'deleteFavourite',
+    MergeToLocalstorage: 'mergeToLocalstorage',
   };
 }

--- a/app/util/apiUtils.js
+++ b/app/util/apiUtils.js
@@ -22,7 +22,9 @@ export function updateFavourites(data) {
     },
     body: JSON.stringify(data),
   };
-  return retryFetch('/api/user/favourites', options, 0, 0);
+  return retryFetch('/api/user/favourites', options, 0, 0).then(res =>
+    res.json(),
+  );
 }
 
 export function deleteFavourites(data) {
@@ -33,7 +35,9 @@ export function deleteFavourites(data) {
     },
     body: JSON.stringify(data),
   };
-  return retryFetch('/api/user/favourites', options, 0, 0);
+  return retryFetch('/api/user/favourites', options, 0, 0).then(res =>
+    res.json(),
+  );
 }
 
 export function getWeatherData(baseURL, time, lat, lon) {


### PR DESCRIPTION
## Proposed Changes

  - Enable localstorage favourites for unlogged user.
  - Favourite synchronization with localstorage.
  - When user logs in, current favourites are merged with ones in backend and they are saved there.
  - When user logs out, the favourites from backend service are saved to localstorage.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
