### PR TITLE
fix: publish packages even if yarn.lock changes

### DIFF
--- a/.github/workflows/next-dev-pipeline.yml
+++ b/.github/workflows/next-dev-pipeline.yml
@@ -287,6 +287,8 @@ jobs:
         run: echo //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} > .npmrc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - name: disregard changed yarn.lock
+        run: git update-index --assume-unchanged yarn.lock
       - name: Publish shared components to npm
         run: echo ::set-output name=publish-logs::$(yarn digitransit-npm-autopublish)
         shell: bash


### PR DESCRIPTION
## Proposed Changes

  - Publish packages even if yarn.lock differs from commited one

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
