### PR TITLE
DT-6017 Support reverse geocoding in additional countries

### DIFF
--- a/app/action/PositionActions.js
+++ b/app/action/PositionActions.js
@@ -11,13 +11,23 @@ let geoWatchId;
 function reverseGeocodeAddress(actionContext, location) {
   const language = actionContext.getStore('PreferencesStore').getLanguage();
 
-  return getJson(actionContext.config.URL.PELIAS_REVERSE_GEOCODER, {
+  const searchParams = {
     'point.lat': location.lat,
     'point.lon': location.lon,
     lang: language,
     size: 1,
     layers: 'address',
-  }).then(data => {
+  };
+
+  if (actionContext.config.searchParams['boundary.country']) {
+    searchParams['boundary.country'] =
+      actionContext.config.searchParams['boundary.country'];
+  }
+
+  return getJson(
+    actionContext.config.URL.PELIAS_REVERSE_GEOCODER,
+    searchParams,
+  ).then(data => {
     if (data.features != null && data.features.length > 0) {
       const match = data.features[0].properties;
       actionContext.dispatch('AddressFound', {

--- a/app/component/ParkOrStationHeader.js
+++ b/app/component/ParkOrStationHeader.js
@@ -17,14 +17,20 @@ const modules = {
 const ParkOrBikeStationHeader = ({ parkOrStation, breakpoint }, { config }) => {
   const [zoneId, setZoneId] = useState(undefined);
   useEffect(() => {
-    getJson(config.URL.PELIAS_REVERSE_GEOCODER, {
+    const searchParams = {
       'point.lat': parkOrStation.lat,
       'point.lon': parkOrStation.lon,
       'boundary.circle.radius': 0.2,
       layers: 'address',
       size: 1,
       zones: 1,
-    }).then(data => {
+    };
+    if (config.searchParams['boundary.country']) {
+      searchParams['boundary.country'] =
+        config.searchParams['boundary.country'];
+    }
+
+    getJson(config.URL.PELIAS_REVERSE_GEOCODER, searchParams).then(data => {
       if (data.features != null && data.features.length > 0) {
         const match = data.features[0].properties;
         const id = getZoneId(config, match.zones, data.zones);

--- a/app/component/StopCardHeader.js
+++ b/app/component/StopCardHeader.js
@@ -27,33 +27,42 @@ class StopCardHeader extends React.Component {
       name = `${name} ${stop.code}`;
     }
 
-    getJson(this.context.config.URL.PELIAS_REVERSE_GEOCODER, {
+    const searchParams = {
       'point.lat': stop.lat,
       'point.lon': stop.lon,
       'boundary.circle.radius': 0.2,
       size: 1,
-    }).then(data => {
-      if (data.features != null && data.features.length > 0) {
-        const match = data.features[0].properties;
-        const city = match.localadmin;
+    };
+    if (this.context.config.searchParams['boundary.country']) {
+      searchParams['boundary.country'] = this.context.config.searchParams[
+        'boundary.country'
+      ];
+    }
 
-        this.context.executeAction(saveSearch, {
-          item: {
-            geometry: { coordinates: [stop.lon, stop.lat] },
-            properties: {
-              name,
-              id,
-              gid: `gtfs:${layer}:${id}`,
-              layer,
-              label: `${stop.name}, ${city}`,
-              localadmin: city,
+    getJson(this.context.config.URL.PELIAS_REVERSE_GEOCODER, searchParams).then(
+      data => {
+        if (data.features != null && data.features.length > 0) {
+          const match = data.features[0].properties;
+          const city = match.localadmin;
+
+          this.context.executeAction(saveSearch, {
+            item: {
+              geometry: { coordinates: [stop.lon, stop.lat] },
+              properties: {
+                name,
+                id,
+                gid: `gtfs:${layer}:${id}`,
+                layer,
+                label: `${stop.name}, ${city}`,
+                localadmin: city,
+              },
+              type: 'Feature',
             },
-            type: 'Feature',
-          },
-          type: 'endpoint',
-        });
-      }
-    });
+            type: 'endpoint',
+          });
+        }
+      },
+    );
   }
 
   get headerConfig() {

--- a/app/component/map/SelectFromMap.js
+++ b/app/component/map/SelectFromMap.js
@@ -59,7 +59,8 @@ class SelectFromMapPageMap extends React.Component {
 
   setAddress = (lat, lon) => {
     const { intl } = this.context;
-    getJson(this.context.config.URL.PELIAS_REVERSE_GEOCODER, {
+
+    const searchParams = {
       'point.lat': lat,
       'point.lon': lon,
       'boundary.circle.radius': 0.1, // 100m
@@ -67,7 +68,14 @@ class SelectFromMapPageMap extends React.Component {
       size: 1,
       layers: 'address',
       zones: 1,
-    }).then(
+    };
+    if (this.context.config.searchParams['boundary.country']) {
+      searchParams['boundary.country'] = this.context.config.searchParams[
+        'boundary.country'
+      ];
+    }
+
+    getJson(this.context.config.URL.PELIAS_REVERSE_GEOCODER, searchParams).then(
       data => {
         if (data.features != null && data.features.length > 0) {
           const match = data.features[0].properties;

--- a/app/component/map/popups/LocationPopup.js
+++ b/app/component/map/popups/LocationPopup.js
@@ -44,7 +44,7 @@ class LocationPopup extends React.Component {
     const { lat, lon } = this.props;
     const { config } = this.context;
 
-    getJson(config.URL.PELIAS_REVERSE_GEOCODER, {
+    const searchParams = {
       'point.lat': lat,
       'point.lon': lon,
       'boundary.circle.radius': 0.1, // 100m
@@ -52,7 +52,13 @@ class LocationPopup extends React.Component {
       size: 1,
       layers: 'address',
       zones: 1,
-    }).then(
+    };
+    if (config.searchParams['boundary.country']) {
+      searchParams['boundary.country'] =
+        config.searchParams['boundary.country'];
+    }
+
+    getJson(config.URL.PELIAS_REVERSE_GEOCODER, searchParams).then(
       data => {
         let pointName;
         if (data.features != null && data.features.length > 0) {


### PR DESCRIPTION
## Proposed Changes

  - Set boundary.country in reverse geocoding calls so they work in optional countries if selected

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
