### PR TITLE
DT-4913: do not  render wait leg if it does not end to a valid stop

### DIFF
--- a/app/component/ItineraryLegs.js
+++ b/app/component/ItineraryLegs.js
@@ -281,7 +281,8 @@ class ItineraryLegs extends React.Component {
           leg.mode !== 'AIRPLANE' &&
           leg.mode !== 'CAR' &&
           !nextLeg.intermediatePlace &&
-          !isNextLegInterlining
+          !isNextLegInterlining &&
+          leg.to.stop
         ) {
           legs.push(
             <WaitLeg

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -290,18 +290,15 @@ const SummaryRow = (
     const longName =
       leg.route && leg.route.shortName && leg.route.shortName.length > 5;
 
-    if (nextLeg) {
+    if (
+      nextLeg &&
+      !nextLeg.intermediatePlace &&
+      !connectsFromViaPoint(nextLeg, intermediatePlaces)
+    ) {
+      // don't show waiting in intermediate places
       waitTime = nextLeg.startTime - leg.endTime;
       waitLength = (waitTime / durationWithoutSlack) * 100;
-      // don't show waiting in intermediate places
-      const viaNext =
-        nextLeg.intermediatePlace ||
-        connectsFromViaPoint(nextLeg, intermediatePlaces);
-      if (
-        !viaNext &&
-        waitTime > waitThreshold &&
-        waitLength > renderBarThreshold
-      ) {
+      if (waitTime > waitThreshold && waitLength > renderBarThreshold) {
         // if waittime is long enough, render a waiting bar
         waiting = true;
       } else {

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -243,7 +243,10 @@ const SummaryRow = (
       noTransitLegs = false;
       transitLegCount += 1;
     }
-    if (leg.intermediatePlace) {
+    if (
+      leg.intermediatePlace ||
+      connectsFromViaPoint(leg, intermediatePlaces)
+    ) {
       intermediateSlack += leg.startTime - compressedLegs[i - 1].endTime; // calculate time spent at each intermediate place
     }
   });
@@ -307,6 +310,7 @@ const SummaryRow = (
           100; // otherwise add the waiting to the current legs length
       }
     }
+
     if (nextLeg?.interlineWithPreviousLeg) {
       interliningWithRoute = nextLeg.route.shortName;
       legLength =

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -290,15 +290,18 @@ const SummaryRow = (
     const longName =
       leg.route && leg.route.shortName && leg.route.shortName.length > 5;
 
-    if (
-      nextLeg &&
-      !nextLeg.intermediatePlace &&
-      !connectsFromViaPoint(nextLeg, intermediatePlaces)
-    ) {
-      // don't show waiting in intermediate places
+    if (nextLeg) {
       waitTime = nextLeg.startTime - leg.endTime;
       waitLength = (waitTime / durationWithoutSlack) * 100;
-      if (waitTime > waitThreshold && waitLength > renderBarThreshold) {
+      // don't show waiting in intermediate places
+      const viaNext =
+        nextLeg.intermediatePlace ||
+        connectsFromViaPoint(nextLeg, intermediatePlaces);
+      if (
+        !viaNext &&
+        waitTime > waitThreshold &&
+        waitLength > renderBarThreshold
+      ) {
         // if waittime is long enough, render a waiting bar
         waiting = true;
       } else {

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -201,6 +201,9 @@ const getViaPointIndex = (leg, intermediatePlaces) => {
   );
 };
 
+const connectsFromViaPoint = (currLeg, intermediatePlaces) =>
+  getViaPointIndex(currLeg, intermediatePlaces) > -1;
+
 const bikeWasParked = legs => {
   const legsLength = legs.length;
   for (let i = 0; i < legsLength; i++) {
@@ -287,7 +290,11 @@ const SummaryRow = (
     const longName =
       leg.route && leg.route.shortName && leg.route.shortName.length > 5;
 
-    if (nextLeg && !nextLeg.intermediatePlace) {
+    if (
+      nextLeg &&
+      !nextLeg.intermediatePlace &&
+      !connectsFromViaPoint(nextLeg, intermediatePlaces)
+    ) {
       // don't show waiting in intermediate places
       waitTime = nextLeg.startTime - leg.endTime;
       waitLength = (waitTime / durationWithoutSlack) * 100;
@@ -444,9 +451,6 @@ const SummaryRow = (
       }
     }
 
-    const connectsFromViaPoint = () =>
-      getViaPointIndex(leg, intermediatePlaces) > -1;
-
     if (leg.route) {
       const withBicycle =
         usingOwnBicycleWholeTrip &&
@@ -454,7 +458,7 @@ const SummaryRow = (
       if (
         previousLeg &&
         !previousLeg.intermediatePlace &&
-        connectsFromViaPoint()
+        connectsFromViaPoint(leg, intermediatePlaces)
       ) {
         legs.push(<ViaLeg key={`via_${leg.mode}_${leg.startTime}`} />);
       }


### PR DESCRIPTION
This fixes a crash when journey after an intermediate stop continues without walking.
In general, it does not make sense to render wait leg unless next leg is a transit leg.
