### PR TITLE
Add citybike feeds to matka and waltti opas

### DIFF
--- a/app/configurations/config.kotka.js
+++ b/app/configurations/config.kotka.js
@@ -66,6 +66,11 @@ export default configMerger(walttiConfig, {
           sv: 'https://kaakau.fi/kotka/?lang=sv',
           en: 'https://kaakau.fi/kotka/?lang=en',
         },
+        returnInstructions: {
+          fi: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          sv: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          en: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+        },
       },
       donkey_hamina: {
         enabled: true,
@@ -86,6 +91,11 @@ export default configMerger(walttiConfig, {
           fi: 'https://kaakau.fi/hamina/',
           sv: 'https://kaakau.fi/hamina/?lang=sv',
           en: 'https://kaakau.fi/hamina/?lang=en',
+        },
+        returnInstructions: {
+          fi: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          sv: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          en: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
         },
       },
     },

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -70,6 +70,7 @@ export default {
       'mode-ferry': '#247C7B',
       'mode-ferry-pier': '#666666',
       'mode-citybike': '#FCBC19',
+      'mode-citybike-secondary': '#333333',
     },
   },
   feedIds: [
@@ -235,6 +236,96 @@ export default {
           en: 'https://kaakau.fi/lappeenranta/?lang=en',
         },
       },
+      donkey_kotka: {
+        enabled: true,
+        season: {
+          // 14.4. - 31.10.
+          start: new Date(new Date().getFullYear(), 3, 14),
+          end: new Date(new Date().getFullYear(), 10, 1),
+        },
+        capacity: BIKEAVL_WITHMAX,
+        icon: 'citybike',
+        name: {
+          fi: 'Kotka',
+          sv: 'Kotka',
+          en: 'Kotka',
+        },
+        type: 'citybike',
+        url: {
+          fi: 'https://kaakau.fi/kotka/',
+          sv: 'https://kaakau.fi/kotka/?lang=sv',
+          en: 'https://kaakau.fi/kotka/?lang=en',
+        },
+        returnInstructions: {
+          fi: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          sv: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          en: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+        },
+      },
+      donkey_hamina: {
+        enabled: true,
+        season: {
+          // 14.4. - 31.10.
+          start: new Date(new Date().getFullYear(), 3, 14),
+          end: new Date(new Date().getFullYear(), 10, 1),
+        },
+        capacity: BIKEAVL_WITHMAX,
+        icon: 'citybike-secondary',
+        name: {
+          fi: 'Hamina',
+          sv: 'Hamina',
+          en: 'Hamina',
+        },
+        type: 'citybike',
+        url: {
+          fi: 'https://kaakau.fi/hamina/',
+          sv: 'https://kaakau.fi/hamina/?lang=sv',
+          en: 'https://kaakau.fi/hamina/?lang=en',
+        },
+        returnInstructions: {
+          fi: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          sv: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          en: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+        },
+      },
+      donkey_kouvola: {
+        enabled: true,
+        season: {
+          // 20.4. - 31.10.
+          start: new Date(new Date().getFullYear(), 3, 20),
+          end: new Date(new Date().getFullYear(), 10, 1),
+        },
+        capacity: BIKEAVL_WITHMAX,
+        icon: 'citybike',
+        name: {
+          fi: 'Kouvola',
+          sv: 'Kouvola',
+          en: 'Kouvola',
+        },
+        type: 'citybike',
+        url: {
+          fi: 'https://kaakau.fi/kouvola/',
+          sv: 'https://kaakau.fi/kouvola/?lang=sv',
+          en: 'https://kaakau.fi/kouvola/?lang=en',
+        },
+        returnInstructions: {
+          fi: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          sv: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          en: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+        },
+      },
+    },
+  },
+
+  getAutoSuggestIcons: {
+    citybikes: station => {
+      if (
+        station.properties.source === 'citybikesdonkey_hamina' ||
+        station.properties.source === 'vantaa'
+      ) {
+        return ['citybike-stop-digitransit-secondary', '#FCBC19'];
+      }
+      return ['citybike-stop-digitransit', '#FCBC19'];
     },
   },
 

--- a/app/configurations/config.walttiOpas.js
+++ b/app/configurations/config.walttiOpas.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import configMerger from '../util/configMerger';
+import { BIKEAVL_WITHMAX } from '../util/citybikes';
 
 const CONFIG = 'walttiOpas';
 const APP_TITLE = 'Waltti-opas';
@@ -25,6 +26,8 @@ export default configMerger(walttiConfig, {
     topBarColor: '#FFC439',
     iconColors: {
       'mode-bus': '#F16522',
+      'mode-citybike': '#f2b62d',
+      'mode-citybike-secondary': '#333333',
     },
   },
   transportModes: {
@@ -37,7 +40,103 @@ export default configMerger(walttiConfig, {
         en: 'Nearby stops on map',
       },
     },
+    citybike: {
+      availableForSelection: true,
+    },
   },
+
+  cityBike: {
+    networks: {
+      donkey_kotka: {
+        enabled: true,
+        season: {
+          // 14.4. - 31.10.
+          start: new Date(new Date().getFullYear(), 3, 14),
+          end: new Date(new Date().getFullYear(), 10, 1),
+        },
+        capacity: BIKEAVL_WITHMAX,
+        icon: 'citybike',
+        name: {
+          fi: 'Kotka',
+          sv: 'Kotka',
+          en: 'Kotka',
+        },
+        type: 'citybike',
+        url: {
+          fi: 'https://kaakau.fi/kotka/',
+          sv: 'https://kaakau.fi/kotka/?lang=sv',
+          en: 'https://kaakau.fi/kotka/?lang=en',
+        },
+        returnInstructions: {
+          fi: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          sv: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          en: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+        },
+      },
+      donkey_hamina: {
+        enabled: true,
+        season: {
+          // 14.4. - 31.10.
+          start: new Date(new Date().getFullYear(), 3, 14),
+          end: new Date(new Date().getFullYear(), 10, 1),
+        },
+        capacity: BIKEAVL_WITHMAX,
+        icon: 'citybike-secondary',
+        name: {
+          fi: 'Hamina',
+          sv: 'Hamina',
+          en: 'Hamina',
+        },
+        type: 'citybike',
+        url: {
+          fi: 'https://kaakau.fi/hamina/',
+          sv: 'https://kaakau.fi/hamina/?lang=sv',
+          en: 'https://kaakau.fi/hamina/?lang=en',
+        },
+        returnInstructions: {
+          fi: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          sv: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          en: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+        },
+      },
+      donkey_kouvola: {
+        enabled: true,
+        season: {
+          // 20.4. - 31.10.
+          start: new Date(new Date().getFullYear(), 3, 20),
+          end: new Date(new Date().getFullYear(), 10, 1),
+        },
+        capacity: BIKEAVL_WITHMAX,
+        icon: 'citybike',
+        name: {
+          fi: 'Kouvola',
+          sv: 'Kouvola',
+          en: 'Kouvola',
+        },
+        type: 'citybike',
+        url: {
+          fi: 'https://kaakau.fi/kouvola/',
+          sv: 'https://kaakau.fi/kouvola/?lang=sv',
+          en: 'https://kaakau.fi/kouvola/?lang=en',
+        },
+        returnInstructions: {
+          fi: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          sv: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+          en: 'https://kaakau.fi/ohjeet/pyoran-palauttaminen/',
+        },
+      },
+    },
+  },
+
+  getAutoSuggestIcons: {
+    citybikes: station => {
+      if (station.properties.source === 'citybikesdonkey_hamina') {
+        return ['citybike-stop-digitransit-secondary', '#f2b62d'];
+      }
+      return ['citybike-stop-digitransit', '#f2b62d'];
+    },
+  },
+
   socialMedia: {
     title: APP_TITLE,
     description: APP_DESCRIPTION,


### PR DESCRIPTION
## Proposed Changes

  - Adds return instructions for Kotka's citybikes
  - Adds Kotka and Kouvola citybikes to matka and waltti opas configs
  - Enables citybikes for waltti opas

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
