### PR TITLE
DT-5045: various ios accessibility fixes to autosuggest

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "1.3.29",
+  "version": "1.3.30",
   "description": "digitransit-component autosuggest-panel module",
   "main": "lib/index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.7.21",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.7.22",
     "@digitransit-component/digitransit-component-icon": "^0.1.13",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.2.6",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.7.21",
+  "version": "1.7.22",
   "description": "digitransit-component autosuggest module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/helpers/MobileSearch.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/helpers/MobileSearch.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import PropTypes from 'prop-types';
 import React, { useState, useEffect, useCallback } from 'react';
 import cx from 'classnames';
@@ -69,6 +67,18 @@ const MobileSearch = ({
     }
   };
 
+  const isKeyboardSelectionEvent = event => {
+    const space = [13, ' ', 'Spacebar'];
+    const enter = [32, 'Enter'];
+    const key = (event && (event.key || event.which || event.keyCode)) || '';
+
+    if (!key || !space.concat(enter).includes(key)) {
+      return false;
+    }
+    event.preventDefault();
+    return true;
+  };
+
   const getValue = suggestion => {
     if (suggestion.type === 'clear-search-history') {
       return '';
@@ -112,6 +122,7 @@ const MobileSearch = ({
         type="button"
         className={styles['clear-input']}
         onClick={clearInput}
+        onKeyDown={e => isKeyboardSelectionEvent(e) && clearInput()}
         aria-label={clearInputButtonText}
       >
         <Icon img="close" color={color} />
@@ -121,10 +132,17 @@ const MobileSearch = ({
 
   const renderContent = () => {
     return (
-      <label className={styles['combobox-container']} htmlFor={inputId}>
-        <div className={styles['combobox-icon']} onClick={onClose}>
+      <div className={styles['combobox-container']} htmlFor={inputId}>
+        <button
+          type="button"
+          className={styles['combobox-icon']}
+          onClick={() => onClose()}
+          onKeyDown={e => isKeyboardSelectionEvent(e) && onClose()}
+          aria-label={dialogSecondaryButtonText}
+          tabIndex={0}
+        >
           <Icon img="arrow" />
-        </div>
+        </button>
         <span className={styles['right-column']}>
           <span className={styles['combobox-label']} id={labelId}>
             {label}
@@ -166,7 +184,7 @@ const MobileSearch = ({
             ref={inputRef}
           />
         </span>
-      </label>
+      </div>
     );
   };
   if (focusInput && inputRef.current?.input) {

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/helpers/translations.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/helpers/translations.js
@@ -43,8 +43,9 @@ const translations = {
     'search-origin': 'Suche Startort, Linie oder Haltestelle',
     'search-origin-index': 'Startort eingeben',
     'search-position': 'Standort ermitteln',
-    'search-autosuggest-label':
+    'search-autosuggest-label-desktop':
       'Venue, place and stopsearch. Navigate list with arrow keys and select with enter key',
+    'search-autosuggest-label-mobile': 'Venue, place and stopsearch.',
     'search-autosuggest-len': 'There is {{count}} suggestion available',
     'search-autosuggest-len_plural':
       'There are {{count}} suggestions available',
@@ -114,8 +115,10 @@ const translations = {
     'search-origin': 'Search origin, route or stop',
     'search-origin-index': 'Enter origin',
     'search-position': 'Detect location',
-    'search-autosuggest-label':
+    'search-autosuggest-label-desktop':
       'Venue, place and stopsearch. Navigate list with arrow keys and select with enter key',
+    'search-autosuggest-label-mobile':
+      'Venue, place and stopsearch. Enter the location and navigate in the list by swiping.',
     'search-autosuggest-len': 'There is {{count}} suggestion available',
     'search-autosuggest-len_plural':
       'There are {{count}} suggestions available',
@@ -187,8 +190,10 @@ const translations = {
     'search-no-results': 'Ei tuloksia',
     'search-origin': 'Hae lähtöpaikkaa, linjaa tai pysäkkiä',
     'search-origin-index': 'Syötä lähtöpaikka',
-    'search-autosuggest-label':
+    'search-autosuggest-label-desktop':
       'Paikka, linja ja pysäkkihaku. Navigoi listassa nuolinäppäimillä ja valitse enterillä',
+    'search-autosuggest-label-mobile':
+      'Paikka, linja ja pysäkkihaku. Syötä sijainti ja navigoi listassa pyyhkäisemällä.',
     'search-autosuggest-len': ' Löydettiin {{count}} ehdotus',
     'search-autosuggest-len_plural': ' Löydettiin {{count}} ehdotusta',
     'search-current-suggestion': 'Tämänhetkinen valinta: {{selection}}',
@@ -261,8 +266,10 @@ const translations = {
     'search-origin': 'Sök avfärdsplats, linje eller hållplats',
     'search-origin-index': 'Skriv avfärdsplats',
     'search-position': 'Sök position',
-    'search-autosuggest-label':
+    'search-autosuggest-label-desktop':
       'Plats, linje och hållplatssökning. Navigera listan med piltangenterna och välj med Enter-tangeten',
+    'search-autosuggest-label-mobile':
+      'Plats, linje och hållplatssökning. Ange platsen och navigera i listan genom att svepa.',
     'search-autosuggest-len': 'Hittade {{count}} förslag',
     'search-current-suggestion': 'Nuvarande val: {{selection}}',
     subway: 'Metro',


### PR DESCRIPTION
## Proposed Changes

  - back arrow now works in mobile autosuggest dialog meaning screen reader user can exit without selecting a location
  - clear input "x" button is now described to screen reader
  - currently chosen value is now read to ios voiceover without opening the dialog
  - different SR navigation instruction for mobile and desktop
  - autosuggest dialog does not open only from focus on mobile meaning desktop users can navigate the mobile version of the site with keyboard navigation. For normal users, the dialog opens as before

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
