### PR TITLE
DT-4872: Stops near you page breaks when browsing with tab

### DIFF
--- a/app/component/StopsNearYouContainer.js
+++ b/app/component/StopsNearYouContainer.js
@@ -14,6 +14,7 @@ import Icon from './Icon';
 class StopsNearYouContainer extends React.Component {
   static propTypes = {
     stopPatterns: PropTypes.any,
+    setLoadState: PropTypes.func,
     currentTime: PropTypes.number.isRequired,
     relay: PropTypes.shape({
       refetchConnection: PropTypes.func.isRequired,
@@ -145,6 +146,7 @@ class StopsNearYouContainer extends React.Component {
   }
 
   componentDidMount() {
+    this.props.setLoadState();
     if (this.state.fetchMoreStops) {
       this.showMore();
     }

--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -90,6 +90,7 @@ class StopsNearYouPage extends React.Component {
       showCityBikeTeaser: true,
       searchPosition: {},
       mapLayerOptions: null,
+      resultsLoaded: false,
     };
   }
 
@@ -193,6 +194,11 @@ class StopsNearYouPage extends React.Component {
       return newState;
     }
     return newState;
+  };
+
+  setLoadState = () => {
+    // trigger a state update in this component to force a rerender when stop data is received for the first time.
+    this.setState({ resultsLoaded: true });
   };
 
   setMapLayerOptions = () => {
@@ -572,6 +578,7 @@ class StopsNearYouPage extends React.Component {
                   )}
                   {props && (
                     <StopsNearYouContainer
+                      setLoadState={this.setLoadState}
                       match={this.props.match}
                       stopPatterns={props.stopPatterns}
                       position={this.state.searchPosition}
@@ -589,6 +596,7 @@ class StopsNearYouPage extends React.Component {
     if (tabs.length > 1) {
       return (
         <SwipeableTabs
+          loaded={this.state.resultsLoaded}
           tabIndex={index}
           onSwipe={this.onSwipe}
           tabs={tabs}

--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -90,6 +90,7 @@ class StopsNearYouPage extends React.Component {
       showCityBikeTeaser: true,
       searchPosition: {},
       mapLayerOptions: null,
+      // eslint-disable-next-line react/no-unused-state
       resultsLoaded: false,
     };
   }
@@ -198,6 +199,9 @@ class StopsNearYouPage extends React.Component {
 
   setLoadState = () => {
     // trigger a state update in this component to force a rerender when stop data is received for the first time.
+    // this fixes a bug where swipeable tabs were not keeping focusable elements up to date after receving stop data
+    // and keyboard focus could be lost to hidden elements.
+    // eslint-disable-next-line react/no-unused-state
     this.setState({ resultsLoaded: true });
   };
 
@@ -596,7 +600,6 @@ class StopsNearYouPage extends React.Component {
     if (tabs.length > 1) {
       return (
         <SwipeableTabs
-          loaded={this.state.resultsLoaded}
           tabIndex={index}
           onSwipe={this.onSwipe}
           tabs={tabs}


### PR DESCRIPTION
## Proposed Changes

  - Force a rerender in to update focusable elements in SwipeableTabs when data arrives for the first time

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
