### PR TITLE
DT-4790: fix waltti citybike teaser content in citybike stop view

### DIFF
--- a/app/component/BikeRentalStationContent.js
+++ b/app/component/BikeRentalStationContent.js
@@ -9,7 +9,10 @@ import CityBikeStopContent from './CityBikeStopContent';
 import BikeRentalStationHeader from './BikeRentalStationHeader';
 import Icon from './Icon';
 import withBreakpoint from '../util/withBreakpoint';
-import { getCityBikeNetworkConfig } from '../util/citybikes';
+import {
+  getCityBikeNetworkConfig,
+  getCityBikeNetworkId,
+} from '../util/citybikes';
 import { isBrowser } from '../util/browser';
 import { PREFIX_BIKESTATIONS } from '../util/path';
 
@@ -43,6 +46,16 @@ const BikeRentalStationContent = (
   if (networkConfig.returnInstructions) {
     returnInstructionsUrl = networkConfig.returnInstructions[language];
   }
+  const { cityBike } = config;
+  const cityBikeBuyUrl = cityBike.buyUrl;
+  let cityBikeNetworkUrl;
+  // Use general information about using city bike, if one network config is available
+  if (Object.keys(cityBike.networks).length === 1) {
+    cityBikeNetworkUrl = getCityBikeNetworkConfig(
+      getCityBikeNetworkId(Object.keys(cityBike.networks)),
+      config,
+    ).url;
+  }
   return (
     <div className="bike-station-page-container">
       <BikeRentalStationHeader
@@ -65,26 +78,37 @@ const BikeRentalStationContent = (
           </a>
         </div>
       )}
-      <div className="citybike-use-disclaimer">
-        <div className="disclaimer-header">
-          <FormattedMessage id="citybike-start-using" />
+      {(cityBikeBuyUrl || cityBikeNetworkUrl) && (
+        <div className="citybike-use-disclaimer">
+          <div className="disclaimer-header">
+            <FormattedMessage id="citybike-start-using" />
+          </div>
+          <div className="disclaimer-content">
+            {cityBikeBuyUrl ? (
+              <FormattedMessage id="citybike-buy-season" />
+            ) : (
+              <a
+                className="external-link-citybike"
+                href={cityBikeNetworkUrl[language]}
+              >
+                <FormattedMessage id="citybike-start-using-info" />{' '}
+              </a>
+            )}
+          </div>
+          {isClient && cityBikeBuyUrl && (
+            <a
+              onClick={e => {
+                e.stopPropagation();
+              }}
+              className="external-link"
+              href={url}
+            >
+              <FormattedMessage id="citybike-purchase-link" />
+              <Icon img="icon-icon_external-link-box" />
+            </a>
+          )}
         </div>
-        <div className="disclaimer-content">
-          <FormattedMessage id="citybike-buy-season" />
-        </div>
-        {isClient && (
-          <a
-            onClick={e => {
-              e.stopPropagation();
-            }}
-            className="external-link"
-            href={url}
-          >
-            <FormattedMessage id="citybike-purchase-link" />
-            <Icon img="icon-icon_external-link-box" />
-          </a>
-        )}
-      </div>
+      )}
     </div>
   );
 };

--- a/app/component/bike-rental-station.scss
+++ b/app/component/bike-rental-station.scss
@@ -64,7 +64,6 @@
     text-decoration: none;
   }
   .citybike-use-disclaimer {
-    height: 120px;
     border-radius: 8px;
     border: solid 1px #dddddd;
     background-color: #f4f4f5;
@@ -72,9 +71,11 @@
     width: 100%;
     margin-top: 24px;
     .disclaimer-header {
+      display: flex;
       font-size: 1.125rem;
     }
     .disclaimer-content {
+      display: flex;
       font-weight: normal;
       font-size: 0.9375rem;
     }


### PR DESCRIPTION
## Proposed Changes

  - Dont show hsl specific info on waltti instances citybike stop view

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
