### PR TITLE
DT-5561 - Consider an empty list of fares as an unknown fare

### DIFF
--- a/app/util/fareUtils.js
+++ b/app/util/fareUtils.js
@@ -46,7 +46,9 @@ export const getFares = (fares, routes, config) => {
   const unknownTotalFare =
     fares && fares[0] && fares[0].type === 'regular' && fares[0].cents === -1;
   const unknownFares = (
-    ((unknownTotalFare || !fares) && Array.isArray(routes) && routes) ||
+    ((unknownTotalFare || !fares || fares.length === 0) &&
+      Array.isArray(routes) &&
+      routes) ||
     []
   )
     .filter(route => !routesWithFares.includes(route.gtfsId))


### PR DESCRIPTION
## Proposed Changes
Previously, the user interface made a difference between null fares and an empty list causing them to be rendered differently. This PR changes the fares rendering so that an empty list is treated the same way as a null value. The reason for this change is that returning null values from OTP2 causes errors in the REST api

