### PR TITLE
DT-4715 Use stops and stations map layers from otp2 in walttiOpas

### DIFF
--- a/app/configurations/config.walttiOpas.js
+++ b/app/configurations/config.walttiOpas.js
@@ -8,12 +8,14 @@ const APP_DESCRIPTION = 'Uusi Reittiopas - Waltti-opas';
 const walttiConfig = require('./config.waltti').default;
 
 const API_URL = process.env.API_URL || 'https://api.digitransit.fi';
+const OTP_URL = process.env.OTP_URL || `${API_URL}/routing/v1/routers/next-waltti/`
 
 export default configMerger(walttiConfig, {
   CONFIG,
 
   URL: {
-    OTP: process.env.OTP_URL || `${API_URL}/routing/v1/routers/next-waltti/`,
+    OTP: OTP_URL,
+    STOP_MAP: `${OTP_URL}vectorTiles/stops,stations/`,
   },
 
   appBarLink: { name: 'Waltti', href: 'https://waltti.fi/' },


### PR DESCRIPTION
## Proposed Changes

  - Instead of using map server for stops map layer, use otp2 instead in walttiOpas

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
