### PR TITLE
fix: enable centering the map  more to the east

### DIFF
--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -448,8 +448,8 @@ export default {
     // areBounds is for keeping map and user inside given area
     // HSL region + Lahti
     areaBounds: {
-      corner1: [61.21, 26.73],
-      corner2: [59.69, 23.69],
+      corner1: [62, 27],
+      corner2: [59, 22],
     },
   },
 

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -448,7 +448,7 @@ export default {
     // areBounds is for keeping map and user inside given area
     // HSL region + Lahti
     areaBounds: {
-      corner1: [61.21, 25.73],
+      corner1: [61.21, 26.73],
       corner2: [59.69, 23.69],
     },
   },


### PR DESCRIPTION
## Proposed Changes

  -Change the area bounds for the front page map so that it can be centered on a more eastern location

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
