### PR TITLE
DT-5948 : Add Feed ids and expand navigation area in Matka config

### DIFF
--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -95,6 +95,8 @@ export default {
     'Kajaani',
     'Salo',
     'Pori',
+    'Viro',
+    'Viking Line',
   ],
 
   stopSearchFilter: stop => {
@@ -141,7 +143,13 @@ export default {
   },
 
   redirectReittiopasParams: true,
-  map: { minZoom: 5 },
+  map: {
+    minZoom: 5,
+    areaBounds: {
+      corner1: [70.25, 32.25],
+      corner2: [55.99, 17.75],
+    },
+  },
   suggestBikeMaxDistance: 2000000,
 
   cityBike: {


### PR DESCRIPTION
## Proposed Changes

  - Adds Viking Line and Estonia related feed ids to list in Matka config
  - Expand the navigation area so that map can show all of Estonia in Matka config

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
