### PR TITLE
DT-5258: Production built UI doesn't allow to navigate to route page timetables directly

### DIFF
--- a/app/component/RouteScheduleContainer.js
+++ b/app/component/RouteScheduleContainer.js
@@ -716,11 +716,11 @@ class RouteScheduleContainer extends PureComponent {
 
   render() {
     const { query } = this.props.match.location;
-    const { intl, config } = this.context;
+    const { intl } = this.context;
     this.hasMergedData = false;
     this.dataExistsDay = 1; // 1 = monday
     // USE FOR TESTING PURPOSE
-    this.testing = config.ROUTEPAGETESTING || false;
+    this.testing = process.env.ROUTEPAGETESTING || false;
     this.testNum = this.testing && query && query.test;
     this.testNoDataDay = ''; // set to next week's Thursday
 

--- a/app/component/RouteScheduleContainer.js
+++ b/app/component/RouteScheduleContainer.js
@@ -25,7 +25,7 @@ import RoutePageControlPanel from './RoutePageControlPanel';
 import { PREFIX_ROUTES, PREFIX_TIMETABLE } from '../util/path';
 import { isBrowser } from '../util/browser';
 import ScrollableWrapper from './ScrollableWrapper';
-import getTestData from '../../test/unit/test-data/RouteScheduleTestData';
+import getTestData from './RouteScheduleDebugData';
 
 const DATE_FORMAT2 = 'D.M.YYYY';
 
@@ -716,11 +716,11 @@ class RouteScheduleContainer extends PureComponent {
 
   render() {
     const { query } = this.props.match.location;
-    const { intl } = this.context;
+    const { intl, config } = this.context;
     this.hasMergedData = false;
     this.dataExistsDay = 1; // 1 = monday
     // USE FOR TESTING PURPOSE
-    this.testing = false;
+    this.testing = config.ROUTEPAGETESTING || false;
     this.testNum = this.testing && query && query.test;
     this.testNoDataDay = ''; // set to next week's Thursday
 

--- a/app/component/RouteScheduleDebugData.js
+++ b/app/component/RouteScheduleDebugData.js
@@ -31,6 +31,7 @@
  */
 
 const data1 = {
+  info: 'test #1',
   wk1mon: [],
   wk1tue: [],
   wk1wed: [
@@ -138,6 +139,7 @@ const data1 = {
 };
 
 const data2 = {
+  info: 'test #0 or #2',
   wk1mon: [],
   wk1tue: [
     { departureStoptime: { scheduledDeparture: 54540 } },
@@ -245,6 +247,7 @@ const data2 = {
 };
 
 const data3 = {
+  info: 'test #3',
   wk1mon: [],
   wk1tue: [
     { departureStoptime: { scheduledDeparture: 54540 } },
@@ -367,6 +370,7 @@ const data3 = {
 };
 
 const data4 = {
+  info: 'test #4',
   wk1mon: [],
   wk1tue: [],
   wk1wed: [

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -755,6 +755,4 @@ export default {
 
   prioritizedStopsNearYou: {},
   routeNotifications: [],
-
-  ROUTEPAGETESTING: process.env.ROUTEPAGETESTING || false,
 };

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -755,4 +755,6 @@ export default {
 
   prioritizedStopsNearYou: {},
   routeNotifications: [],
+
+  ROUTEPAGETESTING: process.env.ROUTEPAGETESTING || false,
 };


### PR DESCRIPTION
## Proposed Changes

  - new process.env-variable (ROUTEPAGETESTING)
  - move test data from test-folder to component-folder

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
