### PR TITLE
DT-5614 Fix speech bubble location and text for transfers after interlining

### DIFF
--- a/app/component/map/ItineraryLine.js
+++ b/app/component/map/ItineraryLine.js
@@ -81,6 +81,7 @@ class ItineraryLine extends React.Component {
 
       const geometry = polyUtil.decode(leg.legGeometry.points);
       let middle = getMiddleOf(geometry);
+      let { to, endTime } = leg;
 
       if (interliningLegs.length > 0) {
         // merge the geometries of legs where user can wait in the vehicle and find the middle point
@@ -90,6 +91,8 @@ class ItineraryLine extends React.Component {
           .flat();
         const interlinedGeometry = [...geometry, ...points];
         middle = getMiddleOf(interlinedGeometry);
+        to = interliningLegs[interliningLegs.length - 1].to;
+        endTime = interliningLegs[interliningLegs.length - 1].endTime;
       }
 
       objs.push(
@@ -173,6 +176,8 @@ class ItineraryLine extends React.Component {
             if (!leg?.interlineWithPreviousLeg) {
               transitLegs.push({
                 ...leg,
+                to,
+                endTime,
                 nextLeg,
                 index: i,
                 mode: mode.toLowerCase(),


### PR DESCRIPTION
## Proposed Changes

  - Fixes an issue where a transfer speech bubble was shown on the map at the end of the first leg of an interlining trip instead at the end stop of the last leg of the interlining trip. Also the transfer time was wrong. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
