### PR TITLE
DT-5787 Empty error message box

### DIFF
--- a/app/component/ItinerarySummaryListContainer/ItinerarySummaryListContainer.js
+++ b/app/component/ItinerarySummaryListContainer/ItinerarySummaryListContainer.js
@@ -4,13 +4,6 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { FormattedMessage } from 'react-intl';
 import cx from 'classnames';
 import { matchShape } from 'found';
-
-import isEqual from 'lodash/isEqual';
-import {
-  getCurrentSettings,
-  getDefaultSettings,
-} from '../../util/planParamUtil';
-
 import Icon from '../Icon';
 import SummaryRow from '../SummaryRow';
 import { isBrowser } from '../../util/browser';
@@ -267,11 +260,6 @@ function ItinerarySummaryListContainer(
     }
   }
 
-  const hasSettingsChanges = !isEqual(
-    getCurrentSettings(config),
-    getDefaultSettings(config),
-  );
-
   return (
     <ItinerarySummaryMessage
       areaPolygon={config.areaPolygon}
@@ -287,7 +275,6 @@ function ItinerarySummaryListContainer(
       currentTime={currentTime}
       to={to}
       walking={walking}
-      hasSettingsChanges={hasSettingsChanges}
     />
   );
 }
@@ -330,6 +317,7 @@ ItinerarySummaryListContainer.defaultProps = {
   loadingMoreItineraries: undefined,
   routingErrors: [],
   routingFeedbackPosition: undefined,
+  onlyHasWalkingItineraries: false,
 };
 
 ItinerarySummaryListContainer.contextTypes = {

--- a/app/component/ItinerarySummaryListContainer/components/ItinerarySummaryMessage.js
+++ b/app/component/ItinerarySummaryListContainer/components/ItinerarySummaryMessage.js
@@ -39,7 +39,6 @@ const ItinerarySummaryMessage = (
     to,
     walking,
     routingErrors,
-    hasSettingsChanges,
   },
   context,
 ) => {
@@ -52,7 +51,6 @@ const ItinerarySummaryMessage = (
     minDistanceBetweenFromAndTo,
     error,
     currentTime,
-    hasSettingsChanges,
   };
   const errorMessageIds = findErrorMessageIds(
     routingErrors,
@@ -107,7 +105,6 @@ ItinerarySummaryMessage.propTypes = {
   to: LocationShape.isRequired,
   walking: PropTypes.bool,
   routingErrors: PropTypes.arrayOf(RoutingErrorShape),
-  hasSettingsChanges: PropTypes.bool,
 };
 
 ItinerarySummaryMessage.defaultProps = {
@@ -118,7 +115,6 @@ ItinerarySummaryMessage.defaultProps = {
   minDistanceBetweenFromAndTo: 0,
   walking: false,
   routingErrors: [],
-  hasSettingsChanges: false,
 };
 
 ItinerarySummaryMessage.contextTypes = {

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -2102,6 +2102,7 @@ class SummaryPage extends React.Component {
       bikeAndPublicDuration = this.getDuration(this.state.bikeAndPublicPlan);
     }
     if (
+      !walkDuration ||
       (bikeDuration && bikeDuration < walkDuration) ||
       (carDuration && carDuration < walkDuration) ||
       (parkAndRideDuration && parkAndRideDuration < walkDuration) ||

--- a/test/unit/util/findErrorMessageIds.test.js
+++ b/test/unit/util/findErrorMessageIds.test.js
@@ -95,7 +95,7 @@ describe('findErrorMessageIds', () => {
           },
         },
       );
-      expect(msgIds2.length).to.equal(0);
+      expect(msgIds2).to.not.equal('no-route-already-at-destination');
     });
 
     it('should return no-route-origin-same-as-destination', () => {


### PR DESCRIPTION
## Proposed Changes

  - Show generic "check the search settings" message when there are no itineraries and the situation does not match any other error message (and there are no routing error messages).
  - Check for the setting changes removed, as the error is unrelated to the "change" of settings and rather just related to the settings being unfavourable in general. (The error message was not shown to someone who managed to get empty results on the first try, because the settings did not change.)
  - Some refactoring to clarify the error situations and related messages.
  - Test fixed to reflect that the "already at destination" message is not given incorrectly. 

Another minor issue fixed:
  - When calculating whether walking is the fastest option, also check if a walking duration actually exists. This is because in some cases the distance was great (like 50km) and there was no walking itineraries but there was still a message after the transport itineraries suggesting that walking would be the fastest option. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
