### PR TITLE
fix: keyboard navigation improved on OSX/Safari

### DIFF
--- a/app/component/RoutePageControlPanel.js
+++ b/app/component/RoutePageControlPanel.js
@@ -507,6 +507,7 @@ class RoutePageControlPanel extends React.Component {
               }}
               tabIndex={activeTab === Tab.Stops ? 0 : -1}
               role="tab"
+              {...(activeTab === Tab.Stops ? { id: 'route-tab' } : {})}
               ref={this.stopTabRef}
               aria-selected={activeTab === Tab.Stops}
               style={{

--- a/app/component/RouteStop.js
+++ b/app/component/RouteStop.js
@@ -184,6 +184,8 @@ const RouteStop = (
       </div>
       <div className="route-stop-row_content-container">
         <Link
+          as="button"
+          type="button"
           to={`/${PREFIX_STOPS}/${encodeURIComponent(stop.gtfsId)}`}
           onClick={() => {
             addAnalyticsEvent({

--- a/app/component/RouteStopListContainer.js
+++ b/app/component/RouteStopListContainer.js
@@ -97,7 +97,11 @@ class RouteStopListContainer extends React.PureComponent {
             default="Departure times for each stop update in real time."
           />
         </span>
-        <ul className={cx('route-stop-list', this.props.className)}>
+        <ul
+          className={cx('route-stop-list', this.props.className)}
+          role="tabpanel"
+          aria-labelledby="route-tab"
+        >
           {this.getStops()}
         </ul>
       </>

--- a/app/component/RouteStopListContainer.js
+++ b/app/component/RouteStopListContainer.js
@@ -90,21 +90,17 @@ class RouteStopListContainer extends React.PureComponent {
 
   render() {
     return (
-      <>
+      <div role="tabpanel" aria-labelledby="route-tab">
         <span className="sr-only">
           <FormattedMessage
             id="stop-list-update.sr-instructions"
             default="Departure times for each stop update in real time."
           />
         </span>
-        <ul
-          className={cx('route-stop-list', this.props.className)}
-          role="tabpanel"
-          aria-labelledby="route-tab"
-        >
+        <ul className={cx('route-stop-list', this.props.className)}>
           {this.getStops()}
         </ul>
-      </>
+      </div>
     );
   }
 }

--- a/app/component/TripRouteStop.js
+++ b/app/component/TripRouteStop.js
@@ -122,7 +122,11 @@ const TripRouteStop = (props, { config }) => {
         />
       </div>
       <div className="route-stop-row_content-container">
-        <Link to={`/${PREFIX_STOPS}/${encodeURIComponent(stop.gtfsId)}`}>
+        <Link
+          as="button"
+          type="button"
+          to={`/${PREFIX_STOPS}/${encodeURIComponent(stop.gtfsId)}`}
+        >
           <div>
             <div className="route-details-upper-row">
               <div className={`route-details_container ${mode}`}>

--- a/app/component/TripStopListContainer.js
+++ b/app/component/TripStopListContainer.js
@@ -113,7 +113,11 @@ class TripStopListContainer extends React.PureComponent {
   render() {
     return (
       <>
-        <div className={cx('route-stop-list', this.props.className)}>
+        <div
+          className={cx('route-stop-list', this.props.className)}
+          role="tabpanel"
+          aria-labelledby="route-tab"
+        >
           {this.getStops()}
         </div>
         <div className="bottom-whitespace" />

--- a/app/component/route.scss
+++ b/app/component/route.scss
@@ -348,7 +348,7 @@ $margin-left-right: 21.3px;
     margin-left: 15px;
     display: flex;
     border-bottom: 1px solid #eef1f3;
-    a {
+    button {
       width: 100%;
       height: 100%;
       padding: 10px 0;

--- a/sass/base/_button.scss
+++ b/sass/base/_button.scss
@@ -11,6 +11,11 @@ button {
   position: relative;
   background-color: transparent;
   transition: none;
+  display: inline-block;
+  text-decoration: none;
+  font-weight: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
   color: inherit;
 
   &:focus {


### PR DESCRIPTION
OSX/Safari ignores all <a> elements while tabbing. Route page stop anchors changed from anchors to buttons to enable keyboard navigation.

## Proposed Changes

  - route stops listing page (eg. /linjat/HSL:6181/pysakit/HSL:6181:0:01) stop items changed from <a> to <button>
 
## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
