### PR TITLE
[chore] Refactor selection circle for markers

### DIFF
--- a/app/util/mapIconUtils.js
+++ b/app/util/mapIconUtils.js
@@ -279,6 +279,34 @@ function drawIconImageBadge(
   );
 }
 
+function drawSelectionCircle(
+  tile,
+  x,
+  y,
+  radius,
+  showAvailabilityBadge = false,
+) {
+  const zoom = tile.coords.z - 1;
+  const selectedCircleOffset = getSelectedIconCircleOffset(zoom, tile.ratio);
+
+  let arc = FULL_CIRCLE;
+  if (showAvailabilityBadge) {
+    arc *= 3 / 4;
+  }
+
+  tile.ctx.beginPath();
+  // eslint-disable-next-line no-param-reassign
+  tile.ctx.lineWidth = 2;
+  tile.ctx.arc(
+    x + selectedCircleOffset,
+    y + 1.85 * selectedCircleOffset,
+    radius - 2,
+    0,
+    arc,
+  );
+  tile.ctx.stroke();
+}
+
 /**
  * Draw a small circle icon used for far away zoom level.
  */
@@ -620,24 +648,10 @@ export function drawCitybikeIcon(
     }
     getImageFromSpriteCache(icon, width, height).then(image => {
       tile.ctx.drawImage(image, x, y);
+      if (isHilighted) {
+        drawSelectionCircle(tile, x, y, radius, false);
+      }
     });
-    if (isHilighted) {
-      const selectedCircleOffset = getSelectedIconCircleOffset(
-        zoom,
-        tile.ratio,
-      );
-      tile.ctx.beginPath();
-      // eslint-disable-next-line no-param-reassign
-      tile.ctx.lineWidth = 2;
-      tile.ctx.arc(
-        x + selectedCircleOffset,
-        y + selectedCircleOffset,
-        radius + 2,
-        0,
-        FULL_CIRCLE,
-      );
-      tile.ctx.stroke();
-    }
   }
   if (style === 'large') {
     const smallCircleRadius = 11 * tile.scaleratio;
@@ -669,21 +683,7 @@ export function drawCitybikeIcon(
         /* eslint-enable no-param-reassign */
       }
       if (isHilighted) {
-        const selectedCircleOffset = getSelectedIconCircleOffset(
-          zoom,
-          tile.ratio,
-        );
-        tile.ctx.beginPath();
-        // eslint-disable-next-line no-param-reassign
-        tile.ctx.lineWidth = 2;
-        tile.ctx.arc(
-          iconX + selectedCircleOffset,
-          iconY + 1.85 * selectedCircleOffset,
-          radius - 2,
-          0,
-          FULL_CIRCLE * (3 / 4),
-        );
-        tile.ctx.stroke();
+        drawSelectionCircle(tile, iconX, iconY, radius, showAvailabilityBadge);
       }
     });
   }


### PR DESCRIPTION
Extracted the subroutine that draws a selection circle around markers into a function.

The function takes the tile to render the circle, coordinates, radius, and a flag that signifies the presence of the badge that shows available vehicles.