### PR TITLE
DT-4718: Safari won't show whole page if there is some notification/alert top of page

### DIFF
--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -650,7 +650,6 @@ section.content {
   .banner-container {
     height: auto;
     display: flex;
-    max-height: 100%;
     overflow: hidden;
 
     .message-bar-content {


### PR DESCRIPTION
## Proposed Changes

  - removing max-height from .banner-container

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
