### PR TITLE
fix: dt-5833 allModesQuery made when expected

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -349,7 +349,7 @@ class SummaryPage extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.isFetching = false;
-    this.secondQuerySent = false;
+    this.walkBikeQuerySent = false;
     this.setParamsAndQuery();
     this.originalPlan = this.props.viewer && this.props.viewer.plan;
     this.origin = undefined;
@@ -1444,7 +1444,7 @@ class SummaryPage extends React.Component {
       this.props.viewer &&
       this.props.viewer.plan &&
       this.props.viewer.plan.itineraries &&
-      !this.secondQuerySent
+      !this.walkBikeQuerySent
     ) {
       this.showScreenreaderLoadedAlert();
     }
@@ -1491,12 +1491,13 @@ class SummaryPage extends React.Component {
         this.props.viewer && this.props.viewer.plan,
         this.originalPlan,
       ) &&
-      this.paramsOrQueryHaveChanged() &&
-      this.secondQuerySent &&
+      (this.paramsOrQueryHaveChanged() ||
+        relevantRoutingSettingsChanged(this.context.config)) &&
+      this.walkBikeQuerySent &&
       !this.state.isFetchingWalkAndBike
     ) {
       this.setParamsAndQuery();
-      this.secondQuerySent = false;
+      this.walkBikeQuerySent = false;
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState(
         {
@@ -1514,13 +1515,13 @@ class SummaryPage extends React.Component {
           alternativePlan: undefined,
         },
         () => {
-          const hasNonWalkingItinerary = this.selectedPlan?.itineraries?.some(
+          const vehicleItinerariesFound = this.selectedPlan?.itineraries?.some(
             itinerary => !itinerary.legs.every(leg => leg.mode === 'WALK'),
           );
           if (
             relevantRoutingSettingsChanged(this.context.config) &&
             hasStartAndDestination(this.context.match.params) &&
-            hasNonWalkingItinerary
+            !vehicleItinerariesFound
           ) {
             this.makeQueryWithAllModes();
           }
@@ -1533,10 +1534,9 @@ class SummaryPage extends React.Component {
       this.props.viewer &&
       this.props.viewer.plan &&
       this.props.viewer.plan.itineraries &&
-      !this.secondQuerySent
+      !this.walkBikeQuerySent
     ) {
       this.originalPlan = this.props.viewer.plan;
-      this.secondQuerySent = true;
       if (
         !isEqual(
           otpToLocation(this.context.match.params.from),
@@ -1544,6 +1544,7 @@ class SummaryPage extends React.Component {
         ) ||
         viaPoints.length > 0
       ) {
+        this.walkBikeQuerySent = true;
         this.makeWalkAndBikeQueries();
       } else {
         // eslint-disable-next-line react/no-did-update-set-state

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -1491,8 +1491,7 @@ class SummaryPage extends React.Component {
         this.props.viewer && this.props.viewer.plan,
         this.originalPlan,
       ) &&
-      (this.paramsOrQueryHaveChanged() ||
-        relevantRoutingSettingsChanged(this.context.config)) &&
+      this.paramsOrQueryHaveChanged() &&
       this.walkBikeQuerySent &&
       !this.state.isFetchingWalkAndBike
     ) {
@@ -2424,7 +2423,11 @@ class SummaryPage extends React.Component {
       /* Should render content if
       1. Fetching public itineraries is complete
       2. Don't have to wait for walk and bike query to complete
-      3. Result has non-walking itineraries OR if not, query with all modes is completed or query is made with default settings
+      3. Result has non-walking itineraries OR 
+         result has only walking itineraries AND 
+          a. all modes query is finished
+          OR 
+          b. relevant settings have changed (alternative routes are not fetched when user chooses to limit the results)
       If all conditions don't apply, render spinner */
       if (
         loadingPublicDone &&
@@ -2432,7 +2435,7 @@ class SummaryPage extends React.Component {
         (!onlyHasWalkingItineraries ||
           (onlyHasWalkingItineraries &&
             (this.allModesQueryDone ||
-              !relevantRoutingSettingsChanged(this.context.config))))
+              relevantRoutingSettingsChanged(this.context.config))))
       ) {
         const activeIndex =
           hash || getActiveIndex(match.location, combinedItineraries);


### PR DESCRIPTION
## Proposed Changes

The spinner no longer spins forever. 

- The spinner is _not_ shown when the relevant settings ("mode") has changed, as alternative routes are not fetched in that case (or if the all modes query has finished).
- Alternative query is also made when it is supposed to be made - when no itineraries or only walking itineraries are found (the boolean variable was inverted). 
- Renamed variables for clarity.
- Edited comment to reflect the change.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
