### PR TITLE
Indicate clearly when release tagging has an error

### DIFF
--- a/.github/workflows/prod-pipeline.yml
+++ b/.github/workflows/prod-pipeline.yml
@@ -14,6 +14,9 @@ jobs:
         run: |
           if [[ ${GITHUB_REF##*/} =~ ^202[0-9][0-1][0-9][0-3][0-9] ]]; then
               echo "match=true" >> $GITHUB_OUTPUT
+          else
+              echo invalid release tag
+              exit 1
           fi
       - name: Push latest image as v3-prod
         if: steps.check-tag.outputs.match == 'true'


### PR DESCRIPTION
Prod release workflow aborts with an error if tagging is not accepted for pushing a new prod image