### PR TITLE
WalkLeg: handle stops without vehicleMode

### DIFF
--- a/app/component/WalkLeg.js
+++ b/app/component/WalkLeg.js
@@ -38,7 +38,7 @@ function WalkLeg(
   // If mode is not WALK, WalkLeg should get information from "to".
   const toOrFrom = leg.mode !== 'WALK' ? 'to' : 'from';
   const modeClassName = 'walk';
-  const fromMode = leg[toOrFrom].stop ? leg[toOrFrom].stop.vehicleMode : '';
+  const fromMode = (leg[toOrFrom].stop && leg[toOrFrom].stop.vehicleMode) || '';
   const isFirstLeg = i => i === 0;
   const [address, place] = splitStringToAddressAndPlace(leg[toOrFrom].name);
 
@@ -79,7 +79,7 @@ function WalkLeg(
             time: moment(leg.startTime).format('HH:mm'),
             to: intl.formatMessage({
               id: `modes.to-${
-                leg.to.stop?.vehicleMode.toLowerCase() || 'place'
+                leg.to.stop?.vehicleMode?.toLowerCase() || 'place'
               }`,
               defaultMessage: 'modes.to-stop',
             }),

--- a/test/unit/WalkLeg.test.js
+++ b/test/unit/WalkLeg.test.js
@@ -188,4 +188,38 @@ describe('<WalkLeg />', () => {
       AlertSeverityLevelType.Info,
     );
   });
+
+  it('should render with leg.{from,to}.stop.vehicleMode being null', () => {
+    const props = {
+      focusAction: () => {},
+      focusToLeg: () => {},
+      index: 1,
+      leg: {
+        distance: 1.23,
+        duration: 34,
+        from: {
+          name: 'Foo',
+          stop: {
+            gtfsId: 'foo',
+            vehicleMode: null,
+          },
+        },
+        to: {
+          name: 'Bar',
+          stop: {
+            gtfsId: 'bar',
+            vehicleMode: null,
+          },
+        },
+        mode: 'WALK',
+        rentedBike: false,
+        startTime: 1668600030868,
+        endTime: 1668600108525,
+      },
+    };
+
+    shallowWithIntl(<WalkLeg {...props} />, {
+      context: { config: { colors: { primary: '#007ac9' } } },
+    });
+  });
 });


### PR DESCRIPTION
## Proposed Changes

According to OTP's GraphQL schema, `Stop.vehicleMode` can be `null`; This PR changes `app/component/WalkLeg.js` to handle that, and adds a smoke test.

We stumbled upon this in [bbnavi](https://bbnavi.de).

## Pull Request Check List

- [x] A reasonable set of unit tests is included
- [ ] Console does not show new warnings/errors
- [x] Changes are documented or they are self explanatory