### PR TITLE
DT-5535: Add a link to stop monitors to HSL reittiopas

### DIFF
--- a/app/component/Timetable.js
+++ b/app/component/Timetable.js
@@ -273,7 +273,7 @@ class Timetable extends React.Component {
       return obj;
     });
     const timetableMap = this.groupArrayByHour(routesWithDetails);
-
+    const { locationType } = this.props.stop;
     const stopIdSplitted = this.props.stop.gtfsId.split(':');
     const stopTimetableHandler =
       this.context.config.timetables &&
@@ -281,7 +281,7 @@ class Timetable extends React.Component {
     const stopPDFURL =
       stopTimetableHandler &&
       this.context.config.URL.STOP_TIMETABLES[stopIdSplitted[0]] &&
-      this.props.stop.locationType !== 'STATION'
+      locationType !== 'STATION'
         ? stopTimetableHandler.stopPdfUrlResolver(
             this.context.config.URL.STOP_TIMETABLES[stopIdSplitted[0]],
             this.props.stop,
@@ -291,7 +291,9 @@ class Timetable extends React.Component {
         : null;
     const virtualMonitorUrl =
       this.context.config?.stopCard?.header?.virtualMonitorBaseUrl &&
-      `${this.context.config.stopCard.header.virtualMonitorBaseUrl}${this.props.stop.gtfsId}`;
+      `${
+        this.context.config.stopCard.header.virtualMonitorBaseUrl
+      }${locationType.toLowerCase()}/${this.props.stop.gtfsId}`;
     const timeTableRows = this.createTimeTableRows(timetableMap);
     const timeDifferenceDays = moment
       .duration(

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -719,4 +719,9 @@ export default {
       },
     },
   },
+  stopCard: {
+    header: {
+      virtualMonitorBaseUrl: 'https://omatnaytot.hsl.fi/',
+    },
+  },
 };

--- a/app/configurations/config.jyvaskyla.js
+++ b/app/configurations/config.jyvaskyla.js
@@ -154,7 +154,7 @@ export default configMerger(walttiConfig, {
 
   stopCard: {
     header: {
-      virtualMonitorBaseUrl: 'https://pysakit.jyvaskyla.fi/stop/',
+      virtualMonitorBaseUrl: 'https://pysakit.jyvaskyla.fi/',
     },
   },
   zones: {

--- a/app/configurations/config.tampere.js
+++ b/app/configurations/config.tampere.js
@@ -65,7 +65,7 @@ export default configMerger(walttiConfig, {
 
   stopCard: {
     header: {
-      virtualMonitorBaseUrl: 'https://tremonitori.digitransit.fi/stop/',
+      virtualMonitorBaseUrl: 'https://tremonitori.digitransit.fi/',
     },
   },
   zones: {


### PR DESCRIPTION
## Proposed Changes

  - Added a link to stop monitors in Timetable view
  - Enabled station links as well
  - modified virtualMonitorBaseUrl, so the code can handle stop / station links

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
