### PR TITLE
DT-4767 Make use of viapoint configurable

### DIFF
--- a/app/component/OriginDestinationBar.js
+++ b/app/component/OriginDestinationBar.js
@@ -146,7 +146,7 @@ class OriginDestinationBar extends React.Component {
           refPoint={refPoint}
           originPlaceHolder="search-origin-index"
           destinationPlaceHolder="search-destination-index"
-          showMultiPointControls
+          showMultiPointControls={this.context.config.viaPointsEnabled}
           viaPoints={this.props.viaPoints}
           updateViaPoints={this.updateViaPoints}
           addAnalyticsEvent={addAnalyticsEvent}

--- a/app/component/map/ItineraryPageMap.js
+++ b/app/component/map/ItineraryPageMap.js
@@ -21,7 +21,7 @@ function ItineraryPageMap(
     showVehicles,
     ...rest
   },
-  { match, router, executeAction },
+  { match, router, executeAction, config },
 ) {
   const { hash } = match.params;
   const leafletObjs = [];
@@ -81,7 +81,10 @@ function ItineraryPageMap(
   });
 
   // max 5 viapoints
-  const locationPopup = viaPoints.length < 5 ? 'all' : 'origindestination';
+  const locationPopup =
+    config.viaPointsEnabled && viaPoints.length < 5
+      ? 'all'
+      : 'origindestination';
   const onSelectLocation = (item, id) =>
     onLocationPopup(item, id, router, match, executeAction);
 

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -717,4 +717,6 @@ export default {
     stops: false,
     itinerary: false,
   },
+
+  viaPointsEnabled: true,
 };

--- a/app/configurations/config.walttiOpas.js
+++ b/app/configurations/config.walttiOpas.js
@@ -7,7 +7,7 @@ const APP_DESCRIPTION = 'Uusi Reittiopas - Waltti-opas';
 
 const walttiConfig = require('./config.waltti').default;
 
-const API_URL = process.env.API_URL || 'https://api.digitransit.fi';
+const API_URL = process.env.API_URL || 'https://dev-api.digitransit.fi';
 const OTP_URL = process.env.OTP_URL || `${API_URL}/routing/v1/routers/next-waltti/`
 
 export default configMerger(walttiConfig, {

--- a/app/configurations/config.walttiOpas.js
+++ b/app/configurations/config.walttiOpas.js
@@ -140,4 +140,6 @@ export default configMerger(walttiConfig, {
       },
     ],
   },
+
+  viaPointsEnabled: false,
 });


### PR DESCRIPTION
## Proposed Changes

  - Add viaPointsEnabled config option that is enabled by default and can be used to hide via point selectors (if there are via points in URL, they are still being used)
     - Hide via points for walttiOpas
  - Change walttiOpas to use dev api by default

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
