### PR TITLE
fix: refpoint typing, incorrect origin value

### DIFF
--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -84,11 +84,6 @@ class StopsNearYouPage extends React.Component {
     favouriteBikeStationIds: PropTypes.arrayOf(PropTypes.string),
     mapLayers: mapLayerShape.isRequired,
     favouritesFetched: PropTypes.bool,
-    originFromStore: PropTypes.shape({
-      address: PropTypes.string,
-      lat: PropTypes.number,
-      lon: PropTypes.number,
-    }),
   };
 
   static defaultProps = {
@@ -96,7 +91,6 @@ class StopsNearYouPage extends React.Component {
     favouriteStationIds: [],
     favouriteBikeStationIds: [],
     favouritesFetched: false,
-    originFromStore: {},
   };
 
   constructor(props) {
@@ -507,7 +501,7 @@ class StopsNearYouPage extends React.Component {
                       mode={nearByStopMode}
                       breakpoint={this.props.breakpoint}
                       lang={this.props.lang}
-                      origin={this.props.originFromStore}
+                      origin={this.state.searchPosition}
                     />
                   )}
                   {this.state.showCityBikeTeaser &&
@@ -997,7 +991,6 @@ const PositioningWrapper = connectToStores(
         .map(station => station.stationId);
     }
     const status = context.getStore('FavouriteStore').getStatus();
-    const originFromStore = context.getStore('OriginStore').getOrigin();
     return {
       ...props,
       position: context.getStore('PositionStore').getLocationState(),
@@ -1009,7 +1002,6 @@ const PositioningWrapper = connectToStores(
       favouriteBikeStationIds,
       favouriteStationIds,
       favouritesFetched: status !== FavouriteStore.STATUS_FETCHING_OR_UPDATING,
-      originFromStore,
     };
   },
 );

--- a/app/component/StopsNearYouSearch.js
+++ b/app/component/StopsNearYouSearch.js
@@ -10,7 +10,10 @@ import { getStopRoutePath } from '../util/path';
 const DTAutoSuggestWithSearchContext = withSearchContext(DTAutoSuggest);
 const searchSources = ['Favourite', 'History', 'Datasource'];
 
-function StopsNearYouSearch({ mode, breakpoint, lang }, { router, config }) {
+function StopsNearYouSearch(
+  { mode, breakpoint, lang, originLocation },
+  { router, config },
+) {
   const isMobile = breakpoint !== 'large';
   const transportMode = `route-${mode}`;
 
@@ -30,7 +33,7 @@ function StopsNearYouSearch({ mode, breakpoint, lang }, { router, config }) {
           icon="search"
           id="stop-route-station"
           lang={lang}
-          refPoint={origin}
+          refPoint={originLocation}
           className="destination"
           placeholder={`stop-near-you-${mode.toLowerCase()}`}
           transportMode={transportMode}
@@ -56,6 +59,15 @@ StopsNearYouSearch.propTypes = {
   mode: PropTypes.string.isRequired,
   breakpoint: PropTypes.string.isRequired,
   lang: PropTypes.string.isRequired,
+  originLocation: PropTypes.shape({
+    address: PropTypes.string,
+    lat: PropTypes.number,
+    lon: PropTypes.number,
+  }),
+};
+
+StopsNearYouSearch.defaultProps = {
+  originLocation: {},
 };
 
 StopsNearYouSearch.contextTypes = {

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.9.5",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.9.6",
     "@digitransit-component/digitransit-component-icon": "^0.2.0",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.2.6",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -269,7 +269,11 @@ class DTAutosuggest extends React.Component {
     mobileLabel: PropTypes.string,
     lock: PropTypes.func.isRequired,
     unlock: PropTypes.func.isRequired,
-    refPoint: PropTypes.string,
+    refPoint: PropTypes.shape({
+      address: PropTypes.string,
+      lat: PropTypes.number,
+      lon: PropTypes.number,
+    }),
     inputClassName: PropTypes.string,
     fontWeights: PropTypes.shape({
       medium: PropTypes.number,
@@ -317,6 +321,7 @@ class DTAutosuggest extends React.Component {
     required: false,
     modeSet: undefined,
     showScroll: false,
+    refPoint: {},
   };
 
   constructor(props) {

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -14,8 +14,8 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^1.9.5",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^2.0.1",
+    "@digitransit-component/digitransit-component-autosuggest": "^1.9.6",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^2.0.2",
     "@digitransit-component/digitransit-component-control-panel": "^1.1.1",
     "@digitransit-component/digitransit-component-favourite-bar": "1.1.1",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1819,11 +1819,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@^2.0.1, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@^2.0.2, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^1.9.5
+    "@digitransit-component/digitransit-component-autosuggest": ^1.9.6
     "@digitransit-component/digitransit-component-icon": ^0.2.0
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.2.6
@@ -1839,7 +1839,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@^1.9.5, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@^1.9.6, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
@@ -2016,8 +2016,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^1.9.5
-    "@digitransit-component/digitransit-component-autosuggest-panel": ^2.0.1
+    "@digitransit-component/digitransit-component-autosuggest": ^1.9.6
+    "@digitransit-component/digitransit-component-autosuggest-panel": ^2.0.2
     "@digitransit-component/digitransit-component-control-panel": ^1.1.1
     "@digitransit-component/digitransit-component-favourite-bar": 1.1.1
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^1.1.2


### PR DESCRIPTION
## Proposed Changes

  - Autosuggest library refpoint changed to object as it handles it like an object. 
  - The origin string sent from stopsnearyou was not a location origin, but the browser origin. Changed the stopsnearyou to use the location origin from the store. Renamed the other 'origin' variable in the class for clarity. 
  - Specified types and default values.
  - Updated the library versions.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
