### PR TITLE
improve fetch error handling

### DIFF
--- a/app/util/fetchUtils.js
+++ b/app/util/fetchUtils.js
@@ -105,7 +105,10 @@ export const retryFetch = async (
  */
 
 export const fetchWithLanguageAndSubscription = (URL, config, lang) => {
-  return fetch(addSubscriptionParam(addLocaleParam(URL, lang), config), {
-    headers: { 'Accept-Language': lang },
-  });
+  return fetchWithErrors(
+    addSubscriptionParam(addLocaleParam(URL, lang), config),
+    {
+      headers: { 'Accept-Language': lang },
+    },
+  );
 };

--- a/app/util/fetchUtils.js
+++ b/app/util/fetchUtils.js
@@ -1,3 +1,19 @@
+export class FetchError extends Error {}
+FetchError.prototype.name = 'FetchError';
+
+export const fetchWithErrors = async (url, options = {}) => {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    const error = new FetchError(`${res.url}: ${res.status} ${res.statusText}`);
+    error.reqUrl = url;
+    error.reqOptions = options;
+    error.res = res;
+    throw error;
+  }
+
+  return res;
+};
+
 const delay = ms =>
   new Promise(resolve => {
     setTimeout(() => {

--- a/app/util/xhrPromise.js
+++ b/app/util/xhrPromise.js
@@ -1,3 +1,5 @@
+import { fetchWithErrors } from './fetchUtils';
+
 function serialize(obj, prefix) {
   if (!obj) {
     return '';
@@ -17,7 +19,7 @@ function serialize(obj, prefix) {
 
 // Return Promise for a url json get request
 export function getJson(url, params) {
-  return fetch(
+  return fetchWithErrors(
     encodeURI(url) +
       (params ? (url.search(/\?/) === -1 ? '?' : '&') + serialize(params) : ''),
     {
@@ -33,7 +35,7 @@ export function getJson(url, params) {
 
 // Return Promise for a json post request
 export function postJson(url, params, payload) {
-  return fetch(
+  return fetchWithErrors(
     encodeURI(url) +
       (params ? (url.search(/\?/) === -1 ? '?' : '&') + serialize(params) : ''),
     {

--- a/test/unit/util/fetchUtil.test.js
+++ b/test/unit/util/fetchUtil.test.js
@@ -76,7 +76,8 @@ describe('retryFetch', () => {
           fetchMock.restore();
           done();
         },
-      );
+      )
+      .catch(done);
   });
 
   it('fetch with larger fetch timeout should take longer', done => {
@@ -121,42 +122,35 @@ describe('retryFetch', () => {
               done();
             },
           );
-      });
+      })
+      .catch(done);
   });
 
   it('fetch that gives 200 should not be retried', done => {
     fetchMock.get(testUrl, testJSONResponse);
     retryFetch(testUrl, {}, 5, 10)
       .then(res => res.json())
-      .then(
-        result => {
-          // calls has array of requests made to given URL
-          const calls = fetchMock.calls(
-            'https://dev-api.digitransit.fi/timetables/v1/hsl/routes/routes.json',
-          );
-          expect(calls.length).to.equal(1);
-          fetchMock.restore();
-          done();
-        },
-        err => {
-          assert.fail('No error should have been thrown');
-        },
-      );
+      .then(result => {
+        // calls has array of requests made to given URL
+        const calls = fetchMock.calls(
+          'https://dev-api.digitransit.fi/timetables/v1/hsl/routes/routes.json',
+        );
+        expect(calls.length).to.equal(1);
+        fetchMock.restore();
+        done();
+      })
+      .catch(done);
   });
 
   it('fetch that gives 200 should have correct result data', done => {
     fetchMock.get(testUrl, testJSONResponse);
     retryFetch(testUrl, {}, 5, 10)
       .then(res => res.json())
-      .then(
-        result => {
-          expect(result.test).to.equal(3);
-          fetchMock.restore();
-          done();
-        },
-        err => {
-          assert.fail('No error should have been thrown');
-        },
-      );
+      .then(result => {
+        expect(result.test).to.equal(3);
+        fetchMock.restore();
+        done();
+      })
+      .catch(done);
   });
 });


### PR DESCRIPTION
Currently, almost all places in the code base assume that

1. network requests are successful – They often fail because state is missing and also don't display an error message.
2. `fetch()` rejects on non-2xx responses, which is *not* the case.

## Proposed Changes

This PR introduces a helper function `fetchWithErrors` that rejects with a `FetchError` on non-2xx responses, and changes some of the network utility functions in the code base to use it.

## Pull Request Check List

- [x] A reasonable set of unit tests is included
- [ ] Console does not show new warnings/errors – It does show different (*the actual*) errors now.
- [ ] Changes are documented or they are self explanatory

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
