### PR TITLE
DT-4736 Theme-color should match top bar color, not primary color

### DIFF
--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -19,8 +19,8 @@ $offcanvas-background-active: scale-color($gray, $lightness: -30%);
 /* top bar */
 $topbar-height: 40px;
 
-$top-navigation-icon-color: navbar-icon-color($primary-color);
-$top-navigation-title-color: navbar-icon-color($primary-color);
+$top-navigation-icon-color: navbar-icon-color($top-bar-color);
+$top-navigation-title-color: navbar-icon-color($top-bar-color);
 
 /* offcanvas */
 $offcanvas-profile-icon-size: 60px;

--- a/app/config.js
+++ b/app/config.js
@@ -39,7 +39,7 @@ function addMetaData(config) {
           e.content = `${appPathPrefix}${stats.outputFilePrefix}${e.content}`; // fix path bug
         } else if (e.name === 'theme-color') {
           // eslint-disable-next-line no-param-reassign
-          e.content = config.colors.primary;
+          e.content = config.colors.topBarColor || config.colors.primary;
         } else if (e.name === 'apple-mobile-web-app-status-bar-style') {
           // eslint-disable-next-line no-param-reassign
           e.content = 'default';

--- a/app/configurations/config.walttiOpas.js
+++ b/app/configurations/config.walttiOpas.js
@@ -22,6 +22,7 @@ export default configMerger(walttiConfig, {
 
   colors: {
     primary: '#F16522',
+    topBarColor: '#FFC439',
     iconColors: {
       'mode-bus': '#F16522',
     },


### PR DESCRIPTION
## Proposed Changes

  - Add a new topBarColor variable to conf when it differs from primary color and use it for theme-color (which should match the color of the navigation bar)
  - Use top-bar-color instead of primary color when deciding the color of icons in the navigation bar (this doesn't affect our current configs but could have caused issues in the future)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
