### PR TITLE
Fix missing backtick in ZIndex.md

### DIFF
--- a/docs/ZIndex.md
+++ b/docs/ZIndex.md
@@ -27,4 +27,4 @@ Selector | Component | Z-Index | Comment
 `.origin-destination-bar { .field-link { span:first-child { &::before` | Summary search bar from/to marker letters | 1 | Could be removed through new icon components
 `.itinerary-summary-row { .itinerary-legs { .line` | Summary result row leg lines | 1 |
 `.itinerary-summary-row { .itinerary-legs { .line { :after` | Hides the Summary result row leg lines behind the mode icon. | -1 |
-`.mobile.top-bar  | Mobile top bar | 1000 |
+`.mobile.top-bar`  | Mobile top bar | 1000 |


### PR DESCRIPTION
The last row of the Z-indices table appears to lack a backtick.

## Proposed Changes

  - Add missing backtick in Z-indices table

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
