### PR TITLE
Remove all vehicles that haven't been updated for 3 minutes

### DIFF
--- a/app/component/map/VehicleMarkerContainer.js
+++ b/app/component/map/VehicleMarkerContainer.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import connectToStores from 'fluxible-addons-react/connectToStores';
 
+import moment from 'moment';
 import VehicleIcon from '../VehicleIcon';
 import IconMarker from './IconMarker';
 import { isBrowser } from '../../util/browser';
@@ -127,9 +128,17 @@ const connectedComponent = connectToStores(
       );
       vehiclesFiltered = Object.fromEntries(filtered);
     }
+    // if you keep the UI open for a long time then trips that have finsished accumulated on the screen
+    // this removes anything that hasn't had an update in 3 minutes
+    const vehiclesWithRecentUpdates = Object.entries(vehiclesFiltered).filter(
+      ([, message]) => {
+        const threeMinutesAgo = moment().subtract(180, 'seconds');
+        return moment.unix(message.timestamp).isAfter(threeMinutesAgo);
+      },
+    );
     return {
       ...props,
-      vehicles: vehiclesFiltered,
+      vehicles: Object.fromEntries(vehiclesWithRecentUpdates),
       setVisibleVehicles,
     };
   },


### PR DESCRIPTION
## Proposed Changes

We noticed that when you keep the screen with bus positions open for a long time, then finished busses accumulate on the screen.

![image](https://user-images.githubusercontent.com/151346/123941416-6ce3ee00-d99a-11eb-9c93-639ef0bd4b21.png)

For this reason we remove any vehicle that hasn't had an update in more than 3 minutes.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
