### PR TITLE
DT-5490 new bike route data and misc fixes

### DIFF
--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -42,8 +42,8 @@ export default {
       default: `${MAP_URL}/map/${MAP_VERSION}/hsl-map/`,
       sv: `${MAP_URL}/map/${MAP_VERSION}/hsl-map-sv/`,
     },
-    STOP_MAP: `${MAP_URL}/map/v1/finland-stop-map/`,
-    CITYBIKE_MAP: `${MAP_URL}/map/v1/finland-citybike-map/`,
+    STOP_MAP: `${MAP_URL}/map/${MAP_VERSION}/finland-stop-map/`,
+    CITYBIKE_MAP: `${MAP_URL}/map/${MAP_VERSION}/finland-citybike-map/`,
     FONT:
       'https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&family=Roboto:wght@400;700',
     PELIAS: `${process.env.GEOCODING_BASE_URL || GEOCODING_BASE_URL}/search`,

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -44,6 +44,8 @@ export default {
     },
     STOP_MAP: `${MAP_URL}/map/${MAP_VERSION}/finland-stop-map/`,
     CITYBIKE_MAP: `${MAP_URL}/map/${MAP_VERSION}/finland-citybike-map/`,
+    PARK_AND_RIDE_MAP: `${MAP_URL}/map/${MAP_VERSION}/hsl-parkandride-map/`,
+
     FONT:
       'https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&family=Roboto:wght@400;700',
     PELIAS: `${process.env.GEOCODING_BASE_URL || GEOCODING_BASE_URL}/search`,

--- a/app/configurations/config.lappeenranta.js
+++ b/app/configurations/config.lappeenranta.js
@@ -154,7 +154,7 @@ export default configMerger(walttiConfig, {
           sv: 'Cykelrutter',
           en: 'Bike routes',
         },
-        url: 'https://ckan.saita.fi/geojson/pyorailyreitit_lpr.geojson',
+        url: 'https://ckanlpr.meitademo.fi/geojson/pyorailyreitit_lpr.geojson',
         isOffByDefault: true,
       },
       {

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -292,7 +292,7 @@ export default {
   parkingAreaSources: ['liipi'],
 
   parkAndRide: {
-    showParkAndRide: true,
+    showParkAndRide: false,
     parkAndRideMinZoom: 13,
     pageContent: {
       default: HSLParkAndRideUtils,


### PR DESCRIPTION
- New lappenranta citybike route data source
- matka.fi now uses only v2 maps
- P&R map layer works now in matka (same way as in hsl service)
 