### PR TITLE
fix: do not display empty alert div

### DIFF
--- a/app/component/RoutePage.js
+++ b/app/component/RoutePage.js
@@ -17,6 +17,7 @@ import { isBrowser } from '../util/browser';
 import LazilyLoad, { importLazy } from './LazilyLoad';
 import { getRouteMode } from '../util/modeUtils';
 import AlertBanner from './AlertBanner';
+import { hasMeaningfulData } from '../util/alertUtils';
 
 const modules = {
   FavouriteRouteContainer: () =>
@@ -134,7 +135,7 @@ class RoutePage extends React.Component {
               </LazilyLoad>
             )}
           </div>
-          {tripId && route.alerts.length > 0 && (
+          {tripId && hasMeaningfulData(route.alerts) && (
             <div className="trip-page-alert-container">
               <AlertBanner
                 alerts={route.alerts}

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -780,6 +780,27 @@ export const createUniqueAlertList = (
 };
 
 /**
+ * Checks whether the alert to be displayed has meaningful data (header or description) or not.
+ * Used to decide whether to render the box for the alert or not.
+ * @param {*} alerts list of alerts.
+ */
+export const hasMeaningfulData = alerts => {
+  if (alerts.length === 0) {
+    return false;
+  }
+  const alertForDisplaying = alerts.sort(alertSeverityCompare)[0];
+  const header = getServiceAlertHeader(alertForDisplaying);
+  const description = getServiceAlertDescription(alertForDisplaying);
+  if (
+    (header && header.length > 0) ||
+    (description && description.length > 0)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+/**
  * Describes the type information for an OTP Service Alert object.
  */
 export const otpServiceAlertShape = PropTypes.shape({

--- a/test/unit/util/alertUtils.test.js
+++ b/test/unit/util/alertUtils.test.js
@@ -1352,4 +1352,41 @@ describe('alertUtils', () => {
       expect(sortedAlerts[0].stop.gtfsId).to.equal('foo:1');
     });
   });
+  describe('hasMeaningfulData', () => {
+    it('should return false if there are no alerts', () => {
+      const alerts = [];
+      expect(utils.hasMeaningfulData(alerts)).to.equal(false);
+    });
+    it('should return true if header or description present', () => {
+      const alerts = [
+        { severityLevel: AlertSeverityLevelType.Warning },
+        {
+          severityLevel: AlertSeverityLevelType.Severe,
+          alertDescriptionText: 'foo',
+        },
+      ];
+      expect(utils.hasMeaningfulData(alerts)).to.equal(true);
+    });
+    it('should return false if neither header or description are present', () => {
+      const alerts = [
+        { severityLevel: AlertSeverityLevelType.Warning },
+        { severityLevel: AlertSeverityLevelType.Severe },
+      ];
+      expect(utils.hasMeaningfulData(alerts)).to.equal(false);
+    });
+    it('should return false if no meaningful data is included in header or description fields', () => {
+      const alerts = [
+        {
+          severityLevel: AlertSeverityLevelType.Warning,
+          alertDescriptionText: 'meaningful but not priority',
+        },
+        {
+          severityLevel: AlertSeverityLevelType.Severe,
+          alertDescriptionText: '',
+          alertHeaderText: '',
+        },
+      ];
+      expect(utils.hasMeaningfulData(alerts)).to.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
Check if the alerts have meaningful data before rendering the alert box.