### PR TITLE
fix: don't show speechbubble on map before walk-bike-fetch complete D…

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -1887,6 +1887,7 @@ class SummaryPage extends React.Component {
         showActive={detailView}
         showVehicles={this.showVehicles()}
         onlyHasWalkingItineraries={onlyHasWalkingItineraries}
+        loading={this.props.loading || this.state.isFetchingWalkAndBike}
       />
     );
   }

--- a/app/component/map/ItineraryLine.js
+++ b/app/component/map/ItineraryLine.js
@@ -35,6 +35,7 @@ class ItineraryLine extends React.Component {
     streetMode: PropTypes.string,
     flipBubble: PropTypes.bool,
     onlyHasWalkingItineraries: PropTypes.bool,
+    loading: PropTypes.bool,
   };
 
   checkStreetMode(leg) {
@@ -100,7 +101,7 @@ class ItineraryLine extends React.Component {
 
       // Show speechbubble despite streetMode not being selected if only walking itineraries are found
       if (
-        this.props.onlyHasWalkingItineraries ||
+        (this.props.onlyHasWalkingItineraries && !this.props.loading) ||
         (this.checkStreetMode(leg) && leg.distance > 100)
       ) {
         const duration = durationToString(leg.endTime - leg.startTime);

--- a/app/component/map/ItineraryPageMap.js
+++ b/app/component/map/ItineraryPageMap.js
@@ -21,6 +21,7 @@ function ItineraryPageMap(
     showVehicles,
     topics,
     onlyHasWalkingItineraries,
+    loading,
     ...rest
   },
   { match, router, executeAction, config },
@@ -57,6 +58,7 @@ function ItineraryPageMap(
         showTransferLabels={showActive}
         showIntermediateStops
         onlyHasWalkingItineraries={onlyHasWalkingItineraries}
+        loading={loading}
       />,
     );
   }
@@ -110,6 +112,7 @@ ItineraryPageMap.propTypes = {
   to: PropTypes.object.isRequired,
   viaPoints: PropTypes.array.isRequired,
   onlyHasWalkingItineraries: PropTypes.bool,
+  loading: PropTypes.bool,
 };
 
 ItineraryPageMap.contextTypes = {


### PR DESCRIPTION
…T-5594

## Proposed Changes

  - Bring loading prop to ItineraryLine to determine whether fetching walk and bike is complete or not

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
