### PR TITLE
DT_5454 truncate route filter list to fit the selector button

### DIFF
--- a/app/component/TimeTableOptionsPanel.js
+++ b/app/component/TimeTableOptionsPanel.js
@@ -6,7 +6,7 @@ import Icon from './Icon';
 import { ExtendedRouteTypes } from '../constants';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
 
-const MAX_ROUTEFILTER_LEN = 16;
+const MAX_ROUTEFILTER_LEN = 13;
 
 class TimeTableOptionsPanel extends React.Component {
   static propTypes = {

--- a/app/component/TimeTableOptionsPanel.js
+++ b/app/component/TimeTableOptionsPanel.js
@@ -6,6 +6,8 @@ import Icon from './Icon';
 import { ExtendedRouteTypes } from '../constants';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
 
+const MAX_ROUTEFILTER_LEN = 16;
+
 class TimeTableOptionsPanel extends React.Component {
   static propTypes = {
     stop: PropTypes.object.isRequired,
@@ -35,12 +37,25 @@ class TimeTableOptionsPanel extends React.Component {
       throw Error('Empty stop');
     }
     const routeNames = this.getRouteNames(this.props.showRoutes);
-    const showRoutesDiv = routeNames.map(
-      (o, i) =>
-        `${o.shortName ? o.shortName : o.agencyName}${
-          i === routeNames.length - 1 ? '' : ', '
-        }`,
-    );
+    const showRoutesDiv = [];
+    for (let i = 0; i < routeNames.length; i++) {
+      const o = routeNames[i];
+      showRoutesDiv[i] = `${o.shortName ? o.shortName : o.agencyName}${
+        i === routeNames.length - 1 ? '' : ', '
+      }`;
+      if (showRoutesDiv.join().length > MAX_ROUTEFILTER_LEN) {
+        if (i > 0) {
+          showRoutesDiv[i] = '\u{02026}';
+        } else {
+          showRoutesDiv[0] = `${showRoutesDiv[0].substr(
+            0,
+            MAX_ROUTEFILTER_LEN - 1,
+          )}\u{02026}`;
+        }
+        break;
+      }
+    }
+
     let stopVehicle = this.props.stop.stoptimesForServiceDate[0].pattern.route.mode.toLowerCase();
     if (stopVehicle === 'bus') {
       stopVehicle = this.props.stop.stoptimesForServiceDate.some(


### PR DESCRIPTION
Route filter button no longer shows all filters, but picks only as many as it can fit.  Ellipsis is rendered to indicate that not everything is displayed.

Also single long route name gets truncated: 
https://opas.matka.fi/pysakit/MATKA%3A89806/aikataulu?date=20220708&routes=MATKA%3A69441397%3A%3A01
