### PR TITLE
DT-5633 : Use long name of route when short name is unavailable

### DIFF
--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -70,6 +70,8 @@ class RoutePage extends React.Component {
       return null;
     }
     const mode = getRouteMode(route);
+    const label = route.shortName ? route.shortName : route.longName || '';
+
     return (
       <div className={cx('route-page-container')}>
         <div className="header-for-printing">
@@ -109,18 +111,21 @@ class RoutePage extends React.Component {
                     id: mode.toLowerCase(),
                   })}{' '}
                 </span>
-                {route.shortName === '' || route.shortName === null
-                  ? route.longName
-                  : route.shortName}
+                {label}
               </h1>
-              {tripId && route.patterns[1]?.headsign && (
-                <div className="trip-destination">
-                  <Icon className="in-text-arrow" img="icon-icon_arrow-right" />
-                  <div className="destination-headsign">
-                    {route.patterns[1].headsign}
+              {tripId &&
+                route.patterns[1]?.headsign &&
+                !label.includes(route.patterns[1].headsign) && (
+                  <div className="trip-destination">
+                    <Icon
+                      className="in-text-arrow"
+                      img="icon-icon_arrow-right"
+                    />
+                    <div className="destination-headsign">
+                      {route.patterns[1].headsign}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
             </div>
             {!tripId && (
               <LazilyLoad modules={modules}>

--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -109,7 +109,9 @@ class RoutePage extends React.Component {
                     id: mode.toLowerCase(),
                   })}{' '}
                 </span>
-                {route.shortName}
+                {route.shortName === '' || route.shortName === null
+                  ? route.shortName
+                  : route.longName}
               </h1>
               {tripId && route.patterns[1]?.headsign && (
                 <div className="trip-destination">

--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -110,8 +110,8 @@ class RoutePage extends React.Component {
                   })}{' '}
                 </span>
                 {route.shortName === '' || route.shortName === null
-                  ? route.shortName
-                  : route.longName}
+                  ? route.longName
+                  : route.shortName}
               </h1>
               {tripId && route.patterns[1]?.headsign && (
                 <div className="trip-destination">

--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -4,6 +4,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { FormattedMessage, intlShape } from 'react-intl';
 import cx from 'classnames';
 import { matchShape, routerShape, RedirectException } from 'found';
+import Icon from './Icon';
 
 import Loading from './Loading';
 import RouteAgencyInfo from './RouteAgencyInfo';
@@ -112,6 +113,14 @@ class RoutePage extends React.Component {
                   ? route.longName
                   : route.shortName}
               </h1>
+              {tripId && route.patterns[1]?.headsign && (
+                <div className="trip-destination">
+                  <Icon className="in-text-arrow" img="icon-icon_arrow-right" />
+                  <div className="destination-headsign">
+                    {route.patterns[1].headsign}
+                  </div>
+                </div>
+              )}
             </div>
             {!tripId && (
               <LazilyLoad modules={modules}>

--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -4,7 +4,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { FormattedMessage, intlShape } from 'react-intl';
 import cx from 'classnames';
 import { matchShape, routerShape, RedirectException } from 'found';
-import Icon from './Icon';
 
 import Loading from './Loading';
 import RouteAgencyInfo from './RouteAgencyInfo';
@@ -113,14 +112,6 @@ class RoutePage extends React.Component {
                   ? route.longName
                   : route.shortName}
               </h1>
-              {tripId && route.patterns[1]?.headsign && (
-                <div className="trip-destination">
-                  <Icon className="in-text-arrow" img="icon-icon_arrow-right" />
-                  <div className="destination-headsign">
-                    {route.patterns[1].headsign}
-                  </div>
-                </div>
-              )}
             </div>
             {!tripId && (
               <LazilyLoad modules={modules}>


### PR DESCRIPTION
## Proposed Changes

  - Use  the long name of a route in a route page if the short name is unavailable

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
