### PR TITLE
DT-4839: screen reader announces when new swipeableTab tab is opened

### DIFF
--- a/app/component/SwipeableTabs.js
+++ b/app/component/SwipeableTabs.js
@@ -225,6 +225,7 @@ export default class SwipeableTabs extends React.Component {
       ariaFrom,
       ariaFromHeader,
     } = this.props;
+    const { intl } = this.context;
     const tabBalls = this.tabBalls(tabs.length);
     const disabled = tabBalls.length < 2;
     let reactSwipeEl;
@@ -305,6 +306,15 @@ export default class SwipeableTabs extends React.Component {
               </div>
             )}
             <div className="swipe-tab-indicator">
+              <span className="sr-only" aria-live="polite">
+                {intl.formatMessage(
+                  {
+                    id: 'swipe-sr-new-tab-opened',
+                    defaultMessage: 'Tab {number} opened.',
+                  },
+                  { number: this.props.tabIndex + 1 },
+                )}
+              </span>
               {disabled ? null : tabBalls}
             </div>
             {!hideArrows && (

--- a/app/translations.js
+++ b/app/translations.js
@@ -1373,6 +1373,7 @@ const translations = {
     'swipe-result-tab-left': 'Press Enter or Space to show the previous tab.',
     'swipe-result-tab-right': 'Press Enter or Space to show the next tab.',
     'swipe-result-tabs': 'Switch tabs using arrow keys.',
+    'swipe-sr-new-tab-opened': 'Tab {number} opened.',
     'swipe-stops-near-you': 'Stops near you swipe result tabs.',
     'swipe-stops-near-you-header': 'Stops near you swipe result tabs',
     'swipe-summary-page': 'Itinerary swipe result tabs',
@@ -2332,6 +2333,7 @@ const translations = {
     'swipe-result-tab-right':
       'Navigointipainike. Näytä seuraava välilehti painamalla enteriä tai välilyöntiä.',
     'swipe-result-tabs': 'Selaa välilehtiä nuolinäppäimillä.',
+    'swipe-sr-new-tab-opened': 'Välilehti {number} avattu.',
     'swipe-stops-near-you': 'Lähipysäkkinäkymävälilehtien',
     'swipe-stops-near-you-header': 'Lähipysäkkinäkymävälilehdet.',
     'swipe-summary-page': 'Reittiehdotusvälilehtien',
@@ -4075,6 +4077,7 @@ const translations = {
     'swipe-result-tab-right':
       'Gå till följande blad genom att trycka på enter eller mellanslag.',
     'swipe-result-tabs': 'Bläddra mellan blad med pilknapparna.',
+    'swipe-sr-new-tab-opened': 'Blad {number} öppnad.',
     'swipe-stops-near-you':
       'Navigeringsknapp för att kunna bläddra hållplatser nära mig.',
     'swipe-stops-near-you-header': 'Hållplatser nära mig.',


### PR DESCRIPTION
## Proposed Changes

  - Screen reader now announces: f.ex "tab 2 opened" when a swipeable tab is changed

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
