### PR TITLE
refactor: use OTP_URL instead of SERVER_ROOT

### DIFF
--- a/build/generate-schema.js
+++ b/build/generate-schema.js
@@ -22,9 +22,8 @@ const copySchema = (src, dest) => {
 };
 
 fetch(
-  `${
-    process.env.SERVER_ROOT || 'https://dev-api.digitransit.fi/routing/v2'
-  }/routers/hsl/index/graphql`,
+  process.env.OTP_URL ||
+    'https://dev-api.digitransit.fi/routing/v2/routers/hsl/index/graphql',
   {
     method: 'post',
     headers: {

--- a/docs/GraphQL.md
+++ b/docs/GraphQL.md
@@ -4,11 +4,11 @@
   `cd build; node generate-schema.js`
 
   If you need to fetch the schema from some non-default location, `SCHEMA_SRC` changes
-  the URL or filepath for the schema file in graphls format and `SERVER_ROOT` fetches json format
+  the URL or filepath for the schema file in graphls format and `OTP_URL` fetches json format
   schema from a running OTP instance:
 
-  `cd build; SCHEMA_SRC=where-schema-file-is-located SERVER_ROOT=http://your-otp-host node generate-schema.js`
+  `cd build; SCHEMA_SRC=where-schema-file-is-located OTP_URL=http://your-otp-host/routers/hsl/index/graphql node generate-schema.js`
 
   When running otp in localhost, this usually translates to something like:
 
-  `cd build; SCHEMA_SRC=~/OpenTripPlanner/src/ext/resources/legacygraphqlapi/schema.graphqls SERVER_ROOT=http://localhost:8080/otp node generate-schema.js`
+  `cd build; SCHEMA_SRC=~/OpenTripPlanner/src/ext/resources/legacygraphqlapi/schema.graphqls OTP_URL=http://localhost:8080/otp/routers/hsl/index/graphql node generate-schema.js`


### PR DESCRIPTION
Makes it possible to use OTP servers that don't run under /routers/hsl/index/graphql.

## Proposed Changes

In generate-schema.js the URL of the OTP server was previously generated by adding the suffix `/routers/hsl/index/graphql` to `SERVER_ROOT`.

This commit replaces all usages of the `SERVER_ROOT` variable with `OTP_URL`. `OTP_URL` is already being used in the same manner in the client configuration files.

After this changeset, it is possible to specify OTP servers that don't use the "hsl" router by specifying e.g. `OTP_URL=http://localhost:8080/otp/routers/default/index/graphql`.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
