### PR TITLE
DT-4508: Stops and bike rental stations are not drawn on map if map is (automatically) zoomed out

### DIFF
--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -632,6 +632,7 @@ class StopsNearYouPage extends React.Component {
     const filteredMapLayers = {
       ...this.props.mapLayers,
       citybike: mode === 'CITYBIKE',
+      citybikeOverrideMinZoom: mode === 'CITYBIKE',
       stop: {},
     };
     if (mode !== 'CITYBIKE') {

--- a/app/component/map/tile-layer/CityBikes.js
+++ b/app/component/map/tile-layer/CityBikes.js
@@ -89,6 +89,11 @@ class CityBikes {
             this.config,
           ),
         );
+        const iconColor =
+          iconName.includes('secondary') &&
+          this.config.colors.iconColors['mode-citybike-secondary']
+            ? this.config.colors.iconColors['mode-citybike-secondary']
+            : this.config.colors.iconColors['mode-citybike'];
         if (
           !this.tile.stopsToShow ||
           this.tile.stopsToShow.includes(result.stationId)
@@ -100,7 +105,7 @@ class CityBikes {
             result.bikesAvailable,
             iconName,
             this.config.cityBike.capacity !== BIKEAVL_UNKNOWN,
-            this.config.colors.iconColors['mode-citybike'],
+            iconColor,
             isHilighted,
           );
         }

--- a/app/component/map/tile-layer/Stops.js
+++ b/app/component/map/tile-layer/Stops.js
@@ -168,8 +168,7 @@ class Stops {
           if (
             vt.layers.stations != null &&
             this.config.terminalStopsMaxZoom >
-              this.tile.coords.z + (this.tile.props.zoomOffset || 0) &&
-            this.tile.coords.z >= this.config.terminalStopsMinZoom
+              this.tile.coords.z + (this.tile.props.zoomOffset || 0)
           ) {
             for (
               let i = 0, ref = vt.layers.stations.length - 1;
@@ -187,12 +186,17 @@ class Stops {
                   this.tile.hilightedStops &&
                   this.tile.hilightedStops.includes(feature.properties.gtfsId);
                 this.features.unshift(pick(feature, ['geom', 'properties']));
-                drawTerminalIcon(
-                  this.tile,
-                  feature.geom,
-                  feature.properties.type,
-                  isHilighted,
-                );
+                if (
+                  isHilighted ||
+                  this.tile.coords.z >= this.config.terminalStopsMinZoom
+                ) {
+                  drawTerminalIcon(
+                    this.tile,
+                    feature.geom,
+                    feature.properties.type,
+                    isHilighted,
+                  );
+                }
               }
             }
           }

--- a/app/component/map/tile-layer/TileContainer.js
+++ b/app/component/map/tile-layer/TileContainer.js
@@ -6,6 +6,8 @@ import { isBrowser } from '../../../util/browser';
 import { isLayerEnabled } from '../../../util/mapLayerUtils';
 import { getStopIconStyles } from '../../../util/mapIconUtils';
 
+import { getCityBikeMinZoomOnStopsNearYou } from '../../../util/citybikes';
+
 class TileContainer {
   constructor(
     coords,
@@ -19,7 +21,10 @@ class TileContainer {
     stopsToShow,
   ) {
     const markersMinZoom = Math.min(
-      config.cityBike.cityBikeMinZoom,
+      getCityBikeMinZoomOnStopsNearYou(
+        config,
+        props.mapLayers.citybikeOverrideMinZoom,
+      ),
       config.stopsMinZoom,
       config.terminalStopsMinZoom,
     );
@@ -62,7 +67,11 @@ class TileContainer {
         }
         if (
           layerName === 'citybike' &&
-          this.coords.z >= config.cityBike.cityBikeMinZoom
+          this.coords.z >=
+            getCityBikeMinZoomOnStopsNearYou(
+              config,
+              props.mapLayers.citybikeOverrideMinZoom,
+            )
         ) {
           return isEnabled;
         }

--- a/app/component/map/tile-layer/TileContainer.js
+++ b/app/component/map/tile-layer/TileContainer.js
@@ -41,7 +41,20 @@ class TileContainer {
     this.vehicles = vehicles;
     this.stopsToShow = stopsToShow;
 
-    if (this.coords.z < markersMinZoom || !this.el.getContext) {
+    let ignoreMinZoomLevel =
+      hilightedStops &&
+      hilightedStops.length > 0 &&
+      !hilightedStops.every(stop => stop === '');
+    if (vehicles && vehicles.length > 0) {
+      ignoreMinZoomLevel = vehicles.every(
+        v => v.mode === 'ferry' && v.mode === 'rail' && v.mode === 'subway',
+      );
+    }
+
+    if (
+      (!ignoreMinZoomLevel && this.coords.z < markersMinZoom) ||
+      !this.el.getContext
+    ) {
       setTimeout(() => done(null, this.el), 0);
       return;
     }
@@ -60,7 +73,8 @@ class TileContainer {
 
         if (
           layerName === 'stop' &&
-          (this.coords.z >= config.stopsMinZoom ||
+          (ignoreMinZoomLevel ||
+            this.coords.z >= config.stopsMinZoom ||
             this.coords.z >= config.terminalStopsMinZoom)
         ) {
           return isEnabled;

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -83,6 +83,7 @@ export default {
       'mode-ferry': '#007A97',
       'mode-metro': '#CA4000',
       'mode-citybike': '#f2b62d',
+      'mode-citybike-secondary': '#333333',
     },
   },
 
@@ -444,6 +445,7 @@ export default {
   localStorageTarget: rootLink,
 
   cityBike: {
+    minZoomStopsNearYou: 10,
     showCityBikes: cityBikesEnabled,
     capacity: BIKEAVL_WITHMAX,
     showFullInfo: true,

--- a/app/util/citybikes.js
+++ b/app/util/citybikes.js
@@ -153,3 +153,10 @@ export const updateCitybikeNetworks = (
   }
   return chosenNetworks;
 };
+
+export const getCityBikeMinZoomOnStopsNearYou = (config, override) => {
+  if (override && config.cityBike.minZoomStopsNearYou) {
+    return config.cityBike.minZoomStopsNearYou;
+  }
+  return config.cityBike.cityBikeMinZoom;
+};

--- a/app/util/mapIconUtils.js
+++ b/app/util/mapIconUtils.js
@@ -96,8 +96,11 @@ export function getStopIconStyles(type, zoom, isHilighted) {
     // use bigger icon for hilighted stops always
     return styles[type][15];
   }
-  if (zoom < 13) {
+  if (zoom < 13 && type !== 'citybike') {
     return null;
+  }
+  if (zoom < 13) {
+    return styles[type][13];
   }
   if (zoom > 16) {
     return styles[type][16];


### PR DESCRIPTION
## Proposed Changes

  - Only bike rental stations is shown as commented 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
