### PR TITLE
Use default unpreferred route penalty

### DIFF
--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -177,7 +177,6 @@ export default {
   // not be computed
   suggestCarMinDistance: 2000,
   itineraryFiltering: 1.5, // drops 66% worse routes
-  useUnpreferredRoutesPenalty: 1200, // adds 10 minute (weight) penalty to routes that are unpreferred
   minTransferTime: 120,
   optimize: 'GREENWAYS',
   transferPenalty: 0,

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -278,9 +278,6 @@ export const preparePlanParams = (config, useDefaultModes) => (
         bikeSpeed: settings.bikeSpeed,
         optimize: config.optimize,
         itineraryFiltering: config.itineraryFiltering,
-        unpreferred: {
-          useUnpreferredRoutesPenalty: config.useUnpreferredRoutesPenalty,
-        },
         disableRemainingWeightHeuristic: getDisableRemainingWeightHeuristic(
           modesOrDefault,
         ),


### PR DESCRIPTION
## Proposed Changes
 
 - Use default unpreferred route penalty function defined in OTP2 instead of client-provided query parameters
 - Related issue: DT-5473

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
