### PR TITLE
#4394: Don't show availbity badge at return station

### DIFF
--- a/app/component/CityBikeLeg.js
+++ b/app/component/CityBikeLeg.js
@@ -69,12 +69,12 @@ function CityBikeLeg(
               width={1.655}
               height={1.655}
               badgeText={
-                citybikeCapacity !== BIKEAVL_UNKNOWN
+                citybikeCapacity !== BIKEAVL_UNKNOWN && !returnBike
                   ? bikeRentalStation.bikesAvailable
                   : null
               }
-              badgeFill={availabilityIndicatorColor}
-              badgeTextFill={availabilityTextColor}
+              badgeFill={returnBike ? null : availabilityIndicatorColor}
+              badgeTextFill={returnBike ? null : availabilityTextColor}
             />
           </div>
           <div className="citybike-itinerary-text-container">

--- a/app/component/map/ItineraryLine.js
+++ b/app/component/map/ItineraryLine.js
@@ -122,7 +122,7 @@ class ItineraryLine extends React.Component {
           objs.push(
             <CityBikeMarker
               key={leg.from.bikeRentalStation.stationId}
-              showBikeAvailability
+              showBikeAvailability={leg.rentedBike}
               station={leg.from.bikeRentalStation}
               transit
             />,


### PR DESCRIPTION
## Proposed Changes
This PR fixes #4394: Citybike availability badge is hidden on return station (on map and CityBikeLeg).

<img width="866" alt="grafik" src="https://user-images.githubusercontent.com/2187389/137460684-07c366ed-d74f-4729-81c4-62a6dff838df.png">

  -

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
