### PR TITLE
DT-4883 Add translations to long citybike leg notifications

### DIFF
--- a/app/translations.js
+++ b/app/translations.js
@@ -930,13 +930,14 @@ const translations = {
     citybike: 'City bike',
     'citybike-buy-season': 'Buy a daily, weekly or season pass',
     'citybike-distance-duration': 'Bike {duration} ({distance})',
-    'citybike-duration-general-header': '',
+    'citybike-duration-general-header':
+      'Extra charge applies to several sections of route to be completed by a city bike.',
     'citybike-duration-info':
       'You can ride a city bike for up to {duration} minutes at a time, after which you will be charged extra.',
     'citybike-duration-info-header':
       'The section of route to be completed by a city bike takes more than {duration} minutes.',
     'citybike-duration-info-short':
-      'Citybike section over {duration} min. Includes an additional fee.',
+      'Section of route takes more than {duration} min. Extra charge applies.',
     'citybike-network-headers': 'Citybikes',
     'citybike-purchase-link': 'Buy',
     'citybike-register-required': 'To use city bikes, you need to register',
@@ -1916,7 +1917,7 @@ const translations = {
       'Osta käyttöoikeutta päiväksi, viikoksi tai koko kaudeksi',
     'citybike-distance-duration': 'Pyöräile {duration} ({distance})',
     'citybike-duration-general-header':
-      'Useampi reitin kaupunkipyöräosuuksista sisältää lisämaksuja',
+      'Useampi reitin kaupunkipyöräosuuksista sisältää lisämaksuja.',
     'citybike-duration-info':
       'Kaupunkipyörää voi käyttää yhtäjaksoisesti {duration} min, jonka jälkeen peritään lisämaksu.',
     'citybike-duration-info-header':
@@ -3679,13 +3680,14 @@ const translations = {
     'citybike-buy-season':
       'Köp ett abonnemang för en dag, en vecka eller för en hel säsong',
     'citybike-distance-duration': 'Cykla {duration} ({distance})',
-    'citybike-duration-general-header': '',
+    'citybike-duration-general-header':
+      'Rutten har flera sträckor med stadscykel som inkluderar tilläggsavgifter.',
     'citybike-duration-info':
       'Du kan använda stadscykeln {duration} minuter åt gången, efter det debiteras en tilläggsavgift.',
     'citybike-duration-info-header':
       'Sträckan med stadscykel tar över {duration} min.',
     'citybike-duration-info-short':
-      'Stadscyckel sträckan tar över {duration} min. Debiteras en tilläggsavgift.',
+      'Sträckan tar över {duration} min. En tilläggsavgift ska debiteras.',
     'citybike-network-headers': 'Stadscyklarna',
     'citybike-purchase-link': 'Gå till köp',
     'citybike-register-required':


### PR DESCRIPTION
## Proposed Changes

  - Updated couple of citybike leg warning translations

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
