### PR TITLE
DT-3734: fix autosuggest safari voiceover alerts

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "1.3.43",
+  "version": "1.3.44",
   "description": "digitransit-component autosuggest-panel module",
   "main": "lib/index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.7.36",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.7.37",
     "@digitransit-component/digitransit-component-icon": "^0.1.15",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.2.6",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.7.36",
+  "version": "1.7.37",
   "description": "digitransit-component autosuggest module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -920,19 +920,9 @@ class DTAutosuggest extends React.Component {
 
     return (
       <React.Fragment>
-        <span
-          className={styles['sr-only']}
-          role={this.state.typing ? undefined : 'alert'}
-          aria-hidden={!this.state.editing}
-        >
-          {ariaSuggestionLen}
-        </span>
-        <span
-          className={styles['sr-only']}
-          role={this.state.typing ? undefined : 'alert'}
-          aria-hidden={!this.state.editing || suggestions.length === 0}
-        >
-          {ariaCurrentSuggestion()}
+        <span className={styles['sr-only']} role="alert">
+          {!this.state.typing &&
+            `${ariaSuggestionLen} ${ariaCurrentSuggestion()}`}
         </span>
         {this.props.isMobile && (
           <MobileSearch

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -922,6 +922,7 @@ class DTAutosuggest extends React.Component {
       <React.Fragment>
         <span className={styles['sr-only']} role="alert">
           {!this.state.typing &&
+            this.state.editing &&
             `${ariaSuggestionLen} ${ariaCurrentSuggestion()}`}
         </span>
         {this.props.isMobile && (

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -14,8 +14,8 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.7.36",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^1.3.43",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.7.37",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^1.3.44",
     "@digitransit-component/digitransit-component-control-panel": "^1.0.0",
     "@digitransit-component/digitransit-component-favourite-bar": "1.0.9",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^0.3.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,11 +2155,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@^1.3.43, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@^1.3.44, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^1.7.36
+    "@digitransit-component/digitransit-component-autosuggest": ^1.7.37
     "@digitransit-component/digitransit-component-icon": ^0.1.15
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.2.6
@@ -2175,7 +2175,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@^1.7.36, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@^1.7.37, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
@@ -2348,8 +2348,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^1.7.36
-    "@digitransit-component/digitransit-component-autosuggest-panel": ^1.3.43
+    "@digitransit-component/digitransit-component-autosuggest": ^1.7.37
+    "@digitransit-component/digitransit-component-autosuggest-panel": ^1.3.44
     "@digitransit-component/digitransit-component-control-panel": ^1.0.0
     "@digitransit-component/digitransit-component-favourite-bar": 1.0.9
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^0.3.14


### PR DESCRIPTION
## Proposed Changes

  - fix autosuggest safari VoiceOver alerts by only having one alert. Multiple alerts might override each other

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
