### PR TITLE
DT-5648 WalttiOpas realtime fixed, changing stop in near you map shows vehicles for the new stop

### DIFF
--- a/app/component/map/StopsNearYouMap.js
+++ b/app/component/map/StopsNearYouMap.js
@@ -57,13 +57,10 @@ const handleStopsAndStations = edges => {
 
 const getRealTimeSettings = (routes, context) => {
   const { realTime } = context.config;
-  let agency;
   /* handle multiple feedid case */
-  context.config.feedIds.forEach(ag => {
-    if (!agency && realTime[ag]) {
-      agency = ag;
-    }
-  });
+  const agency = context.config.feedIds.find(
+    ag => realTime[ag] && routes[0].feedId === ag,
+  );
   const source = agency && realTime[agency];
   if (source && source.active && routes.length > 0) {
     return {
@@ -166,7 +163,7 @@ function StopsNearYouMap(
     isFetching: false,
     stop: null,
   });
-  const prevMode = useRef();
+  const prevPlace = useRef();
   const { mode } = match.params;
   const isTransitMode = mode !== 'CITYBIKE';
   const walkRoutingThreshold =
@@ -259,7 +256,7 @@ function StopsNearYouMap(
     }
   };
   useEffect(() => {
-    prevMode.current = match.params.mode;
+    prevPlace.current = match.params.place;
     return function cleanup() {
       stopClient(context);
     };
@@ -314,9 +311,9 @@ function StopsNearYouMap(
       if (!clientOn) {
         startClient(context, uniqueRealtimeTopics);
         setClientOn(true);
-      } else if (match.params.mode !== prevMode.current) {
+      } else if (match.params.place !== prevPlace.current) {
         updateClient(context, uniqueRealtimeTopics);
-        prevMode.current = match.params.mode;
+        prevPlace.current = match.params.place;
       }
     }
   }, [uniqueRealtimeTopics]);

--- a/app/component/map/StopsNearYouMap.js
+++ b/app/component/map/StopsNearYouMap.js
@@ -164,6 +164,7 @@ function StopsNearYouMap(
     stop: null,
   });
   const prevPlace = useRef();
+  const prevMode = useRef();
   const { mode } = match.params;
   const isTransitMode = mode !== 'CITYBIKE';
   const walkRoutingThreshold =
@@ -257,6 +258,7 @@ function StopsNearYouMap(
   };
   useEffect(() => {
     prevPlace.current = match.params.place;
+    prevMode.current = match.params.mode;
     return function cleanup() {
       stopClient(context);
     };
@@ -311,9 +313,13 @@ function StopsNearYouMap(
       if (!clientOn) {
         startClient(context, uniqueRealtimeTopics);
         setClientOn(true);
-      } else if (match.params.place !== prevPlace.current) {
+      } else if (
+        match.params.place !== prevPlace.current ||
+        match.params.mode !== prevMode.current
+      ) {
         updateClient(context, uniqueRealtimeTopics);
         prevPlace.current = match.params.place;
+        prevMode.current = match.params.mode;
       }
     }
   }, [uniqueRealtimeTopics]);

--- a/app/configurations/config.walttiOpas.js
+++ b/app/configurations/config.walttiOpas.js
@@ -44,9 +44,9 @@ export default configMerger(walttiConfig, {
       availableForSelection: true,
       defaultValue: true,
       nearYouLabel: {
-        fi: 'Lähipysäkit kartalla',
-        sv: 'Hållplatser på kartan',
-        en: 'Nearby stops on map',
+        fi: 'Bussit ja lähipysäkit kartalla',
+        sv: 'Bussar och hållplatser på kartan',
+        en: 'Buses and nearby stops on map',
       },
     },
   },

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.10.0",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.9.4",
     "@digitransit-component/digitransit-component-icon": "^0.2.0",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.2.6",

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.9.4",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.10.0",
     "@digitransit-component/digitransit-component-icon": "^0.2.0",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.2.6",

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.9.4",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.9.5",
     "@digitransit-component/digitransit-component-icon": "^0.2.0",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.2.6",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.9.4",
+  "version": "1.10.0",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.10.0",
+  "version": "1.9.4",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -269,7 +269,7 @@ class DTAutosuggest extends React.Component {
     mobileLabel: PropTypes.string,
     lock: PropTypes.func.isRequired,
     unlock: PropTypes.func.isRequired,
-    refPoint: PropTypes.object,
+    refPoint: PropTypes.string,
     inputClassName: PropTypes.string,
     fontWeights: PropTypes.shape({
       medium: PropTypes.number,

--- a/digitransit-component/packages/digitransit-component-suggestion-item/src/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/src/helpers/styles.scss
@@ -5,7 +5,7 @@
 
 .suggestion-item-container {
   display: flex;
-  min-height: 25;
+  min-height: 25px;
   &.futureroute {
     min-height: 79px;
   }

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -14,8 +14,8 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.9.4",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^2.0.0",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.9.5",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^2.0.1",
     "@digitransit-component/digitransit-component-control-panel": "^1.1.1",
     "@digitransit-component/digitransit-component-favourite-bar": "1.1.1",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^1.1.2",

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -14,7 +14,7 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.9.4",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.10.0",
     "@digitransit-component/digitransit-component-autosuggest-panel": "^2.0.0",
     "@digitransit-component/digitransit-component-control-panel": "^1.1.1",
     "@digitransit-component/digitransit-component-favourite-bar": "1.1.1",

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -14,7 +14,7 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.10.0",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.9.4",
     "@digitransit-component/digitransit-component-autosuggest-panel": "^2.0.0",
     "@digitransit-component/digitransit-component-control-panel": "^1.1.1",
     "@digitransit-component/digitransit-component-favourite-bar": "1.1.1",

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -5,9 +5,9 @@
 
 You need [Node](https://nodejs.org/), [Yarn](https://yarnpkg.com) (or npm) and watchman.
 
-- `node -v` should be >= 12.x
+- `node -v` should be >= 12.x (version 12.22.12 is known to work)
   - We recommend that you use [`nvm`](https://github.com/nvm-sh/nvm) to install a specific Node.js version. Optionally, you can also set up [its automatic version switching shell integration](https://github.com/nvm-sh/nvm/tree/e6fa80cb6178ff4e9735265281b5eae811f05f11#deeper-shell-integration).
-- `yarn --version` should be >= 1.22.0. The project will then use yarn 2 from the included file. (or `npm -v` should be >= 3)
+- `yarn --version` should be >= 1.22.0. (version 1.22.0 is known to work) The project will then use yarn 2 from the included file. (or `npm -v` should be >= 3)
 
 You also need a C compiler:
 - Linux: GCC 4.6 or later
@@ -34,6 +34,7 @@ or in some systems to build the binaries from code following
 
 ## Installation
 - `yarn install && yarn setup`
+- yarn install may require ignoring engines `yarn install --ignore-engines`
 
 ## Start development version
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -7,7 +7,7 @@ You need [Node](https://nodejs.org/), [Yarn](https://yarnpkg.com) (or npm) and w
 
 - `node -v` should be >= 12.x (version 12.22.12 is known to work)
   - We recommend that you use [`nvm`](https://github.com/nvm-sh/nvm) to install a specific Node.js version. Optionally, you can also set up [its automatic version switching shell integration](https://github.com/nvm-sh/nvm/tree/e6fa80cb6178ff4e9735265281b5eae811f05f11#deeper-shell-integration).
-- `yarn --version` should be >= 1.22.0. (version 1.22.0 is known to work) The project will then use yarn 2 from the included file. (or `npm -v` should be >= 3)
+- `yarn --version` should be >= 1.22.0 (version 1.22.0 is known to work). The project will then use yarn 2 from the included file. (or `npm -v` should be >= 3)
 
 You also need a C compiler:
 - Linux: GCC 4.6 or later
@@ -34,7 +34,7 @@ or in some systems to build the binaries from code following
 
 ## Installation
 - `yarn install && yarn setup`
-- yarn install may require ignoring engines `yarn install --ignore-engines`
+- yarn install may require ignoring engines: `yarn install --ignore-engines`
 
 ## Start development version
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -7,7 +7,7 @@ You need [Node](https://nodejs.org/), [Yarn](https://yarnpkg.com) (or npm) and w
 
 - `node -v` should be >= 12.x (version 12.22.12 is known to work)
   - We recommend that you use [`nvm`](https://github.com/nvm-sh/nvm) to install a specific Node.js version. Optionally, you can also set up [its automatic version switching shell integration](https://github.com/nvm-sh/nvm/tree/e6fa80cb6178ff4e9735265281b5eae811f05f11#deeper-shell-integration).
-- `yarn --version` should be >= 1.22.0 (version 1.22.0 is known to work). The project will then use yarn 2 from the included file. (or `npm -v` should be >= 3)
+- `yarn --version` should be > 1.22.0 (version 2.4.1 is known to work). The project will then use yarn 2 from the included file. (or `npm -v` should be >= 3)
 
 You also need a C compiler:
 - Linux: GCC 4.6 or later
@@ -34,7 +34,6 @@ or in some systems to build the binaries from code following
 
 ## Installation
 - `yarn install && yarn setup`
-- yarn install may require ignoring engines: `yarn install --ignore-engines`
 
 ## Start development version
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1819,11 +1819,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@^2.0.0, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@^2.0.1, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^1.9.4
+    "@digitransit-component/digitransit-component-autosuggest": ^1.9.5
     "@digitransit-component/digitransit-component-icon": ^0.2.0
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.2.6
@@ -1839,7 +1839,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@^1.9.4, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@^1.9.5, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
@@ -2016,8 +2016,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^1.9.4
-    "@digitransit-component/digitransit-component-autosuggest-panel": ^2.0.0
+    "@digitransit-component/digitransit-component-autosuggest": ^1.9.5
+    "@digitransit-component/digitransit-component-autosuggest-panel": ^2.0.1
     "@digitransit-component/digitransit-component-control-panel": ^1.1.1
     "@digitransit-component/digitransit-component-favourite-bar": 1.1.1
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^1.1.2
@@ -2863,6 +2863,13 @@ __metadata:
   version: 0.1.5
   resolution: "@hsl-fi/content-delivery-api-types@npm:0.1.5"
   checksum: b70c59cd8f01f7e34cc54adc2106c0778f4fdbe156ee808fa2bb3a41dd7ccd2ceaf632ef5d2f9315b19ad0a71cb168ab5c8f8169d720b5465b0664e1198889cc
+  languageName: node
+  linkType: hard
+
+"@hsl-fi/cookies@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@hsl-fi/cookies@npm:1.0.0"
+  checksum: ca1552e18401e77ee417f37f3e0a01b156a7f6fa05bde87a1d3c979f7e80e620c0f7aa341923eee18ca220e60eb1b6b85f850df4ba18e3823e5c4155a8ed3c7d
   languageName: node
   linkType: hard
 
@@ -10171,6 +10178,7 @@ __metadata:
     "@commitlint/cli": 9.1.2
     "@commitlint/config-conventional": 9.1.2
     "@hsl-fi/container-spinner": 0.3.1
+    "@hsl-fi/cookies": 1.0.0
     "@hsl-fi/hooks": 1.2.0
     "@hsl-fi/modal": " ^0.3.1"
     "@hsl-fi/sass": " ^0.2.0"


### PR DESCRIPTION
## Proposed Changes

  - When there are multiple feedIDs, the selection is done based on the feedID of the first route on the list of routes. In WalttiOpas it is possible to change between stops in areas far from each other where the feedIDs can be different. 
  - Updating the mqtt client is done whenever the place changes as different stops are related to different vehicles. This fixes an issue where changing the stop moves the map to a new location but still shows the vehicles of the previous stop. 
  - Minor fixes on units and variable types based on the prints in the console.
  - Installation instructions updated with versions that are known to work. Also, removed yarn version 1.22.0 from the recommendations as it is now known not to work correctly (issues with tests crashing).  

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
