### PR TITLE
fix: make embedded search work without a logo

### DIFF
--- a/app/component/EmbeddedSearch/EmbeddedSearch.js
+++ b/app/component/EmbeddedSearch/EmbeddedSearch.js
@@ -276,14 +276,18 @@ const EmbeddedSearch = (props, context) => {
   };
 
   useEffect(() => {
-    import(
-      /* webpackChunkName: "embedded-search" */ `../../configurations/images/${
-        config.secondaryLogo || config.logo
-      }`
-    ).then(l => {
-      setLogo(l.default);
+    if (config.secondaryLogo || config.logo) {
+      import(
+        /* webpackChunkName: "embedded-search" */ `../../configurations/images/${
+          config.secondaryLogo || config.logo
+        }`
+      ).then(l => {
+        setLogo(l.default);
+        setLoading(false);
+      });
+    } else {
       setLoading(false);
-    });
+    }
   }, []);
 
   if (i18next.language !== lang) {
@@ -318,11 +322,15 @@ const EmbeddedSearch = (props, context) => {
             {...locationSearchProps}
           />
           <div className="embedded-search-button-container">
-            <img
-              src={logo}
-              className="brand-logo"
-              alt={`${config.title} logo`}
-            />
+            {logo ? (
+              <img
+                src={logo}
+                className="brand-logo"
+                alt={`${config.title} logo`}
+              />
+            ) : (
+              <span className="brand-logo">{config.title}</span>
+            )}
             <button
               ref={buttonRef}
               className="search-button"


### PR DESCRIPTION
## Proposed Changes

  - Embedded search didn't work for journey planners without a logo. Render a span displaying the config name if logo doesn't exist, this has a nuance difference to img's alt property

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
