### PR TITLE
fix: reloading stop page doesn't take date into consideration DT-5540

### DIFF
--- a/app/stopRoutes.js
+++ b/app/stopRoutes.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Route from 'found/Route';
 import { graphql } from 'react-relay';
 
+import moment from 'moment';
 import Error404 from './component/404';
 import Loading from './component/LoadingPage';
 import {
@@ -16,7 +17,8 @@ import {
   getComponentOrNullRenderer,
   getComponentOrLoadingRenderer,
 } from './util/routerUtils';
-import { prepareDatesForStops, prepareServiceDay } from './util/dateParamUtils';
+import { prepareDatesForStops } from './util/dateParamUtils';
+import { DATE_FORMAT } from './constants';
 
 const queries = {
   stop: {
@@ -230,7 +232,13 @@ export default function getStopRoutes(isTerminal = false) {
                         .catch(errorLoading);
                 }}
                 query={queryMap.pageTimetable}
-                prepareVariables={prepareServiceDay}
+                prepareVariables={(params, { location }) => {
+                  const date = location?.query?.date;
+                  return {
+                    ...params,
+                    date: date || moment().format(DATE_FORMAT),
+                  };
+                }}
                 render={getComponentOrLoadingRenderer}
               />
               <Route


### PR DESCRIPTION
## Proposed Changes

  - Fixes an issue where reloading stop page causes the fetch to use the current date and not the date that is set by the user.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
