### PR TITLE
DT-4695: Allow wider map scale in matka.fi

### DIFF
--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -97,6 +97,7 @@ export default {
   },
 
   redirectReittiopasParams: true,
+  map: { minZoom: 5 },
 
   cityBike: {
     showCityBikes: true,


### PR DESCRIPTION
## Proposed Changes

  - Map scale covers whole finland in matka config
  - You can test this by doing route search Helsinki - Kittilä. To see the difference check how it looks like in current configuration

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
