### PR TITLE
hide sorting arrows without exploding hslfi layout

### DIFF
--- a/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-editing-modal",
-  "version": "0.3.16",
+  "version": "1.0.0",
   "description": "digitransit-component favourite-editing-modal module",
   "main": "lib/index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-favourite-editing-modal/src/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-favourite-editing-modal/src/helpers/styles.scss
@@ -41,14 +41,14 @@
         align-items: center;
 
         .favourite-edit-list-arrow-hidden {
-          left: -999px;
-          position: absolute;
           z-index: -999;
+          opacity: 0;
+          width: 0;
         }
         .favourite-edit-list-arrow-hidden:focus {
           font-weight: bold;
-          left: 0;
           z-index: 10;
+          opacity: 1;
         }
 
         .favourite-edit-list-item-drag {

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -18,7 +18,7 @@
     "@digitransit-component/digitransit-component-autosuggest-panel": "^1.4.6",
     "@digitransit-component/digitransit-component-control-panel": "^1.0.2",
     "@digitransit-component/digitransit-component-favourite-bar": "1.0.12",
-    "@digitransit-component/digitransit-component-favourite-editing-modal": "^0.3.16",
+    "@digitransit-component/digitransit-component-favourite-editing-modal": "^1.0.0",
     "@digitransit-component/digitransit-component-favourite-modal": "^0.3.17",
     "@digitransit-component/digitransit-component-icon": "^0.1.16",
     "@digitransit-component/digitransit-component-suggestion-item": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2263,7 +2263,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-favourite-editing-modal@^0.3.16, @digitransit-component/digitransit-component-favourite-editing-modal@workspace:digitransit-component/packages/digitransit-component-favourite-editing-modal":
+"@digitransit-component/digitransit-component-favourite-editing-modal@^1.0.0, @digitransit-component/digitransit-component-favourite-editing-modal@workspace:digitransit-component/packages/digitransit-component-favourite-editing-modal":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-favourite-editing-modal@workspace:digitransit-component/packages/digitransit-component-favourite-editing-modal"
   peerDependencies:
@@ -2352,7 +2352,7 @@ __metadata:
     "@digitransit-component/digitransit-component-autosuggest-panel": ^1.4.6
     "@digitransit-component/digitransit-component-control-panel": ^1.0.2
     "@digitransit-component/digitransit-component-favourite-bar": 1.0.12
-    "@digitransit-component/digitransit-component-favourite-editing-modal": ^0.3.16
+    "@digitransit-component/digitransit-component-favourite-editing-modal": ^1.0.0
     "@digitransit-component/digitransit-component-favourite-modal": ^0.3.17
     "@digitransit-component/digitransit-component-icon": ^0.1.16
     "@digitransit-component/digitransit-component-suggestion-item": ^1.0.1


### PR DESCRIPTION
Rendering arrows to  absolute position -999 px left caused really interesting effects in hsl.fi - arrow was rendered outside the browser window!  