### PR TITLE
DT-4362: Focus management when viewing itinerary details

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -1191,6 +1191,24 @@ class SummaryPage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
+    // screen reader alert when new itineraries are fetched
+    if (
+      this.props.match.params.hash === undefined &&
+      this.props.viewer &&
+      this.props.viewer.plan &&
+      this.props.viewer.plan.itineraries &&
+      !this.secondQuerySent &&
+      this.alertRef.current
+    ) {
+      this.alertRef.current.innerHTML = this.context.intl.formatMessage({
+        id: 'itinerary-page.itineraries-loaded',
+        defaultMessage: 'More itineraries loaded',
+      });
+      setTimeout(() => {
+        this.alertRef.current.innerHTML = null;
+      }, 100);
+    }
+
     const viaPoints = getIntermediatePlaces(this.props.match.location.query);
     if (
       this.props.match.params.hash &&

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -1453,6 +1453,19 @@ class SummaryPage extends React.Component {
           .catch(err => {
             this.pendingWeatherHash = undefined;
             this.setState({ isFetchingWeather: false, weatherData: { err } });
+          })
+          .finally(() => {
+            if (this.alertRef.current) {
+              this.alertRef.current.innerHTML = this.context.intl.formatMessage(
+                {
+                  id: 'itinerary-summary-page-street-mode.update-alert',
+                  defaultMessage: 'Walking and biking results updated',
+                },
+              );
+              setTimeout(() => {
+                this.alertRef.current.innerHTML = null;
+              }, 100);
+            }
           });
       }
     }
@@ -1899,19 +1912,6 @@ class SummaryPage extends React.Component {
       latestArrivalTime = Math.max(...combinedItineraries.map(i => i.endTime));
     }
 
-    const loadingStreeModeSelector =
-      this.props.loading ||
-      this.state.isFetchingWalkAndBike ||
-      (!this.state.weatherData.temperature && !this.state.weatherData.err);
-
-    const screenReaderWalkAndBikeUpdateAlert = (
-      <span className="sr-only" role="alert">
-        <FormattedMessage
-          id="itinerary-summary-page-street-mode.update-alert"
-          defaultMessage="Walking and biking results updated"
-        />
-      </span>
-    );
     const screenReaderAlert = (
       <>
         <span className="sr-only" role="alert" ref={this.alertRef} />
@@ -2111,7 +2111,6 @@ class SummaryPage extends React.Component {
                   }
                 />
               )}
-              {!loadingStreeModeSelector && screenReaderWalkAndBikeUpdateAlert}
             </React.Fragment>
           }
           content={content}
@@ -2261,7 +2260,6 @@ class SummaryPage extends React.Component {
                   }
                 />
               )}
-              {!loadingStreeModeSelector && screenReaderWalkAndBikeUpdateAlert}
             </React.Fragment>
           ) : (
             false

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -56,6 +56,7 @@ class SummaryPlanContainer extends React.Component {
     loading: PropTypes.bool.isRequired,
     onLater: PropTypes.func.isRequired,
     onEarlier: PropTypes.func.isRequired,
+    onDetailsTabFocused: PropTypes.func.isRequired,
     loadingMoreItineraries: PropTypes.string,
   };
 
@@ -130,6 +131,7 @@ class SummaryPlanContainer extends React.Component {
     this.context.router.replace(newState);
     newState.pathname = indexPath;
     this.context.router.push(newState);
+    this.props.onDetailsTabFocused();
   };
 
   onNow = () => {


### PR DESCRIPTION
## Proposed Changes

  - Move focus to heading when itinerary detail view is opened
  - Focus stays on back button when going back to summary view
  - Fix some alerts on summary page so they don't remain on page after being announced
  - Remove "search results updated" alert when moving to detail view

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
