### PR TITLE
fix: don't override theme colors with values from hsl theme

### DIFF
--- a/app/component/itinerary.scss
+++ b/app/component/itinerary.scss
@@ -1,5 +1,4 @@
 @charset "UTF-8";
-@import "../../sass/themes/hsl/theme";
 
 $topbar-height: 40px;
 $itinerary-tab-switch-height: 48px;
@@ -2406,7 +2405,7 @@ $font-print-decrease: 0.7;
   width: 60%;
   border-radius: 50vh;
   padding: 5px;
-  color:  $hsl-blue;
+  color:  $primary-color;
   border: 1px solid #888;
   text-align: center;
   text-decoration: none;


### PR DESCRIPTION
I noticed two things:

## 1)  Some theme colors get lost

The import of `@import "../../sass/themes/hsl/theme";` in `itinerary.scss` results in some theme colors being overridden by the HSL theme values.

With the above import line, notice how some text and icons are in the `$hsl-blue: #007ac9` color:

![image](https://user-images.githubusercontent.com/73987547/229797143-ee574367-4b58-4d1a-99e4-3f48fbb75fbb.png)

Without the above import, the green of the current theme is being used:

![image](https://user-images.githubusercontent.com/73987547/229797271-b7bbe443-d0c6-4b59-acf8-689e3c08fbe8.png)

This can be resolved by removing (or changing) the import line.

## 2) HSL theme specific variable added

A HSL theme specific style variable is being used inside `.routing-feedback-link`.

```scss
  color:  $hsl-blue;
```

I think it is better to use theme independent style variables.

As the HSL theme sets the `$primary-color` to `$hsl-blue`, we can also use `$primary-color` and get the same color.
