### PR TITLE
Add FOLI feed to varely configuration

### DIFF
--- a/app/configurations/config.varely.js
+++ b/app/configurations/config.varely.js
@@ -22,7 +22,7 @@ export default configMerger(walttiConfig, {
     STOP_MAP: `${OTP_URL}vectorTiles/stops,stations/`,
   },
 
-  feedIds: ['VARELY'],
+  feedIds: ['VARELY', 'FOLI'],
 
   searchParams: {
     'boundary.rect.min_lat': 59.475641,


### PR DESCRIPTION
## Proposed Changes

  - Add feed named 'FOLI' to varely configuration 

## Depends on

PR https://github.com/HSLdevcom/OpenTripPlanner-data-container/pull/270
