### PR TITLE
fix: use url param instead of header for map subscription key

### DIFF
--- a/app/util/fetchUtils.js
+++ b/app/util/fetchUtils.js
@@ -14,6 +14,15 @@ const addSubscriptionHeader = (headers, config) => {
   return updatedHeaders;
 };
 
+const addSubscriptionParam = (url, config) => {
+  if (config.hasAPISubscriptionQueryParameter) {
+    return `${encodeURI(url)}${url.search(/\?/) === -1 ? '?' : '&'}${
+      config.API_SUBSCRIPTION_QUERY_PARAMETER_NAME
+    }=${config.API_SUBSCRIPTION_TOKEN}`;
+  }
+  return encodeURI(url);
+};
+
 // Tries to fetch 1 + retryCount times until 200 is returned.
 // Uses retryDelay (ms) between requests. url and options are normal fetch parameters
 export const retryFetch = (
@@ -62,6 +71,4 @@ export const retryFetch = (
  * @returns fetch's promise
  */
 export const fetchWithSubscription = (URL, config) =>
-  fetch(URL, {
-    headers: addSubscriptionHeader({}, config),
-  });
+  fetch(addSubscriptionParam(URL, config));


### PR DESCRIPTION
## Proposed Changes

  - Use query param instead of header to avoid options queries that return 401

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
