### PR TITLE
DT-5416

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -1887,15 +1887,15 @@ class SummaryPage extends React.Component {
     if (this.headerRef.current && this.contentRef.current) {
       setTimeout(() => {
         let inputs = Array.from(
-          this.headerRef.current.querySelectorAll(
+          this.headerRef?.current?.querySelectorAll(
             'input, button, *[role="button"]',
-          ),
+          ) || [],
         );
         inputs = inputs.concat(
           Array.from(
-            this.contentRef.current.querySelectorAll(
+            this.contentRef?.current?.querySelectorAll(
               'input, button, *[role="button"]',
-            ),
+            ) || [],
           ),
         );
         /* eslint-disable no-param-reassign */

--- a/app/component/customizesearch/CityBikeNetworkSelector.js
+++ b/app/component/customizesearch/CityBikeNetworkSelector.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import xor from 'lodash/xor';
 import Toggle from './Toggle';
 import { saveRoutingSettings } from '../../action/SearchSettingsActions';
 import Icon from '../Icon';
@@ -10,6 +11,8 @@ import {
   updateCitybikeNetworks,
   getCitybikeNetworks,
 } from '../../util/citybikes';
+import { getModes } from '../../util/modeUtils';
+import { TransportMode } from '../../constants';
 
 const CityBikeNetworkSelector = (
   { currentOptions },
@@ -50,12 +53,20 @@ const CityBikeNetworkSelector = (
               ).length > 0
             }
             onToggle={() => {
-              executeAction(saveRoutingSettings, {
-                allowedBikeRentalNetworks: updateCitybikeNetworks(
-                  getCitybikeNetworks(config),
-                  network.networkName,
-                ),
-              });
+              const newNetworks = updateCitybikeNetworks(
+                getCitybikeNetworks(config),
+                network.networkName,
+              );
+              const modes = getModes(config);
+              const newSettings = { allowedBikeRentalNetworks: newNetworks };
+              if (newNetworks.length > 0) {
+                if (modes.indexOf(TransportMode.Citybike) === -1) {
+                  newSettings.modes = xor(modes, [TransportMode.Citybike]);
+                }
+              } else if (modes.indexOf(TransportMode.Citybike) !== -1) {
+                newSettings.modes = xor(modes, [TransportMode.Citybike]);
+              }
+              executeAction(saveRoutingSettings, newSettings);
             }}
           />
         </label>

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -161,8 +161,8 @@ export default {
         },
       },
       turku: {
-        enabled: TurkuConfig.cityBike.networks.turku.enabled,
-        season: TurkuConfig.cityBike.networks.turku.season,
+        enabled: TurkuConfig.cityBike.networks.donkey_turku.enabled,
+        season: TurkuConfig.cityBike.networks.donkey_turku.season,
         capacity: BIKEAVL_WITHMAX,
         icon: 'citybike',
         name: {
@@ -172,9 +172,9 @@ export default {
         },
         type: 'citybike',
         url: {
-          fi: 'https://www.foli.fi/kaupunkipyorat',
-          sv: 'https://www.foli.fi/sv/stadscyklar',
-          en: 'https://www.foli.fi/en/citybikes',
+          fi: 'https://www.foli.fi/fi/aikataulut-ja-reitit/fölifillarit',
+          sv: 'https://www.foli.fi/sv/fölicyklar',
+          en: 'https://www.foli.fi/en/föli-bikes',
         },
       },
       vilkku: {

--- a/app/configurations/config.turku.js
+++ b/app/configurations/config.turku.js
@@ -53,13 +53,13 @@ export default configMerger(walttiConfig, {
 
   cityBike: {
     networks: {
-      turku: {
+      donkey_turku: {
         capacity: BIKEAVL_WITHMAX,
         enabled: true,
         season: {
           // 1.6. - 30.9.
-          start: new Date(new Date().getFullYear(), 5, 1),
-          end: new Date(new Date().getFullYear(), 9, 1),
+          start: new Date(new Date().getFullYear(), 4, 1),
+          end: new Date(new Date().getFullYear(), 10, 1),
         },
         icon: 'citybike',
         name: {
@@ -69,9 +69,9 @@ export default configMerger(walttiConfig, {
         },
         type: 'citybike',
         url: {
-          fi: 'https://www.foli.fi/kaupunkipyorat',
-          sv: 'https://www.foli.fi/sv/stadscyklar',
-          en: 'https://www.foli.fi/en/citybikes',
+          fi: 'https://www.foli.fi/fi/aikataulut-ja-reitit/fölifillarit',
+          sv: 'https://www.foli.fi/sv/fölicyklar',
+          en: 'https://www.foli.fi/en/föli-bikes',
         },
       },
     },

--- a/app/configurations/config.turku.js
+++ b/app/configurations/config.turku.js
@@ -58,7 +58,7 @@ export default configMerger(walttiConfig, {
         enabled: true,
         season: {
           // 1.6. - 30.9.
-          start: new Date(new Date().getFullYear(), 4, 1),
+          start: new Date(new Date().getFullYear(), 5, 1),
           end: new Date(new Date().getFullYear(), 10, 1),
         },
         icon: 'citybike',

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -206,7 +206,7 @@ export const preparePlanParams = (config, useDefaultModes) => (
   const intermediatePlaceLocations = getIntermediatePlaces({
     intermediatePlaces,
   });
-  const modesOrDefault = useDefaultModes
+  let modesOrDefault = useDefaultModes
     ? getDefaultModes(config)
     : filterModes(
         config,
@@ -233,6 +233,13 @@ export const preparePlanParams = (config, useDefaultModes) => (
               : network,
           )
       : defaultSettings.allowedBikeRentalNetworks;
+  if (
+    !allowedBikeRentalNetworksMapped ||
+    !allowedBikeRentalNetworksMapped.length
+  ) {
+    // do not ask citybike routes if no networks are allowed
+    modesOrDefault = modesOrDefault.filter(mode => mode !== 'BICYCLE_RENT');
+  }
   const formattedModes = modesAsOTPModes(modesOrDefault);
   const wheelchair =
     getNumberValueOrDefault(settings.accessibilityOption, defaultSettings) ===


### PR DESCRIPTION
- Update Turku citybike config
- Fix broken citybike setting logic. Network selection changes now update citybike mode in itinerary search. 
- Clear citybike mode from itinerary search during query preparations if all networks are disabled. This heals already mangled search settings.