### PR TITLE
DT-5085: Summary with interlined transfer does not expand

### DIFF
--- a/app/component/BusLeg.js
+++ b/app/component/BusLeg.js
@@ -19,10 +19,6 @@ const BusLeg = ({ leg, ...props }) => (
 
 BusLeg.propTypes = {
   leg: PropTypes.object.isRequired,
-  index: PropTypes.number.isRequired,
-  focusAction: PropTypes.func.isRequired,
-  interliningWait: PropTypes.number,
-  nextInterliningLeg: PropTypes.any,
 };
 
 export default BusLeg;

--- a/app/component/InterlineInfo.js
+++ b/app/component/InterlineInfo.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { durationToString } from '../util/timeUtils';
+import { getHeadsignFromRouteLongName } from '../util/legUtils';
+import Icon from './Icon';
+
+const InterlineInfo = ({ legs, leg, wait }) => {
+  return (
+    <div className="interline-info-container">
+      {legs.length === 1 && (
+        <>
+          <Icon img="icon-icon_wait" />
+          <FormattedMessage
+            id="itinerary-summary.interline-wait"
+            values={{
+              shortName: (
+                <span className="bold">{legs[0]?.route.shortName}</span>
+              ),
+              destination: (
+                <span className="bold">
+                  {legs[0]?.trip.tripHeadsign ||
+                    getHeadsignFromRouteLongName(legs[0]?.route)}
+                </span>
+              ),
+              stop: leg.to.name,
+              time: <span className="bold">{durationToString(wait)}</span>,
+            }}
+          />
+        </>
+      )}
+      {legs.length > 1 && (
+        <>
+          <Icon img="icon-icon_wait" />
+          <FormattedMessage id="itinerary-summary.interline-wait-multiple-legs" />
+        </>
+      )}
+    </div>
+  );
+};
+
+InterlineInfo.propTypes = {
+  leg: PropTypes.object,
+  legs: PropTypes.arrayOf(
+    PropTypes.shape({
+      route: PropTypes.shape({
+        shortName: PropTypes.string,
+      }).isRequired,
+      trip: PropTypes.shape({
+        tripHeadsign: PropTypes.string.isRequired,
+      }).isRequired,
+    }),
+  ).isRequired,
+  wait: PropTypes.number,
+};
+export default InterlineInfo;

--- a/app/component/InterlineInfo.js
+++ b/app/component/InterlineInfo.js
@@ -6,6 +6,14 @@ import { getHeadsignFromRouteLongName } from '../util/legUtils';
 import Icon from './Icon';
 
 const InterlineInfo = ({ legs, leg, wait }) => {
+  let totalWait = wait;
+  if (legs.length > 1) {
+    legs.forEach((iLeg, i) => {
+      if (legs[i + 1]) {
+        totalWait += legs[i + 1].startTime - iLeg.endTime;
+      }
+    });
+  }
   return (
     <div className="interline-info-container">
       {legs.length === 1 && (
@@ -24,7 +32,7 @@ const InterlineInfo = ({ legs, leg, wait }) => {
                 </span>
               ),
               stop: leg.to.name,
-              time: <span className="bold">{durationToString(wait)}</span>,
+              time: <span className="bold">{durationToString(totalWait)}</span>,
             }}
           />
         </>
@@ -32,7 +40,12 @@ const InterlineInfo = ({ legs, leg, wait }) => {
       {legs.length > 1 && (
         <>
           <Icon img="icon-icon_wait" />
-          <FormattedMessage id="itinerary-summary.interline-wait-multiple-legs" />
+          <FormattedMessage
+            id="itinerary-summary.interline-wait-multiple-legs"
+            values={{
+              time: <span className="bold">{durationToString(totalWait)}</span>,
+            }}
+          />
         </>
       )}
     </div>
@@ -43,6 +56,7 @@ InterlineInfo.propTypes = {
   leg: PropTypes.object,
   legs: PropTypes.arrayOf(
     PropTypes.shape({
+      startTime: PropTypes.number,
       route: PropTypes.shape({
         shortName: PropTypes.string,
       }).isRequired,

--- a/app/component/ItineraryLegs.js
+++ b/app/component/ItineraryLegs.js
@@ -128,10 +128,19 @@ class ItineraryLegs extends React.Component {
         }
         return undefined;
       };
+      let index = j;
+      const interliningLegs = [];
+      // there can be an arbitrary amount of interlining legs, search for the last one
+      while (
+        compressedLegs[index + 1] &&
+        compressedLegs[index + 1].interlineWithPreviousLeg
+      ) {
+        interliningLegs.push(compressedLegs[index + 1]);
+        index += 1;
+      }
       const isNextLegInterlining = nextLeg
         ? nextLeg.interlineWithPreviousLeg
         : false;
-      const nextInterliningLeg = isNextLegInterlining ? nextLeg : undefined;
       const bikePark = previousLeg?.to.bikePark;
       const fromBikePark = leg?.from.bikePark;
       if (leg.mode !== 'WALK' && isCallAgencyPickupType(leg)) {
@@ -192,7 +201,7 @@ class ItineraryLegs extends React.Component {
             index={j}
             leg={leg}
             interliningWait={interliningWait()}
-            nextInterliningLeg={nextInterliningLeg}
+            interliningLegs={interliningLegs}
             focusAction={this.focus(leg.from)}
           />,
         );
@@ -202,7 +211,7 @@ class ItineraryLegs extends React.Component {
             index={j}
             leg={leg}
             interliningWait={interliningWait()}
-            nextInterliningLeg={nextInterliningLeg}
+            interliningLegs={interliningLegs}
             focusAction={this.focus(leg.from)}
           />,
         );
@@ -212,7 +221,7 @@ class ItineraryLegs extends React.Component {
             index={j}
             leg={leg}
             interliningWait={interliningWait()}
-            nextInterliningLeg={nextInterliningLeg}
+            interliningLegs={interliningLegs}
             focusAction={this.focus(leg.from)}
           />,
         );
@@ -222,7 +231,7 @@ class ItineraryLegs extends React.Component {
             index={j}
             leg={leg}
             interliningWait={interliningWait()}
-            nextInterliningLeg={nextInterliningLeg}
+            interliningLegs={interliningLegs}
             focusAction={this.focus(leg.from)}
           />,
         );
@@ -232,7 +241,7 @@ class ItineraryLegs extends React.Component {
             index={j}
             leg={leg}
             interliningWait={interliningWait()}
-            nextInterliningLeg={nextInterliningLeg}
+            interliningLegs={interliningLegs}
             focusAction={this.focus(leg.from)}
           />,
         );

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -15,6 +15,7 @@ import {
   compressLegs,
   getLegBadgeProps,
   isCallAgencyPickupType,
+  getInterliningLegs,
 } from '../util/legUtils';
 import { dateOrEmpty, isTomorrow } from '../util/timeUtils';
 import withBreakpoint from '../util/withBreakpoint';
@@ -269,7 +270,6 @@ const SummaryRow = (
   let showRentalBikeDurationWarning = false;
   const citybikeNetworks = new Set();
   let citybikeicon;
-
   compressedLegs.forEach((leg, i) => {
     let interliningWithRoute;
     let renderBar = true;
@@ -305,10 +305,18 @@ const SummaryRow = (
       }
     }
 
-    if (nextLeg?.interlineWithPreviousLeg) {
-      interliningWithRoute = nextLeg.route.shortName;
+    const [interliningLines, interliningLegs] = getInterliningLegs(
+      compressedLegs,
+      i,
+    );
+
+    const lastLegWithInterline = interliningLegs[interliningLegs.length - 1];
+    if (lastLegWithInterline) {
+      interliningWithRoute = interliningLines.join(' / ');
       legLength =
-        ((nextLeg.endTime - leg.startTime) / durationWithoutSlack) * 100;
+        ((lastLegWithInterline.endTime - leg.startTime) /
+          durationWithoutSlack) *
+        100;
     }
     legLength += addition;
     addition = 0;

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -131,7 +131,7 @@ class TransitLeg extends React.Component {
         const nextZoneId =
           (array[i + 1] && array[i + 1].stop.zoneId) ||
           (isLastPlace &&
-            interliningLegs[interliningLegs.length - 1].to.stop.zoneId) ||
+            interliningLegs[interliningLegs.length - 1]?.to.stop.zoneId) ||
           leg.to.stop.zoneId;
         const previousZoneIdDiffers =
           previousZoneId && previousZoneId !== currentZoneId;

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -32,6 +32,7 @@ import { shouldShowFareInfo } from '../util/fareUtils';
 import { AlertSeverityLevelType } from '../constants';
 import ZoneIcon from './ZoneIcon';
 import StopInfo from './StopInfo';
+import InterlineInfo from './InterlineInfo';
 
 class TransitLeg extends React.Component {
   constructor(props) {
@@ -59,9 +60,9 @@ class TransitLeg extends React.Component {
   };
 
   getZoneChange() {
-    const { leg, nextInterliningLeg } = this.props;
+    const { leg } = this.props;
     const startZone = leg.from.stop.zoneId;
-    const endZone = nextInterliningLeg?.to?.stop.zoneId || leg.to.stop.zoneId;
+    const endZone = leg.to?.stop.zoneId || leg.to.stop.zoneId;
     if (
       startZone !== endZone &&
       !this.state.showIntermediateStops &&
@@ -102,17 +103,21 @@ class TransitLeg extends React.Component {
   }
 
   renderIntermediate() {
-    const { leg, mode, nextInterliningLeg } = this.props;
+    const { leg, mode, interliningLegs } = this.props;
     if (
       leg.intermediatePlaces.length > 0 &&
       this.state.showIntermediateStops === true
     ) {
       const places = leg.intermediatePlaces.slice();
-      if (this.props.nextInterliningLeg) {
-        places.push(
-          { ...leg.to, arrivalTime: leg.endTime },
-          ...this.props.nextInterliningLeg.intermediatePlaces,
-        );
+      if (interliningLegs) {
+        let previousLeg = leg;
+        interliningLegs.forEach(iLeg => {
+          places.push(
+            { ...previousLeg.to, arrivalTime: previousLeg.endTime },
+            ...iLeg.intermediatePlaces,
+          );
+          previousLeg = iLeg;
+        });
       }
       const stopList = places.map((place, i, array) => {
         const isFirstPlace = i === 0;
@@ -125,7 +130,8 @@ class TransitLeg extends React.Component {
         const currentZoneId = place.stop.zoneId;
         const nextZoneId =
           (array[i + 1] && array[i + 1].stop.zoneId) ||
-          (isLastPlace && nextInterliningLeg?.to?.stop.zoneId) ||
+          (isLastPlace &&
+            interliningLegs[interliningLegs.length - 1].to.stop.zoneId) ||
           leg.to.stop.zoneId;
         const previousZoneIdDiffers =
           previousZoneId && previousZoneId !== currentZoneId;
@@ -182,8 +188,9 @@ class TransitLeg extends React.Component {
       leg,
       mode,
       lang,
-      nextInterliningLeg,
       omitDivider,
+      interliningWait,
+      interliningLegs,
     } = this.props;
     const { config, intl } = this.context;
     const originalTime = leg.realTime &&
@@ -274,9 +281,11 @@ class TransitLeg extends React.Component {
       leg.trip.tripHeadsign || getHeadsignFromRouteLongName(leg.route);
 
     let intermediateStopCount = leg.intermediatePlaces.length;
-    if (this.props.nextInterliningLeg) {
-      intermediateStopCount +=
-        this.props.nextInterliningLeg.intermediatePlaces.length + 1;
+    if (interliningLegs) {
+      intermediateStopCount = interliningLegs.reduce(
+        (prev, curr) => prev + curr.intermediatePlaces.length + 1,
+        leg.intermediatePlaces.length,
+      );
     }
 
     const routeNotifications = [];
@@ -485,32 +494,12 @@ class TransitLeg extends React.Component {
               </div>
             </div>
           )}
-          {nextInterliningLeg ? (
-            <div className="interline-info-container">
-              <Icon img="icon-icon_wait" />
-              <FormattedMessage
-                id="itinerary-summary.interline-wait"
-                values={{
-                  shortName: (
-                    <span className="bold">
-                      {nextInterliningLeg.route.shortName}
-                    </span>
-                  ),
-                  destination: (
-                    <span className="bold">
-                      {nextInterliningLeg.trip.tripHeadsign ||
-                        getHeadsignFromRouteLongName(nextInterliningLeg.route)}
-                    </span>
-                  ),
-                  stop: leg.to.name,
-                  time: (
-                    <span className="bold">
-                      {durationToString(this.props.interliningWait)}
-                    </span>
-                  ),
-                }}
-              />
-            </div>
+          {interliningLegs?.length > 0 ? (
+            <InterlineInfo
+              legs={interliningLegs}
+              leg={leg}
+              wait={interliningWait}
+            />
           ) : (
             !omitDivider &&
             routeNotifications.length === 0 && <div className="divider" />
@@ -524,8 +513,9 @@ class TransitLeg extends React.Component {
                 leg={leg}
                 intermediateStopCount={intermediateStopCount}
                 duration={
-                  this.props.nextInterliningLeg
-                    ? this.props.nextInterliningLeg.endTime - leg.startTime
+                  interliningLegs.length > 0
+                    ? interliningLegs[interliningLegs.length - 1].endTime -
+                      leg.startTime
                     : leg.duration * 1000
                 }
                 showIntermediateStops={this.state.showIntermediateStops}
@@ -633,31 +623,33 @@ TransitLeg.propTypes = {
     ).isRequired,
     interlineWithPreviousLeg: PropTypes.bool.isRequired,
   }).isRequired,
-  nextInterliningLeg: PropTypes.shape({
-    intermediatePlaces: PropTypes.arrayOf(
-      PropTypes.shape({
-        arrivalTime: PropTypes.number.isRequired,
+  interliningLegs: PropTypes.arrayOf(
+    PropTypes.shape({
+      intermediatePlaces: PropTypes.arrayOf(
+        PropTypes.shape({
+          arrivalTime: PropTypes.number.isRequired,
+          stop: PropTypes.shape({
+            gtfsId: PropTypes.string.isRequired,
+            code: PropTypes.string,
+            platformCode: PropTypes.string,
+            zoneId: PropTypes.string,
+          }).isRequired,
+        }),
+      ).isRequired,
+      route: PropTypes.shape({
+        shortName: PropTypes.string,
+      }).isRequired,
+      trip: PropTypes.shape({
+        tripHeadsign: PropTypes.string.isRequired,
+      }).isRequired,
+      endTime: PropTypes.number.isRequired,
+      to: PropTypes.shape({
         stop: PropTypes.shape({
-          gtfsId: PropTypes.string.isRequired,
-          code: PropTypes.string,
-          platformCode: PropTypes.string,
           zoneId: PropTypes.string,
         }).isRequired,
-      }),
-    ).isRequired,
-    route: PropTypes.shape({
-      shortName: PropTypes.string,
-    }).isRequired,
-    trip: PropTypes.shape({
-      tripHeadsign: PropTypes.string.isRequired,
-    }).isRequired,
-    endTime: PropTypes.number.isRequired,
-    to: PropTypes.shape({
-      stop: PropTypes.shape({
-        zoneId: PropTypes.string,
       }).isRequired,
-    }).isRequired,
-  }),
+    }),
+  ),
   index: PropTypes.number.isRequired,
   mode: PropTypes.string.isRequired,
   interliningWait: PropTypes.number,

--- a/app/component/map/ItineraryLine.js
+++ b/app/component/map/ItineraryLine.js
@@ -12,7 +12,11 @@ import Icon from '../Icon';
 import CityBikeMarker from './non-tile-layer/CityBikeMarker';
 import { getMiddleOf } from '../../util/geo-utils';
 import { isBrowser } from '../../util/browser';
-import { isCallAgencyPickupType, getLegText } from '../../util/legUtils';
+import {
+  isCallAgencyPickupType,
+  getLegText,
+  getInterliningLegs,
+} from '../../util/legUtils';
 import IconMarker from './IconMarker';
 import SpeechBubble from './SpeechBubble';
 import { durationToString } from '../../util/timeUtils';
@@ -55,8 +59,13 @@ class ItineraryLine extends React.Component {
       const nextLeg = this.props.legs[i + 1];
 
       let { mode } = leg;
-      const interliningWithRoute =
-        nextLeg?.interlineWithPreviousLeg && nextLeg.route.shortName;
+
+      const [interliningLines, interliningLegs] = getInterliningLegs(
+        this.props.legs,
+        i,
+      );
+
+      const interliningWithRoute = interliningLines.join(' / ');
 
       if (leg.rentedBike && leg.mode !== 'WALK') {
         mode = 'CITYBIKE';
@@ -68,11 +77,13 @@ class ItineraryLine extends React.Component {
       const geometry = polyUtil.decode(leg.legGeometry.points);
       let middle = getMiddleOf(geometry);
 
-      if (nextLeg?.interlineWithPreviousLeg) {
-        const interlinedGeometry = [
-          ...geometry,
-          ...polyUtil.decode(nextLeg.legGeometry.points),
-        ];
+      if (interliningLegs.length > 0) {
+        // merge the geometries of legs where user can wait in the vehicle and find the middle point
+        // of the new geometry
+        const points = interliningLegs
+          .map(iLeg => polyUtil.decode(iLeg.legGeometry.points))
+          .flat();
+        const interlinedGeometry = [...geometry, ...points];
         middle = getMiddleOf(interlinedGeometry);
       }
 

--- a/app/translations.js
+++ b/app/translations.js
@@ -1110,6 +1110,8 @@ const translations = {
     'itinerary-summary.bikePark-title': 'Leave your bike at a Park & Ride',
     'itinerary-summary.interline-wait':
       'The route number ({shortName}) and destination ({destination}) will change at the {stop} stop. Waiting time at the stop is {time}. Please wait onboard.',
+    'itinerary-summary.interline-wait-multiple-legs':
+      'The route number and destination will change multiple times during the journey. Please wait onboard.',
     'itinerary-summary.show-on-map': 'Show on map {target}',
     'itinerary-ticket.title': 'Required ticket',
     'itinerary-tickets.title': 'Required tickets',
@@ -2113,6 +2115,8 @@ const translations = {
     'itinerary-summary.bikePark-title': 'Jätä pyöräsi liityntäpysäköintiin',
     'itinerary-summary.interline-wait':
       'Linjatunnus ({shortName}) ja määränpää ({destination}) vaihtuvat pysäkillä {stop}. Matka jatkuu {time} odotuksen jälkeen. Odota kulkuneuvossa.',
+    'itinerary-summary.interline-wait-multiple-legs':
+      'Linjatunnus ja määränpää vaihtuvat useita kertoja matkan aikana. Odota ajoneuvossa.',
     'itinerary-summary.show-on-map': 'Näytä kartalla {target}',
     'itinerary-ticket.title': 'Reitillä tarvittava lippu',
     'itinerary-tickets.title': 'Reitillä tarvittavat liput',
@@ -3900,6 +3904,8 @@ const translations = {
       'Lämna din cykel till anslutningsparkeringen',
     'itinerary-summary.interline-wait':
       'Linjenumret ({shortName}) och destinationen ({destination}) ändras vid hållplats {stop}. Resan fortsätter om {time}. Vänta ombord på bussen.',
+    'itinerary-summary.interline-wait-multiple-legs':
+      'Linjatunnus ja määränpää vaihtuvat useita kertoja matkan aikana. Odota ajoneuvossa.',
     'itinerary-summary.show-on-map': 'Visa på kartan {target}',
     'itinerary-ticket.title': 'Biljett som behövs',
     'itinerary-tickets.title': 'Biljetter som behövs',

--- a/app/translations.js
+++ b/app/translations.js
@@ -1111,7 +1111,7 @@ const translations = {
     'itinerary-summary.interline-wait':
       'The route number ({shortName}) and destination ({destination}) will change at the {stop} stop. Waiting time at the stop is {time}. Please wait onboard.',
     'itinerary-summary.interline-wait-multiple-legs':
-      'The route number and destination will change multiple times during the journey. Please wait onboard.',
+      'The route number and destination will change multiple times during the journey. Total waiting time during the journey is {time}. Please wait onboard.',
     'itinerary-summary.show-on-map': 'Show on map {target}',
     'itinerary-ticket.title': 'Required ticket',
     'itinerary-tickets.title': 'Required tickets',
@@ -2116,7 +2116,7 @@ const translations = {
     'itinerary-summary.interline-wait':
       'Linjatunnus ({shortName}) ja määränpää ({destination}) vaihtuvat pysäkillä {stop}. Matka jatkuu {time} odotuksen jälkeen. Odota kulkuneuvossa.',
     'itinerary-summary.interline-wait-multiple-legs':
-      'Linjatunnus ja määränpää vaihtuvat useita kertoja matkan aikana. Odota ajoneuvossa.',
+      'Linjatunnus ja määränpää vaihtuvat useita kertoja matkan aikana. Odotusta yhteensä {time}. Odota ajoneuvossa.',
     'itinerary-summary.show-on-map': 'Näytä kartalla {target}',
     'itinerary-ticket.title': 'Reitillä tarvittava lippu',
     'itinerary-tickets.title': 'Reitillä tarvittavat liput',

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -124,6 +124,26 @@ export const getLegText = (route, config, interliningWithRoute) => {
   return '';
 };
 
+/**
+ * Returns all legs after a given index in which the user can wait in the vehilce for the next transit leg
+ * to start.
+ * @param {*} legs An array of itinerary legs
+ * @param {*} index Current index on the array
+ */
+export const getInterliningLegs = (legs, index) => {
+  const interliningLegs = [];
+  const interliningLines = [];
+  let i = index;
+  while (legs[i + 1] && legs[i + 1].interlineWithPreviousLeg) {
+    interliningLegs.push(legs[i + 1]);
+    interliningLines.push(legs[i + 1].route.shortName);
+    i += 1;
+  }
+  const uniqueLines = Array.from(new Set(interliningLines));
+
+  return [uniqueLines, interliningLegs];
+};
+
 const bikingEnded = leg1 => {
   return leg1.from.bikeRentalStation && leg1.mode === 'WALK';
 };

--- a/test/unit/component/TransitLeg.test.js
+++ b/test/unit/component/TransitLeg.test.js
@@ -15,6 +15,7 @@ import { mockContext } from '../helpers/mock-context';
 
 const defaultProps = {
   children: <div />,
+  interliningLegs: [],
   focusAction: () => {},
   index: 0,
   lang: 'fi',


### PR DESCRIPTION
## Proposed Changes

  - The ui now allows for an arbitrary amount of legs after one another where the user can stay on the same vehicle while the vehicle changes its headsign and/or destination.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
