### PR TITLE
DT-5488: shortnames with 5 or 6 characters stretch the route number plate

### DIFF
--- a/app/component/DepartureRow.js
+++ b/app/component/DepartureRow.js
@@ -116,7 +116,9 @@ const DepartureRow = (
       key={uuid()}
     >
       <td
-        className="route-number-container"
+        className={cx('route-number-container', {
+          long: shortName.length <= 6 && shortName.length >= 5,
+        })}
         style={{ backgroundColor: `#${departure.trip.route.color}` }}
       >
         {renderWithLink(

--- a/app/component/stop.scss
+++ b/app/component/stop.scss
@@ -307,7 +307,11 @@
       height: 1.5em;
       margin-top: 2px;
       min-width: 2.25em;
-      padding: 0 4px;
+      padding: 0 2px;
+      &.long {
+        width: unset;
+        min-width: 48px;
+      }
       .route-number {
         .icon-container {
           font-size: 1.5em;

--- a/app/component/stops-near-you.scss
+++ b/app/component/stops-near-you.scss
@@ -310,8 +310,12 @@
         margin-right: 10px;
         width: 3em;
         height: 1.25em;
-        padding: 0 4px;
         position: relative;
+        padding: 0 2px;
+        &.long {
+          width: unset;
+          min-width: 48px;
+        }
       }
       .route-headsign {
         font-family: $font-family-narrow;


### PR DESCRIPTION
## Proposed Changes

  - A mode icon is shown if a shortname has more than six characters 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
