### PR TITLE
DT-4723: Header hides timepicker modal and waltti tooltips

### DIFF
--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -100,6 +100,7 @@ $content-background-color: $background-color;
 .mobile.top-bar {
   height: 50px;
   min-height: 50px;
+  z-index: 1000;
   background: $top-bar-color;
   .logo {
     min-height: 30px;

--- a/app/configurations/config.hameenlinna.js
+++ b/app/configurations/config.hameenlinna.js
@@ -52,15 +52,6 @@ export default configMerger(walttiConfig, {
     ],
   },
 
-  mapLayers: {
-    tooltip: {
-      fi: 'Uutta! Saat nyt lähellä olevat bussit kartalle asetuksista.',
-      en: 'New! You can now get nearby busses on the map from the settings.',
-      sv:
-        'Nytt! I inställningarna kan du nu välja att se närliggande bussar på kartan.',
-    },
-  },
-
   searchParams: {
     'boundary.rect.min_lat': 60.75705,
     'boundary.rect.max_lat': 61.30156,

--- a/app/configurations/config.joensuu.js
+++ b/app/configurations/config.joensuu.js
@@ -39,15 +39,6 @@ export default configMerger(walttiConfig, {
     description: APP_DESCRIPTION,
   },
 
-  mapLayers: {
-    tooltip: {
-      fi: 'Uutta! Saat nyt lähellä olevat bussit kartalle asetuksista.',
-      en: 'New! You can now get nearby busses on the map from the settings.',
-      sv:
-        'Nytt! I inställningarna kan du nu välja att se närliggande bussar på kartan.',
-    },
-  },
-
   transportModes: {
     ferry: {
       availableForSelection: true,

--- a/app/configurations/config.jyvaskyla.js
+++ b/app/configurations/config.jyvaskyla.js
@@ -59,15 +59,6 @@ export default configMerger(walttiConfig, {
   // Navbar logo
   logo: 'jyvaskyla/favicon.png',
 
-  mapLayers: {
-    tooltip: {
-      fi: 'Uutta! Saat nyt lähellä olevat bussit kartalle asetuksista.',
-      en: 'New! You can now get nearby busses on the map from the settings.',
-      sv:
-        'Nytt! I inställningarna kan du nu välja att se närliggande bussar på kartan.',
-    },
-  },
-
   textLogo: false,
 
   vehicles: true,

--- a/app/configurations/config.kuopio.js
+++ b/app/configurations/config.kuopio.js
@@ -34,15 +34,6 @@ export default configMerger(walttiConfig, {
   // Navbar logo
   logo: 'kuopio/logo.png',
 
-  mapLayers: {
-    tooltip: {
-      fi: 'Uutta! Saat nyt lähellä olevat bussit kartalle asetuksista.',
-      en: 'New! You can now get nearby busses on the map from the settings.',
-      sv:
-        'Nytt! I inställningarna kan du nu välja att se närliggande bussar på kartan.',
-    },
-  },
-
   feedIds: ['Kuopio', 'KuopioEly'],
 
   showTicketInformation: true,

--- a/app/configurations/config.lahti.js
+++ b/app/configurations/config.lahti.js
@@ -40,15 +40,6 @@ export default configMerger(walttiConfig, {
 
   feedIds: ['Lahti'],
 
-  mapLayers: {
-    tooltip: {
-      fi: 'Uutta! Saat nyt lähellä olevat bussit kartalle asetuksista.',
-      en: 'New! You can now get nearby busses on the map from the settings.',
-      sv:
-        'Nytt! I inställningarna kan du nu välja att se närliggande bussar på kartan.',
-    },
-  },
-
   searchParams: {
     'boundary.rect.min_lat': minLat,
     'boundary.rect.max_lat': maxLat,

--- a/app/configurations/config.lappeenranta.js
+++ b/app/configurations/config.lappeenranta.js
@@ -33,15 +33,6 @@ export default configMerger(walttiConfig, {
 
   favicon: './app/configurations/images/lappeenranta/bussi_fin.jpeg',
 
-  mapLayers: {
-    tooltip: {
-      fi: 'Uutta! Saat nyt lähellä olevat bussit kartalle asetuksista.',
-      en: 'New! You can now get nearby busses on the map from the settings.',
-      sv:
-        'Nytt! I inställningarna kan du nu välja att se närliggande bussar på kartan.',
-    },
-  },
-
   cityBike: {
     showCityBikes: true,
     capacity: BIKEAVL_UNKNOWN,

--- a/app/configurations/config.oulu.js
+++ b/app/configurations/config.oulu.js
@@ -37,15 +37,6 @@ export default configMerger(walttiConfig, {
   // Navbar logo
   logo: 'oulu/oulu-logo.png',
 
-  mapLayers: {
-    tooltip: {
-      fi: 'Uutta! Saat nyt lähellä olevat bussit kartalle asetuksista.',
-      en: 'New! You can now get nearby busses on the map from the settings.',
-      sv:
-        'Nytt! I inställningarna kan du nu välja att se närliggande bussar på kartan.',
-    },
-  },
-
   cityBike: {
     showCityBikes: false,
     networks: {

--- a/app/configurations/config.tampere.js
+++ b/app/configurations/config.tampere.js
@@ -57,17 +57,6 @@ export default configMerger(walttiConfig, {
     ],
   },
 
-  mapLayers: {
-    tooltip: {
-      fi:
-        'Uutta! Saat nyt vyöhykkeet ja lähellä olevat bussit kartalle asetuksista.',
-      en:
-        'New! You can now get zones and nearby busses on the map from the settings.',
-      sv:
-        'Nytt! I inställningarna kan du nu välja att se zoner och närliggande bussar på kartan.',
-    },
-  },
-
   itinerary: {
     // Number of days to include to the service time range from the future (DT-3175)
     serviceTimeRange: 60,

--- a/app/configurations/config.turku.js
+++ b/app/configurations/config.turku.js
@@ -50,15 +50,6 @@ export default configMerger(walttiConfig, {
   // Navbar logo
   logo: 'turku/foli-logo.png',
 
-  mapLayers: {
-    tooltip: {
-      fi: 'Uutta! Saat nyt lähellä olevat bussit kartalle asetuksista.',
-      en: 'New! You can now get nearby busses on the map from the settings.',
-      sv:
-        'Nytt! I inställningarna kan du nu välja att se närliggande bussar på kartan.',
-    },
-  },
-
   cityBike: {
     showCityBikes: true,
     networks: {

--- a/docs/ZIndex.md
+++ b/docs/ZIndex.md
@@ -29,3 +29,4 @@ Selector | Component | Z-Index | Comment
 `.origin-destination-bar { .field-link { span:first-child { &::before` | Summary search bar from/to marker letters | 1 | Could be removed through new icon components
 `.itinerary-summary-row { .itinerary-legs { .line` | Summary result row leg lines | 1 |
 `.itinerary-summary-row { .itinerary-legs { .line { :after` | Hides the Summary result row leg lines behind the mode icon. | -1 |
+`.mobile.top-bar  | Mobile top bar | 1000 |


### PR DESCRIPTION
## Proposed Changes

  - Added z-index to top-bar so it won't be datetimepicker's way.
  - Removed so-called new features tooltip content from waltti configs. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
