### PR TITLE
DT-5654 Fix SummaryPage regressions

### DIFF
--- a/app/component/ItinerarySummaryListContainer.js
+++ b/app/component/ItinerarySummaryListContainer.js
@@ -187,7 +187,7 @@ function ItinerarySummaryListContainer(
             />
           )}
         </div>
-        {onlyHasWalkingItineraries && (
+        {onlyHasWalkingItineraries && !showAlternativePlan && (
           <div className="summary-no-route-found" style={{ marginTop: 0 }}>
             <div
               className={cx('flex-horizontal', 'summary-notification', 'info')}

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -355,6 +355,7 @@ class SummaryPage extends React.Component {
     this.origin = undefined;
     this.destination = undefined;
     this.expandMap = 0;
+    this.allModesQueryDone = false;
 
     if (props.error) {
       reportError(props.error);
@@ -1108,6 +1109,7 @@ class SummaryPage extends React.Component {
           this.setLoading(false);
           this.isFetching = false;
           this.setParamsAndQuery();
+          this.allModesQueryDone = true;
         },
       );
     });
@@ -1519,7 +1521,13 @@ class SummaryPage extends React.Component {
           alternativePlan: undefined,
         },
         () => {
-          if (relevantRoutingSettingsChanged(this.context.config)) {
+          const hasNonWalkingItinerary = this.selectedPlan?.itineraries?.some(
+            itinerary => !itinerary.legs.every(leg => leg.mode === 'WALK'),
+          );
+          if (
+            relevantRoutingSettingsChanged(this.context.config) &&
+            hasNonWalkingItinerary
+          ) {
             this.makeQueryWithAllModes();
           }
         },
@@ -2080,7 +2088,7 @@ class SummaryPage extends React.Component {
     const walkDuration = this.getDuration(this.state.walkPlan);
     const bikeDuration = this.getDuration(this.state.bikePlan);
     const carDuration = this.getDuration(this.state.carPlan);
-    const parkAndRideDuration = this.getDuration(this.state.parkAndRide);
+    const parkAndRideDuration = this.getDuration(this.state.parkRidePlan);
     const bikeParkDuration = this.getDuration(this.state.bikeParkPlan);
     let bikeAndPublicDuration;
     if (this.context.config.includePublicWithBikePlan) {
@@ -2104,6 +2112,16 @@ class SummaryPage extends React.Component {
     }
     const min = Math.min(...plan.itineraries.map(itin => itin.duration));
     return min;
+  };
+
+  isLoading = (onlyWalkingItins, onlyWalkingAlternatives) => {
+    if (this.state.loading) {
+      return true;
+    }
+    if (!this.state.loading && onlyWalkingItins && onlyWalkingAlternatives) {
+      return true;
+    }
+    return false;
   };
 
   render() {
@@ -2394,7 +2412,12 @@ class SummaryPage extends React.Component {
       planHasNoItineraries && this.state.isFetchingWalkAndBike;
     if (this.props.breakpoint === 'large') {
       let content;
-      if (loadingPublicDone && !waitForBikeAndWalk()) {
+      if (
+        loadingPublicDone &&
+        !waitForBikeAndWalk() &&
+        (!onlyHasWalkingItineraries ||
+          (onlyHasWalkingItineraries && this.allModesQueryDone))
+      ) {
         const activeIndex =
           hash || getActiveIndex(match.location, combinedItineraries);
         const selectedItineraries = combinedItineraries;
@@ -2482,7 +2505,10 @@ class SummaryPage extends React.Component {
                 !onlyWalkingAlternatives
               }
               separatorPosition={this.state.separatorPosition}
-              loading={this.isFetching}
+              loading={this.isLoading(
+                onlyHasWalkingItineraries,
+                onlyWalkingAlternatives,
+              )}
               onLater={this.onLater}
               onEarlier={this.onEarlier}
               onDetailsTabFocused={() => {
@@ -2494,8 +2520,10 @@ class SummaryPage extends React.Component {
               }
               openSettingsModal={this.toggleCustomizeSearchOffcanvas}
               alternativePlan={this.state.alternativePlan}
-              driving={showCarOptionButton}
-              onlyHasWalkingItineraries={onlyHasWalkingItineraries}
+              driving={showCarOptionButton || showParkRideOptionButton}
+              onlyHasWalkingItineraries={
+                onlyHasWalkingItineraries && onlyWalkingAlternatives
+              }
             >
               {this.props.content &&
                 React.cloneElement(this.props.content, {
@@ -2702,7 +2730,10 @@ class SummaryPage extends React.Component {
                 !onlyWalkingAlternatives
               }
               separatorPosition={this.state.separatorPosition}
-              loading={this.isFetching}
+              loading={this.isLoading(
+                onlyHasWalkingItineraries,
+                onlyWalkingAlternatives,
+              )}
               onLater={this.onLater}
               onEarlier={this.onEarlier}
               onDetailsTabFocused={() => {
@@ -2714,7 +2745,7 @@ class SummaryPage extends React.Component {
               }
               openSettingsModal={this.toggleCustomizeSearchOffcanvas}
               alternativePlan={this.state.alternativePlan}
-              driving={showCarOptionButton}
+              driving={showCarOptionButton || showParkRideOptionButton}
             />
           </>
         );

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -2521,9 +2521,7 @@ class SummaryPage extends React.Component {
               openSettingsModal={this.toggleCustomizeSearchOffcanvas}
               alternativePlan={this.state.alternativePlan}
               driving={showCarOptionButton || showParkRideOptionButton}
-              onlyHasWalkingItineraries={
-                onlyHasWalkingItineraries && onlyWalkingAlternatives
-              }
+              onlyHasWalkingItineraries={onlyHasWalkingItineraries}
             >
               {this.props.content &&
                 React.cloneElement(this.props.content, {


### PR DESCRIPTION
## Proposed Changes

  - Don't show conflicting info messages (no showing alternative plans and "only walking routes were found" at the same time)
  - Don't make second allmodesquery if selected plan only consists of a walking itinerary
  - Fix isWalkingFastest(). There was a bug in determining the duration of park and ride. Also, consider park and ride as driving so the info message displays correctly. Example: previously if walking and park and ride were found, park and ride wasn't considered as driving --> "only walking itineraries found" was rendered, which is not true
  - isLoading() to determine when to render suggestions. If public itineraries are fetched but only walking itineraries are found, we need to wait to load alternative suggestions
  - Fix "only walking component" rendering logic
  - Make sure public itineraries are displayed right away IF not only walking itineraries are found

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
