### PR TITLE
chore: add city labels for alerts in walttiOpas

### DIFF
--- a/app/configurations/config.walttiOpas.js
+++ b/app/configurations/config.walttiOpas.js
@@ -139,4 +139,22 @@ export default configMerger(walttiConfig, {
   viaPointsEnabled: false,
   showVehiclesOnStopPage: true,
   showVehiclesOnSummaryPage: true,
+
+  sourceForAlertsAndDisruptions: {
+    Kotka: {
+      fi: 'Kotkan seutu',
+      sv: 'Kotkaregion',
+      en: 'Kotka region',
+    },
+    Kouvola: {
+      fi: 'Kouvola',
+      sv: 'Kouvola',
+      en: 'Kouvola',
+    },
+    Salo: {
+      fi: 'Salo',
+      sv: 'Salo',
+      en: 'Salo',
+    },
+  },
 });


### PR DESCRIPTION
## Proposed Changes

  - Change walttiOpas config so that alerts will get city labels

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
