### PR TITLE
DT-4620: Route page timetable merge first weeks data when possible

### DIFF
--- a/app/component/RouteScheduleContainer.js
+++ b/app/component/RouteScheduleContainer.js
@@ -77,6 +77,8 @@ class RouteScheduleContainer extends Component {
     hasLoaded: false,
   };
 
+  hasMergedData = false;
+
   onFromSelectChange = selectFrom => {
     const from = Number(selectFrom);
     this.setState(prevState => {
@@ -152,7 +154,11 @@ class RouteScheduleContainer extends Component {
   changeDate = newServiceDay => {
     // Don't set past dates because we have no data from them
     if (moment(newServiceDay).isBefore(moment())) {
-      newServiceDay = moment().format(DATE_FORMAT);
+      if (this.hasMergedData) {
+        newServiceDay = moment(newServiceDay).add(7, 'd').format(DATE_FORMAT);
+      } else {
+        newServiceDay = moment().format(DATE_FORMAT);
+      }
     }
     addAnalyticsEvent({
       category: 'Route',
@@ -447,6 +453,7 @@ class RouteScheduleContainer extends Component {
   render() {
     const { query } = this.props.match.location;
     const { intl } = this.context;
+    this.hasMergedData = false;
 
     if (!this.props.pattern) {
       if (isBrowser) {
@@ -490,6 +497,7 @@ class RouteScheduleContainer extends Component {
       if (thisWeekHashes.every(hash => nextWeekHashes.includes(hash))) {
         // eslint-disable-next-line prefer-destructuring
         firstDepartures[0] = firstDepartures[1];
+        this.hasMergedData = true;
       }
     }
 


### PR DESCRIPTION
## Proposed Changes

  - On route page timetable view "merge" incomplete first week data with the next weeks data when they match

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
