### PR TITLE
Do not try fetching favourites if user is not logged in

### DIFF
--- a/app/action/FavouriteActions.js
+++ b/app/action/FavouriteActions.js
@@ -1,6 +1,14 @@
 import { addMessage } from './MessageActions';
 import { failedFavouriteMessage, favouriteTypes } from '../util/messageUtils';
 
+export function fetchFavourites(actionContext) {
+  actionContext.dispatch('FetchFavourites');
+}
+
+export function fetchFavouritesComplete(actionContext) {
+  actionContext.dispatch('FetchFavouritesComplete');
+}
+
 export function saveFavourite(actionContext, data) {
   const favouriteType =
     typeof data === 'object' && favouriteTypes.includes(data.type)

--- a/app/component/TopLevel.js
+++ b/app/component/TopLevel.js
@@ -18,6 +18,10 @@ import ErrorBoundary from './ErrorBoundary';
 import { DesktopOrMobile } from '../util/withBreakpoint';
 import { getUser } from '../util/apiUtils';
 import setUser from '../action/userActions';
+import {
+  fetchFavourites,
+  fetchFavouritesComplete,
+} from '../action/FavouriteActions';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
 
 class TopLevel extends React.Component {
@@ -69,9 +73,11 @@ class TopLevel extends React.Component {
           this.context.executeAction(setUser, {
             ...user,
           });
+          this.context.executeAction(fetchFavourites);
         })
         .catch(() => {
           this.context.executeAction(setUser, { notLogged: true });
+          this.context.executeAction(fetchFavouritesComplete);
         });
     }
   }

--- a/app/component/map/non-tile-layer/TransitLegMarkers.js
+++ b/app/component/map/non-tile-layer/TransitLegMarkers.js
@@ -212,7 +212,7 @@ class TransitLegMarkers extends React.Component {
     return `${this.context.intl.formatMessage({
       id: 'transfer',
       defaultMessage: 'Transfer',
-    })}: ${duration}min`;
+    })}: ${duration} min`;
   }
 
   componentDidMount() {

--- a/app/store/FavouriteStore.js
+++ b/app/store/FavouriteStore.js
@@ -42,28 +42,10 @@ export default class FavouriteStore extends Store {
   constructor(dispatcher) {
     super(dispatcher);
     this.config = dispatcher.getContext().config;
-    this.fetchingOrUpdating();
-    if (this.config.allowLogin) {
-      getFavourites()
-        .then(res => {
-          if (this.config.allowFavouritesFromLocalstorage) {
-            this.mergeWithLocalstorage(res);
-          } else {
-            this.favourites = res;
-            this.fetchComplete();
-          }
-        })
-        .catch(() => {
-          if (this.config.allowFavouritesFromLocalstorage) {
-            this.favourites = getFavouriteStorage();
-            this.fetchComplete();
-          } else {
-            this.fetchFailed();
-          }
-        });
-    } else {
+    if (!this.config.allowLogin) {
       this.favourites = getFavouriteStorage();
-      this.fetchComplete();
+    } else {
+      this.status = FavouriteStore.STATUS_FETCHING_OR_UPDATING;
     }
     // this.migrateRoutes();
     // this.migrateStops();
@@ -83,6 +65,27 @@ export default class FavouriteStore extends Store {
   fetchFailed() {
     this.status = FavouriteStore.FETCH_FAILED;
     this.emitChange();
+  }
+
+  fetchFavourites() {
+    this.fetchingOrUpdating();
+    getFavourites()
+      .then(res => {
+        if (this.config.allowFavouritesFromLocalstorage) {
+          this.mergeWithLocalstorage(res);
+        } else {
+          this.favourites = res;
+          this.fetchComplete();
+        }
+      })
+      .catch(() => {
+        if (this.config.allowFavouritesFromLocalstorage) {
+          this.favourites = getFavouriteStorage();
+          this.fetchComplete();
+        } else {
+          this.fetchFailed();
+        }
+      });
   }
 
   getStatus() {
@@ -392,5 +395,7 @@ export default class FavouriteStore extends Store {
     SaveFavourite: 'saveFavourite',
     UpdateFavourites: 'updateFavourites',
     DeleteFavourite: 'deleteFavourite',
+    FetchFavourites: 'fetchFavourites',
+    FetchFavouritesComplete: 'fetchComplete',
   };
 }

--- a/app/translations.js
+++ b/app/translations.js
@@ -4635,7 +4635,7 @@ const translations = {
     'track-short-no-num': 'Spår',
     tram: 'Spårvagn',
     'tram-with-route-number': 'Spårvagn {routeNumber} {headSign}',
-    transfer: 'Byten',
+    transfer: 'Byte',
     transfers: 'Antal byten',
     'transfers-allowed': 'Flera byten',
     'transfers-margin': 'Bytestid minst',


### PR DESCRIPTION
Currently every browsing session of HSL journey planner creates a 403 error, if user is not logged in.  This adds unnecessary error noise and network traffic.

This pull request moves favourite fetching from the store constructor to an explicit fetch call which happens after the user login state has been checked.

A minor translation error fixed, too.