### PR TITLE
DT-4770: Stops near you scroll in wrong place

### DIFF
--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -846,6 +846,7 @@ class StopsNearYouPage extends React.Component {
               }
               bckBtnFallback="back"
               content={this.renderContent()}
+              scrollable
               map={
                 <>
                   {this.renderSearchBox()}

--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -818,6 +818,7 @@ class StopsNearYouPage extends React.Component {
   render() {
     const { mode } = this.props.match.params;
     const { phase } = this.state;
+    const nearByStopModes = this.getNearByStopModes();
 
     if (PH_SHOWSEARCH.includes(phase)) {
       return <div>{this.renderDialogModal()}</div>;
@@ -846,7 +847,7 @@ class StopsNearYouPage extends React.Component {
               }
               bckBtnFallback="back"
               content={this.renderContent()}
-              scrollable
+              scrollable={nearByStopModes.length === 1}
               map={
                 <>
                   {this.renderSearchBox()}


### PR DESCRIPTION
## Proposed Changes

  - Scroll was placed on whole page when there was only 1 mode on stop near you page, e.g. on jyvaskyla config.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
