### PR TITLE
fix: in trip view, only display vehicle with given trip DT-5531

### DIFF
--- a/app/component/RoutePageControlPanel.js
+++ b/app/component/RoutePageControlPanel.js
@@ -73,6 +73,7 @@ class RoutePageControlPanel extends React.Component {
     breakpoint: PropTypes.string.isRequired,
     noInitialServiceDay: PropTypes.bool,
     language: PropTypes.string,
+    tripStartTime: PropTypes.string,
   };
 
   static defaultProps = { language: 'fi' };
@@ -277,7 +278,7 @@ class RoutePageControlPanel extends React.Component {
 
   startClient(pattern) {
     const { config, executeAction } = this.context;
-    const { match, route } = this.props;
+    const { match, route, tripStartTime } = this.props;
     const { realTime } = config;
     if (config.NODE_ENV === 'test' || !realTime) {
       return;
@@ -310,6 +311,7 @@ class RoutePageControlPanel extends React.Component {
           gtfsId: routeParts[1],
           headsign: pattern.headsign,
           directionInt,
+          tripStartTime,
         },
       ],
     });

--- a/app/component/TripStopsContainer.js
+++ b/app/component/TripStopsContainer.js
@@ -48,6 +48,7 @@ function TripStopsContainer({ breakpoint, match, trip, route }) {
             match={match}
             route={route}
             breakpoint={breakpoint}
+            tripStartTime={tripStartTime}
           />
         )}
         <TripStopListContainer

--- a/app/configurations/realtimeUtils.js
+++ b/app/configurations/realtimeUtils.js
@@ -52,23 +52,13 @@ export default {
       if (Number.isInteger(direction)) {
         direction += 1;
       }
-      // HFP uses 24 hour system so this converts, for example, 25:05 to 01:05
-      function convertTo24HourFormat(time) {
-        return parseInt(time.substring(0, 2), 10) > 23
-          ? '0' + (parseInt(time.substring(0, 2), 10) - 24) + time.substring(2)
-          : time;
-      }
-      const fixedStartTime =
-        tripStartTime && tripStartTime !== '+' && tripStartTime.lengh > 4
-          ? convertTo24HourFormat(tripStartTime)
-          : tripStartTime;
       return (
         '/hfp/v2/journey/ongoing/+/+/+/+/' +
         route +
         '/' +
         direction +
         '/+/' +
-        fixedStartTime +
+        tripStartTime +
         '/#'
       );
     },

--- a/app/util/mqttClient.js
+++ b/app/util/mqttClient.js
@@ -1,6 +1,7 @@
 import ceil from 'lodash/ceil';
 import moment from 'moment';
 import { parseFeedMQTT } from './gtfsRtParser';
+import { convertTo24HourFormat } from './timeUtils';
 
 const standardModes = ['bus', 'tram', 'ferry'];
 
@@ -31,7 +32,9 @@ function getTopic(options, settings) {
     options.headsign && options.headsign.indexOf('/') === -1
       ? options.headsign
       : '+';
-  const tripStartTime = options.tripStartTime ? options.tripStartTime : '+';
+  const tripStartTime = options.tripStartTime
+    ? convertTo24HourFormat(options.tripStartTime)
+    : '+';
   const topic = settings.mqttTopicResolver(
     route,
     direction,

--- a/app/util/timeUtils.js
+++ b/app/util/timeUtils.js
@@ -102,6 +102,9 @@ export function getCurrentSecs() {
 
 // converts time from 24+ hour HHmm to 24 hour HH:mm format
 export function convertTo24HourFormat(time) {
+  if (time.match(/^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/)) {
+    return time;
+  }
   return parseInt(time.substring(0, 2), 10) > 23
     ? `0${parseInt(time.substring(0, 2), 10) - 24}:${time.substring(2, 4)}`
     : `${time.substring(0, 2)}:${time.substring(2, 4)}`;

--- a/test/unit/util/timeUtils.test.js
+++ b/test/unit/util/timeUtils.test.js
@@ -73,5 +73,8 @@ describe('timeUtils', () => {
     it('should change format to 00:00 at midnight', () => {
       expect(convertTo24HourFormat('2400')).to.equal('00:00');
     });
+    it('should return given parameter if already correct format', () => {
+      expect(convertTo24HourFormat('23:45')).to.equal('23:45');
+    });
   });
 });


### PR DESCRIPTION
## Proposed Changes

  - HFP cannot use tripId to track, must use tripStartTime with HH:MM format. Other mqttTopicResolvers remain unchanged. Some views pass a correct time format, so let's check the validity in the converter function to avoid regression

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
