### PR TITLE
DT-4931: Broken layout in waltti weather info modal

### DIFF
--- a/app/component/weather-details.scss
+++ b/app/component/weather-details.scss
@@ -15,7 +15,7 @@
 
 .weather-details-content {
   background: white;
-  margin: 40px 0;
+  margin: 50px 0;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Proposed Changes

  - Fixed by adding more margin for the modal, so the X button is higher
  - Root cause issue is that the modal X button has 30 px padding on all sides. But since to modal is not from our repo, quickest solution is this  

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
