### PR TITLE
fix syntactic errors in SVG sprites, let CI lint them

### DIFF
--- a/.github/workflows/v3-dev-pipeline.yml
+++ b/.github/workflows/v3-dev-pipeline.yml
@@ -31,6 +31,10 @@ jobs:
         run: yarn setup
       - name: Run linters
         run: yarn lint
+      - name: lint SVG sprites using xmllint
+        run: |
+          sudo apt install -y libxml2-utils
+          xmllint --nonet --noout static/assets/svg-sprite.*.svg
 
   unit-test:
     runs-on: ubuntu-latest

--- a/static/assets/svg-sprite.default.svg
+++ b/static/assets/svg-sprite.default.svg
@@ -1637,7 +1637,7 @@
         </g>
     </g>
 </symbol>
-<symbol id="icon-icon_citybike-secondary_station_green_small"viewBox="0 0 16 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-icon_citybike-secondary_station_green_small" viewBox="0 0 16 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>icon-citybike_station-green-small</title>
     <defs>
         <circle id="path-1" cx="7.2" cy="7.2" r="7.2"></circle>
@@ -1802,7 +1802,7 @@
     </g>
 </symbol>
 
-<symbol id="icon-icon_citybike_station_small"viewBox="0 0 16 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-icon_citybike_station_small" viewBox="0 0 16 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>icon-citybike_station-small</title>
     <defs>
         <circle id="path-1" cx="7.2" cy="7.2" r="7.2"></circle>

--- a/static/assets/svg-sprite.hsl.svg
+++ b/static/assets/svg-sprite.hsl.svg
@@ -1530,7 +1530,7 @@
         </g>
     </g>
 </symbol>
-<symbol id="icon-icon_citybike-secondary_station_green_small"viewBox="0 0 16 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-icon_citybike-secondary_station_green_small" viewBox="0 0 16 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>icon-citybike_station-green-small</title>
     <defs>
         <circle id="path-1" cx="7.2" cy="7.2" r="7.2"></circle>
@@ -1730,7 +1730,7 @@
     </g>
 </symbol>
 
-<symbol id="icon-icon_citybike_station_small"viewBox="0 0 16 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-icon_citybike_station_small" viewBox="0 0 16 22" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>icon-citybike_station-small</title>
     <defs>
         <circle id="path-1" cx="7.2" cy="7.2" r="7.2"></circle>


### PR DESCRIPTION
`static/assets/svg-sprite.{default,hsl}.svg` had malformed syntax(es). This PR fixes them and introduces a CI check for all SVG sprites.