### PR TITLE
DT-4954 Avoid fetching citybike information from OTP in stops near you map when zoomed out

### DIFF
--- a/app/component/map/tile-layer/CityBikes.js
+++ b/app/component/map/tile-layer/CityBikes.js
@@ -22,8 +22,6 @@ const query = graphql`
     station: bikeRentalStation(id: $id) {
       stationId
       bikesAvailable
-      spacesAvailable
-      capacity
       networks
       state
     }

--- a/app/component/map/tile-layer/CityBikes.js
+++ b/app/component/map/tile-layer/CityBikes.js
@@ -4,7 +4,11 @@ import { graphql, fetchQuery } from 'react-relay';
 import pick from 'lodash/pick';
 
 import { isBrowser } from '../../../util/browser';
-import { getMapIconScale, drawCitybikeIcon } from '../../../util/mapIconUtils';
+import {
+  getMapIconScale,
+  drawCitybikeIcon,
+  getStopIconStyles,
+} from '../../../util/mapIconUtils';
 import { showCitybikeNetwork } from '../../../util/modeUtils';
 
 import {
@@ -76,46 +80,59 @@ class CityBikes {
     });
 
   fetchAndDrawStatus = ({ geom, properties: { id, networks } }) => {
+    if (
+      (this.tile.stopsToShow && !this.tile.stopsToShow.includes(id)) ||
+      !showCitybikeNetwork(this.config.cityBike.networks[networks])
+    ) {
+      return;
+    }
     const lastFetch = timeOfLastFetch[id];
     const currentTime = new Date().getTime();
 
+    const iconName = getCityBikeNetworkIcon(
+      getCityBikeNetworkConfig(getCityBikeNetworkId(networks), this.config),
+    );
+    const citybikeCapacity = getCitybikeCapacity(this.config, networks);
+    const iconColor =
+      iconName.includes('secondary') &&
+      this.config.colors.iconColors['mode-citybike-secondary']
+        ? this.config.colors.iconColors['mode-citybike-secondary']
+        : this.config.colors.iconColors['mode-citybike'];
+
+    const isHilighted = this.tile.hilightedStops?.includes(id);
+
     const callback = ({ station: result }) => {
-      const isHilighted = this.tile.hilightedStops?.includes(result.stationId);
       timeOfLastFetch[id] = new Date().getTime();
       if (result) {
-        const iconName = getCityBikeNetworkIcon(
-          getCityBikeNetworkConfig(
-            getCityBikeNetworkId(result.networks),
-            this.config,
-          ),
+        drawCitybikeIcon(
+          this.tile,
+          geom,
+          result.state,
+          result.bikesAvailable,
+          iconName,
+          citybikeCapacity !== BIKEAVL_UNKNOWN,
+          iconColor,
+          isHilighted,
         );
-        const iconColor =
-          iconName.includes('secondary') &&
-          this.config.colors.iconColors['mode-citybike-secondary']
-            ? this.config.colors.iconColors['mode-citybike-secondary']
-            : this.config.colors.iconColors['mode-citybike'];
-        if (
-          (!this.tile.stopsToShow ||
-            this.tile.stopsToShow.includes(result.stationId)) &&
-          showCitybikeNetwork(this.config.cityBike.networks[result.networks])
-        ) {
-          const citybikeCapacity = getCitybikeCapacity(this.config, networks);
-          drawCitybikeIcon(
-            this.tile,
-            geom,
-            result.state,
-            result.bikesAvailable,
-            iconName,
-            citybikeCapacity !== BIKEAVL_UNKNOWN,
-            iconColor,
-            isHilighted,
-          );
-        }
       }
       return this;
     };
 
-    if (lastFetch && currentTime - lastFetch <= 30000) {
+    const zoom = this.tile.coords.z - 1;
+    // If small icon is shown, enough information is within vector tile
+    // and no need to fetch additional data from routing
+    if (getStopIconStyles('citybike', zoom, isHilighted)?.style === 'small') {
+      drawCitybikeIcon(
+        this.tile,
+        geom,
+        undefined,
+        undefined,
+        iconName,
+        citybikeCapacity !== BIKEAVL_UNKNOWN,
+        iconColor,
+        false,
+      );
+    } else if (lastFetch && currentTime - lastFetch <= 30000) {
       fetchQuery(this.relayEnvironment, query, { id }).then(callback);
     } else {
       fetchQuery(this.relayEnvironment, query, { id }, { force: true }).then(


### PR DESCRIPTION
## Proposed Changes

  - Remove unused fields from citybike relay query
  - Only fetch additional information from relay if vector tiles don't contain enough information to avoid fetching data about hundreds of citybike stations from routing when zoomed out

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
