### PR TITLE
fix: differentiate realtime in screen reading

### DIFF
--- a/app/component/AlternativeLegsInfo.js
+++ b/app/component/AlternativeLegsInfo.js
@@ -28,6 +28,11 @@ const AlternativeLegsInfo = ({ legs, showAlternativeLegs, toggle }) => {
               style={{ fontWeight: 500 }}
             >
               {moment(legs[0].startTime).format('HH:mm')}
+              {legs[0].realTime && (
+                <span className="sr-only">
+                  <FormattedMessage id="realtime" />
+                </span>
+              )}
             </span>
           ),
           startTime2: (
@@ -36,6 +41,11 @@ const AlternativeLegsInfo = ({ legs, showAlternativeLegs, toggle }) => {
               style={{ fontWeight: 500 }}
             >
               {moment(legs[1].startTime).format('HH:mm')}
+              {legs[1].realTime && (
+                <span className="sr-only">
+                  <FormattedMessage id="realtime" />
+                </span>
+              )}
             </span>
           ),
         }}
@@ -53,6 +63,11 @@ const AlternativeLegsInfo = ({ legs, showAlternativeLegs, toggle }) => {
               style={{ fontWeight: 500 }}
             >
               {moment(legs[0].startTime).format('HH:mm')}
+              {legs[0].realTime && (
+                <span className="sr-only">
+                  <FormattedMessage id="realtime" />
+                </span>
+              )}
             </span>
           ),
         }}

--- a/app/component/DepartureTime.js
+++ b/app/component/DepartureTime.js
@@ -52,6 +52,14 @@ function DepartureTime(props, context) {
           >
             {shownTime}
           </span>
+          {props.realtime && (
+            <span className="sr-only">
+              {context.intl.formatMessage({
+                id: 'realtime',
+                defaultMessage: 'Realtime',
+              })}
+            </span>
+          )}
         </>
       )}
       <span

--- a/app/component/LegInfo.js
+++ b/app/component/LegInfo.js
@@ -64,9 +64,19 @@ const LegInfo = (
         </div>
       )}
       {displayTime && (
-        <span className={cx('leg-departure-time', { realtime: leg.realTime })}>
-          {moment(leg.startTime).format('HH:mm')}
-        </span>
+        <>
+          <span className="sr-only">
+            {`${moment(leg.startTime).format('HH:mm')} ${
+              leg.realTime ? intl.formatMessage({ id: 'realtime' }) : ''
+            }`}
+          </span>
+          <span
+            className={cx('leg-departure-time', { realtime: leg.realTime })}
+            aria-hidden="true"
+          >
+            {moment(leg.startTime).format('HH:mm')}
+          </span>
+        </>
       )}
     </div>
   );

--- a/app/component/RouteStop.js
+++ b/app/component/RouteStop.js
@@ -90,6 +90,9 @@ const RouteStop = (
     if (patternExists) {
       text += `${intl.formatMessage({ id: 'leaves' })},`;
       text += `${getDepartureTime(stop.stopTimesForPattern[0])},`;
+      if (firstDeparture.realtime) {
+        text += `${intl.formatMessage({ id: 'realtime' })},`;
+      }
       if (stop.stopTimesForPattern[0].stop.platformCode) {
         text += `${intl.formatMessage({ id: 'platform' })},`;
         text += `${stop.stopTimesForPattern[0].stop.platformCode},`;
@@ -100,6 +103,9 @@ const RouteStop = (
           stop.stopTimesForPattern[1],
           currentTime,
         )},`;
+        if (nextDeparture.realtime) {
+          text += `${intl.formatMessage({ id: 'realtime' })},`;
+        }
         if (
           stop.stopTimesForPattern[1] &&
           stop.stopTimesForPattern[1].stop.platformCode

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -228,6 +228,7 @@ class TransitLeg extends React.Component {
         id="itinerary-details.transit-leg-part-1"
         values={{
           time: moment(leg.startTime).format('HH:mm'),
+          realtime: leg.realTime ? intl.formatMessage({ id: 'realtime' }) : '',
         }}
       />
     );

--- a/app/translations.js
+++ b/app/translations.js
@@ -1104,7 +1104,7 @@ const translations = {
     'itinerary-details.route-has-warning-alert': 'Route has disruptions.',
     'itinerary-details.scooter-leg':
       'At {time} ride your kick scooter {distance} from {origin} to {destination}. Estimated time {duration}',
-    'itinerary-details.transit-leg-part-1': 'At {time} take',
+    'itinerary-details.transit-leg-part-1': 'At {time} {realtime} take',
     'itinerary-details.transit-leg-part-2':
       'from stop {startStop} {startZoneInfo} {trackInfo} to stop {endStop} {endZoneInfo}. Estimated duration {duration}',
     'itinerary-details.via-leg':
@@ -2236,7 +2236,7 @@ const translations = {
     'itinerary-details.route-has-warning-alert': 'Reitillä on häiriöitä.',
     'itinerary-details.scooter-leg':
       '{time} potkulautaile {distance} kohteesta {origin} kohteeseen {destination}. Matka-aika {duration}',
-    'itinerary-details.transit-leg-part-1': '{time} ota',
+    'itinerary-details.transit-leg-part-1': '{time} {realtime} ota',
     'itinerary-details.transit-leg-part-2':
       'pysäkiltä {startStop} {startZoneInfo} {trackInfo} pysäkille {endStop} {endZoneInfo}. Arvioitu matka-aika {duration}',
     'itinerary-details.via-leg':
@@ -4142,7 +4142,7 @@ const translations = {
     'itinerary-details.route-has-warning-alert': 'Störningar längs rutten..',
     'itinerary-details.scooter-leg':
       '{time} sparkcykla {distance} från {origin} till destinationen {destination}. Restid {duration}',
-    'itinerary-details.transit-leg-part-1': '{time} ta',
+    'itinerary-details.transit-leg-part-1': '{time} {realtime} ta',
     'itinerary-details.transit-leg-part-2':
       'från hållplats {startStop} {startZoneInfo} {trackInfo} till hållplats {endStop} {endZoneInfo}. Beräknad restid {duration}',
     'itinerary-details.via-leg':


### PR DESCRIPTION
## Proposed Changes

  - Update views for the screen reader to imply times being realtime or not

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
