### PR TITLE
DT-5456 make sure P&R button always includes transport mode icon

### DIFF
--- a/app/component/StreetModeSelectorButton.js
+++ b/app/component/StreetModeSelectorButton.js
@@ -68,16 +68,20 @@ export const StreetModeSelectorButton = (
       }
     }
   } else if (name === 'parkAndRide') {
-    const publicModes = plan.itineraries[0].legs.filter(
-      obj =>
-        obj.mode !== 'WALK' && obj.mode !== 'BICYCLE' && obj.mode !== 'CAR',
-    );
-    if (publicModes.length > 0) {
-      const firstMode = publicModes[0].mode.toLowerCase();
-      secondaryIcon = `icon-icon_${firstMode}`;
-      if (firstMode === 'subway') {
-        metroColor = '#CA4000';
+    let mode = 'rail';
+    for (let i = 0; i < plan.itineraries.length; i++) {
+      const publicModes = plan.itineraries[i].legs.filter(
+        obj =>
+          obj.mode !== 'WALK' && obj.mode !== 'BICYCLE' && obj.mode !== 'CAR',
+      );
+      if (publicModes.length > 0) {
+        mode = publicModes[0].mode.toLowerCase();
+        break;
       }
+    }
+    secondaryIcon = `icon-icon_${mode}`;
+    if (mode === 'subway') {
+      metroColor = '#CA4000';
     }
   }
   return (


### PR DESCRIPTION
Park & Ride routing sometimes suggests first itinerary where traveler parks the car and walks to destination. Previously no public transport icon was rendered to P&R button in itinerary summary page. This is especially confusing in current matka dev planner, as it looks like there are options for driving a small slow or a big fast car.
