### PR TITLE
fix: nvda reading messagebar alerts multiple times on firefox

### DIFF
--- a/app/component/MessageBar.js
+++ b/app/component/MessageBar.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { intlShape } from 'react-intl';
 import { graphql, fetchQuery, ReactRelayContext } from 'react-relay';
-import { v4 as uuid } from 'uuid';
 
 import SwipeableTabs from './SwipeableTabs';
 import Icon from './Icon';
@@ -185,11 +184,11 @@ class MessageBar extends Component {
     }
   };
 
-  ariaContent = content => {
+  ariaContent = (content, id) => {
     return (
-      <span key={uuid()}>
+      <span key={`message-${id}`}>
         {content.map(e => (
-          <span key={uuid()}>{e.content}</span>
+          <span key={`message-content-${id}-${e.type}`}>{e.content}</span>
         ))}
       </span>
     );
@@ -271,14 +270,16 @@ class MessageBar extends Component {
     return (
       <>
         <span className="sr-only" role="alert">
-          {this.validMessages().map(el =>
-            this.ariaContent(el.content[this.props.lang] || el.content.fi),
+          {messages.map(el =>
+            this.ariaContent(
+              el.content[this.props.lang] || el.content.fi,
+              el.id,
+            ),
           )}
         </span>
         <section
           key={this.props.duplicateMessageCounter}
           id="messageBar"
-          role="banner"
           className="message-bar flex-horizontal"
           style={{ background: backgroundColor }}
         >


### PR DESCRIPTION
## Proposed Changes

  - The uuid keys changed on every render resulting in screen reader believing the content had changed

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
