### PR TITLE
fix: reset topicsByRoute in store on reset DT-5605

### DIFF
--- a/app/store/RealTimeInformationStore.js
+++ b/app/store/RealTimeInformationStore.js
@@ -47,12 +47,14 @@ class RealTimeInformationStore extends Store {
     }
     this.client = undefined;
     this.topics = undefined;
+    this.topicsByRoute = undefined;
     this.vehicles = {};
     this.emitChange();
   }
 
   resetClient() {
     this.topics = undefined;
+    this.topicsByRoute = undefined;
     this.vehicles = {};
     this.emitChange();
   }


### PR DESCRIPTION
## Proposed Changes

  - topicsByRoute must be reset when updating topics because of filtering old messages

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
