### PR TITLE
oldParamParser.js unit test: configure moment timezone explicitly

### DIFF
--- a/test/unit/oldParamParser.test.js
+++ b/test/unit/oldParamParser.test.js
@@ -4,6 +4,7 @@ import fetchMock from 'fetch-mock';
 import oldParamParser from '../../app/util/oldParamParser';
 
 import config from '../../app/configurations/config.default';
+import configureMoment from '../../app/util/configure-moment';
 // import { PREFIX_ITINERARY_SUMMARY } from '../../app/util/path';
 
 const largeMaxAgeConf = {
@@ -110,6 +111,10 @@ describe('oldParamParser', () => {
       'begin:https://dev-api.digitransit.fi/geocoding/v1/search?text=koivikkotie',
       resTo,
     );
+  });
+
+  beforeEach(() => {
+    configureMoment('fi', config);
   });
 
   after(() => {


### PR DESCRIPTION
in [bbnavi](https://bbnavi.de)'s CI, on `v3`, the `test/unit/oldParamParser.test.js` test (sometimes?) fails because it implicitly depends on other tests `import`ing `moment-timezone` (which loads all tz data), and apparently something about the order in which tests are executed.

This happens because the actual implementation in `app/util/oldParamParser.js` `import`s `moment-timezone/moment-timezone`, which doesn't load the tz data. The change was introduced in https://github.com/HSLdevcom/digitransit-ui/commit/c471aac9a6b5dac79443a2cc22b9476a1796ccf4#diff-95b1650be039580bba4296598c20b9ccc1dfe5fad7b2d74212a8ecb5482503ffR2.

@hbruch and I have discussed the possible solutions and decided to use `configureMoment()` in the test (instead of `import`ing `moment-timezone`, in order to follow the intended structure.