### PR TITLE
WIP: DT-4988: Stops near you page refetches data when switching tabs

### DIFF
--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -61,7 +61,7 @@ const PH_READY = [PH_USEDEFAULTPOS, PH_USEGEOLOCATION, PH_USEMAPCENTER]; // rend
 
 const DTAutoSuggestWithSearchContext = withSearchContext(DTAutoSuggest);
 
-class StopsNearYouPage extends React.PureComponent {
+class StopsNearYouPage extends React.Component {
   // eslint-disable-line
   static contextTypes = {
     config: PropTypes.object.isRequired,

--- a/app/component/map/StopsNearYouMap.js
+++ b/app/component/map/StopsNearYouMap.js
@@ -146,7 +146,6 @@ function StopsNearYouMap(
     isFetching: false,
     stop: null,
   });
-  // const { mode } = match.params;
   const isTransitMode = mode !== 'CITYBIKE';
   const walkRoutingThreshold =
     mode === 'RAIL' || mode === 'SUBWAY' || mode === 'FERRY' ? 3000 : 1500;

--- a/app/component/map/StopsNearYouMap.js
+++ b/app/component/map/StopsNearYouMap.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { matchShape } from 'found';
 import { graphql, fetchQuery } from 'react-relay';
 import moment from 'moment';
 import uniqBy from 'lodash/uniqBy';
@@ -121,9 +120,9 @@ const getLocationMarker = location => {
 function StopsNearYouMap(
   {
     breakpoint,
+    mode,
     currentTime,
     stopsNearYou,
-    match,
     loading,
     favouriteIds,
     relay,
@@ -147,7 +146,7 @@ function StopsNearYouMap(
     isFetching: false,
     stop: null,
   });
-  const { mode } = match.params;
+  // const { mode } = match.params;
   const isTransitMode = mode !== 'CITYBIKE';
   const walkRoutingThreshold =
     mode === 'RAIL' || mode === 'SUBWAY' || mode === 'FERRY' ? 3000 : 1500;
@@ -436,6 +435,7 @@ function StopsNearYouMap(
 }
 
 StopsNearYouMap.propTypes = {
+  mode: PropTypes.string,
   currentTime: PropTypes.number.isRequired,
   stopsNearYou: PropTypes.object.isRequired,
   prioritizedStopsNearYou: PropTypes.array,
@@ -443,7 +443,6 @@ StopsNearYouMap.propTypes = {
   mapLayers: PropTypes.object.isRequired,
   mapLayerOptions: mapLayerOptionsShape.isRequired,
   position: dtLocationShape.isRequired,
-  match: matchShape.isRequired,
   breakpoint: PropTypes.string.isRequired,
   language: PropTypes.string.isRequired,
   relay: PropTypes.shape({


### PR DESCRIPTION
## Proposed Changes

  - save current tabindex in state and use window.history instead of router.replace

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
