### PR TITLE
chore: add Raasepori to walttiOpas DT-5864

### DIFF
--- a/app/configurations/config.walttiOpas.js
+++ b/app/configurations/config.walttiOpas.js
@@ -61,7 +61,7 @@ export default configMerger(walttiConfig, {
   // Navbar logo
   logo: 'walttiOpas/waltti-logo.png',
 
-  feedIds: ['Salo', 'Kajaani'],
+  feedIds: ['Salo', 'Kajaani', 'Raasepori'],
 
   defaultEndpoint: {
     address: 'Helsinki-Vantaan Lentoasema',
@@ -167,6 +167,11 @@ export default configMerger(walttiConfig, {
       sv: 'Salo',
       en: 'Salo',
     },
+    Raasepori: {
+      fi: 'Raasepori',
+      sv: 'Raasepori',
+      en: 'Raasepori',
+    }
   },
 
   useSearchPolygon: true,
@@ -181,9 +186,13 @@ export default configMerger(walttiConfig, {
     [29.2, 64.1],
     [28.7, 63.9],
     [28.1, 63.8],
-    // Salo:
+    // Salo + Raasepori:
     [23.1, 60.6],
-    [23.7, 60.2],
+    [23.898, 60.207],
+    [23.942, 60.129],
+    [23.836, 59.980],
+    [23.847, 59.892],
+    [23.581, 59.796],
     [22.8, 59.9],
     [22.7, 60.4],
     [23.1, 60.6],


### PR DESCRIPTION
## Proposed Changes

  - Extend Salo geocoding polygon to include Raasepori (they're practically adjacent), add new feedId

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
