### PR TITLE
DT-4738: Departure times at route page are not aligned correctly on waltti instances

### DIFF
--- a/app/component/TripRouteStop.js
+++ b/app/component/TripRouteStop.js
@@ -5,8 +5,8 @@ import cx from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 
 import ComponentUsageExample from './ComponentUsageExample';
+import AddressRow from './AddressRow';
 import ServiceAlertIcon from './ServiceAlertIcon';
-import StopCode from './StopCode';
 import PatternLink from './PatternLink';
 import { fromStopTime } from './DepartureTime';
 import { RealtimeStateType, AlertSeverityLevelType } from '../constants';
@@ -147,12 +147,16 @@ const TripRouteStop = (props, context) => {
               </div>
             </div>
             <div className="route-details-bottom-row">
-              <span className="route-stop-address">{stop.desc}</span>
-              {stop.code && <StopCode code={stop.code} />}
-              <ZoneIcon
-                zoneId={getZoneLabel(stop.zoneId, config)}
-                showUnknown={false}
-              />
+              <AddressRow desc={stop.desc} code={stop.code} />
+              {config.zones.stops && stop.zoneId ? (
+                <ZoneIcon
+                  className="itinerary-zone-icon"
+                  zoneId={getZoneLabel(stop.zoneId, config)}
+                  showUnknown={false}
+                />
+              ) : (
+                <div className="itinerary-zone-icon" />
+              )}
             </div>
           </div>
         </Link>

--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -280,17 +280,13 @@ $margin-left-right: 1.333em;
   .route-stop-row_content-container {
     width: 100%; //calc(100% - 13% - 15px - 1em);
     margin-left: 15px;
-    display: block;
+    display: flex;
     border-bottom: 1px solid #eef1f3;
     a {
-      display: flex;
-      flex-direction: row;
       width: 100%;
       height: 100%;
       padding: 10px 0;
       text-decoration: none;
-      justify-content: space-between;
-      align-items: center;
       .route-details_container {
         flex-grow: 1;
         display: flex;

--- a/test/unit/component/TripRouteStop.test.js
+++ b/test/unit/component/TripRouteStop.test.js
@@ -26,7 +26,7 @@ describe('<TripRouteStop />', () => {
       stoptime: {},
     };
     const wrapper = mountWithIntl(<TripRouteStop {...props} />, {
-      context: { config: {} },
+      context: { config: { zones: { stops: true } } },
       childContextTypes: { config: PropTypes.object },
     });
     expect(wrapper.find(ServiceAlertIcon).isEmptyRender()).to.equal(true);


### PR DESCRIPTION
## Proposed Changes

  - Align departure times correctly on trip page.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
