### PR TITLE
fix: show one alternative leg if no more are found

### DIFF
--- a/app/component/AlternativeLegsInfo.js
+++ b/app/component/AlternativeLegsInfo.js
@@ -7,39 +7,58 @@ import Icon from './Icon';
 import { isKeyboardSelectionEvent } from '../util/browser';
 
 const AlternativeLegsInfo = ({ legs, showAlternativeLegs, toggle }) => {
-  const message = (showAlternativeLegs && (
-    <FormattedMessage
-      className="alternative-leg-info"
-      id="itinerary-hide-alternative-legs"
-      defaultMessage="Hide alternative legs"
-    />
-  )) || (
-    <FormattedMessage
-      className="alternative-leg-info"
-      id="alternative-legs"
-      values={{
-        leg1: legs[0].route.shortName,
-        leg2: legs[1].route.shortName,
-        startTime1: (
-          <span
-            className={cx({ realtime: legs[0].realTime })}
-            style={{ fontWeight: 500 }}
-          >
-            {moment(legs[0].startTime).format('HH:mm')}
-          </span>
-        ),
-        startTime2: (
-          <span
-            className={cx({ realtime: legs[1].realTime })}
-            style={{ fontWeight: 500 }}
-          >
-            {moment(legs[1].startTime).format('HH:mm')}
-          </span>
-        ),
-      }}
-      defaultMessage="Also {leg1} at {startTime1} and {leg2} at {startTime2}"
-    />
-  );
+  const message =
+    (showAlternativeLegs && (
+      <FormattedMessage
+        className="alternative-leg-info"
+        id="itinerary-hide-alternative-legs"
+        defaultMessage="Hide alternative legs"
+      />
+    )) ||
+    (legs.length > 1 ? (
+      <FormattedMessage
+        className="alternative-leg-info"
+        id="alternative-legs"
+        values={{
+          leg1: legs[0].route.shortName,
+          leg2: legs[1].route.shortName,
+          startTime1: (
+            <span
+              className={cx({ realtime: legs[0].realTime })}
+              style={{ fontWeight: 500 }}
+            >
+              {moment(legs[0].startTime).format('HH:mm')}
+            </span>
+          ),
+          startTime2: (
+            <span
+              className={cx({ realtime: legs[1].realTime })}
+              style={{ fontWeight: 500 }}
+            >
+              {moment(legs[1].startTime).format('HH:mm')}
+            </span>
+          ),
+        }}
+        defaultMessage="Also {leg1} at {startTime1} and {leg2} at {startTime2}"
+      />
+    ) : (
+      <FormattedMessage
+        className="alternative-leg-info"
+        id="alternative-legs-single"
+        values={{
+          leg1: legs[0].route.shortName,
+          startTime1: (
+            <span
+              className={cx({ realtime: legs[0].realTime })}
+              style={{ fontWeight: 500 }}
+            >
+              {moment(legs[0].startTime).format('HH:mm')}
+            </span>
+          ),
+        }}
+        defaultMessage="Also {leg1} at {startTime1}"
+      />
+    ));
 
   return legs ? (
     <div

--- a/app/translations.js
+++ b/app/translations.js
@@ -862,6 +862,7 @@ const translations = {
     all: 'All',
     'alternative-legs':
       'Also {leg1} at {startTime1} and {leg2} at {startTime2}',
+    'alternative-legs-single': 'Also {leg1} at {startTime1}',
     'aria-itinerary-summary':
       'Total journey time {duration}. Departing at {inFuture} {departureTime} and arriving at {arrivalTime}',
     'aria-itinerary-summary-bike-distance':
@@ -1990,6 +1991,7 @@ const translations = {
     all: 'Kaikki',
     'alternative-legs':
       'Myös {leg1} klo {startTime1} ja {leg2} klo {startTime2}',
+    'alternative-legs-single': 'Myös {leg1} klo {startTime1}',
     'aria-itinerary-summary':
       'Matkan kokonaiskesto {duration}. Lähtö {inFuture} kello {departureTime}. Perillä kello {arrivalTime}.',
     'aria-itinerary-summary-bike-distance':
@@ -3915,6 +3917,7 @@ const translations = {
     all: 'Allt',
     'alternative-legs':
       'Också {leg1} kl. {startTime1} och {leg2} kl.{startTime2}',
+    'alternative-legs-single': 'Också {leg1} kl. {startTime1}',
     'aria-itinerary-summary':
       'Den totala restiden {duration}. Avgång {inFuture} klockan {departureTime}. Framme klockan {arrivalTime}',
     'aria-itinerary-summary-bike-distance':


### PR DESCRIPTION
## Proposed Changes

  - Fixes a crash in AlternativeLegsInfo by checking the number of alternative legs returned and adapting the rendered message accordingly

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
