### PR TITLE
DT-6059 Use new HSL stop timetable endpoint

### DIFF
--- a/app/component/Timetable.js
+++ b/app/component/Timetable.js
@@ -52,6 +52,7 @@ class Timetable extends React.Component {
       onDateChange: PropTypes.func,
     }).isRequired,
     date: PropTypes.string,
+    language: PropTypes.string.isRequired,
   };
 
   static contextTypes = {
@@ -301,11 +302,13 @@ class Timetable extends React.Component {
     const stopPDFURL =
       stopTimetableHandler &&
       this.context.config.URL.STOP_TIMETABLES[stopIdSplitted[0]] &&
-      locationType !== 'STATION'
+      locationType !== 'STATION' &&
+      date
         ? stopTimetableHandler.stopPdfUrlResolver(
             this.context.config.URL.STOP_TIMETABLES[stopIdSplitted[0]],
             this.props.stop,
-            date,
+            this.props.date,
+            this.props.language,
           )
         : null;
     const virtualMonitorUrl =

--- a/app/component/Timetable.js
+++ b/app/component/Timetable.js
@@ -225,6 +225,7 @@ class Timetable extends React.Component {
     // Check if stop is constant operation
     const { constantOperationStops } = this.context.config;
     const stopId = this.props.stop.gtfsId;
+    const { date } = this.props;
     const { locale } = this.context.intl;
     if (constantOperationStops && constantOperationStops[stopId]) {
       return (
@@ -304,8 +305,7 @@ class Timetable extends React.Component {
         ? stopTimetableHandler.stopPdfUrlResolver(
             this.context.config.URL.STOP_TIMETABLES[stopIdSplitted[0]],
             this.props.stop,
-            this.context.config.API_SUBSCRIPTION_QUERY_PARAMETER_NAME,
-            this.context.config.API_SUBSCRIPTION_TOKEN,
+            date,
           )
         : null;
     const virtualMonitorUrl =

--- a/app/component/Timetable.js
+++ b/app/component/Timetable.js
@@ -314,7 +314,7 @@ class Timetable extends React.Component {
         ? stopTimetableHandler.stopPdfUrlResolver(
             this.context.config.URL.STOP_TIMETABLES[stopIdSplitted[0]],
             this.props.stop,
-            this.props.date,
+            date,
             this.props.language,
           )
         : null;

--- a/app/component/Timetable.js
+++ b/app/component/Timetable.js
@@ -6,7 +6,7 @@ import sortBy from 'lodash/sortBy';
 import groupBy from 'lodash/groupBy';
 import padStart from 'lodash/padStart';
 import { FormattedMessage, intlShape } from 'react-intl';
-import { matchShape, routerShape } from 'found';
+import { matchShape, routerShape, RedirectException } from 'found';
 import cx from 'classnames';
 import Icon from './Icon';
 import FilterTimeTableModal from './FilterTimeTableModal';
@@ -18,6 +18,8 @@ import { addAnalyticsEvent } from '../util/analyticsUtils';
 import DateSelect from './DateSelect';
 import ScrollableWrapper from './ScrollableWrapper';
 import { replaceQueryParams } from '../util/queryUtils';
+import { isBrowser } from '../util/browser';
+import { PREFIX_STOPS } from '../util/path';
 
 class Timetable extends React.Component {
   static propTypes = {
@@ -65,7 +67,12 @@ class Timetable extends React.Component {
   constructor(props) {
     super(props);
     if (!this.props.stop) {
-      throw new Error('Empty stop');
+      const path = `/${PREFIX_STOPS}`;
+      if (isBrowser) {
+        this.context.router.replace(path);
+      } else {
+        throw new RedirectException(path);
+      }
     }
     this.state = {
       showRoutes: [],

--- a/app/component/TimetableContainer.js
+++ b/app/component/TimetableContainer.js
@@ -1,39 +1,45 @@
 import { createFragmentContainer, graphql } from 'react-relay';
+import connectToStores from 'fluxible-addons-react/connectToStores';
 
 import Timetable from './Timetable';
 
-export default createFragmentContainer(Timetable, {
-  stop: graphql`
-    fragment TimetableContainer_stop on Stop
-    @argumentDefinitions(date: { type: "String" }) {
-      gtfsId
-      name
-      url
-      locationType
-      stoptimesForServiceDate(date: $date, omitCanceled: false) {
-        pattern {
-          headsign
-          code
-          route {
-            id
-            shortName
-            longName
-            type
-            mode
-            agency {
+export default createFragmentContainer(
+  connectToStores(Timetable, ['PreferencesStore'], context => ({
+    language: context.getStore('PreferencesStore').getLanguage(),
+  })),
+  {
+    stop: graphql`
+      fragment TimetableContainer_stop on Stop
+      @argumentDefinitions(date: { type: "String" }) {
+        gtfsId
+        name
+        url
+        locationType
+        stoptimesForServiceDate(date: $date, omitCanceled: false) {
+          pattern {
+            headsign
+            code
+            route {
               id
-              name
+              shortName
+              longName
+              type
+              mode
+              agency {
+                id
+                name
+              }
             }
           }
-        }
-        stoptimes {
-          realtimeState
-          scheduledDeparture
-          serviceDay
-          headsign
-          pickupType
+          stoptimes {
+            realtimeState
+            scheduledDeparture
+            serviceDay
+            headsign
+            pickupType
+          }
         }
       }
-    }
-  `,
-});
+    `,
+  },
+);

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -11,6 +11,8 @@ const MAP_URL =
 const MAP_VERSION = process.env.MAP_VERSION || 'v2';
 const POI_MAP_PREFIX = `${MAP_URL}/map/v3/finland`;
 const OTP_URL = process.env.OTP_URL || `${API_URL}/routing/v2/routers/finland/`;
+const STOP_TIMETABLES_URL =
+  process.env.STOP_TIMETABLES_URL || 'https://dev.kartat.hsl.fi';
 const APP_PATH = process.env.APP_CONTEXT || '';
 const {
   SENTRY_DSN,
@@ -95,7 +97,7 @@ export default {
       tampere: 'https://www.nysse.fi/aikataulut-ja-reitit/linjat/',
     },
     STOP_TIMETABLES: {
-      HSL: `${API_URL}/timetables/v1/hsl/stops/`,
+      HSL: `${STOP_TIMETABLES_URL}/julkaisin-render/?component=Timetable`,
     },
     WEATHER_DATA:
       'https://opendata.fmi.fi/wfs?service=WFS&version=2.0.0&request=getFeature&storedquery_id=fmi::forecast::harmonie::surface::point::simple&timestep=5&parameters=temperature,WindSpeedMS,WeatherSymbol3',

--- a/app/configurations/timetableConfigUtils.js
+++ b/app/configurations/timetableConfigUtils.js
@@ -35,17 +35,15 @@ export default {
     ) {
       this.availableRouteTimetables = timetables;
     },
-    stopPdfUrlResolver: function stopPdfUrlResolver(
-      baseURL,
-      stop,
-      subscriptionParam,
-      subscriptionToken,
-    ) {
-      const stopIdSplitted = stop.gtfsId.split(':');
-      const url = new URL(`${baseURL}${stopIdSplitted[1]}.pdf`);
-      if (subscriptionParam && subscriptionToken) {
-        url.searchParams.set(subscriptionParam, subscriptionToken);
-      }
+    stopPdfUrlResolver: function stopPdfUrlResolver(baseURL, stop, date) {
+      const stopId = stop.gtfsId.split(':')[1];
+      // From YYYYMMDD to YYYY-MM-DD
+      const formattedDate = date.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3');
+      const defaultSearchParams =
+        'props[isSummerTimetable]=false&props[printTimetablesAsA4]=true&props[printTimetablesAsGreyscale]=false&props[template]=default&props[showAddressInfo]=false&props[showPrintButton]=true&props[redirect]=false&template=default';
+      const url = new URL(`${baseURL}&${defaultSearchParams}`);
+      url.searchParams.append('props[stopId]', stopId);
+      url.searchParams.append('props[date]', formattedDate);
       return url;
     },
   },
@@ -59,12 +57,7 @@ export default {
       const routeNumber = route.shortName.replace(/\D/g, '');
       return new URL(`${baseURL}${routeNumber}.html`);
     },
-    stopPdfUrlResolver: function stopPdfUrlResolver(
-      baseURL,
-      stop,
-      subscriptionParam,
-      subscriptionToken,
-    ) {
+    stopPdfUrlResolver: function stopPdfUrlResolver(baseURL, stop, date) {
       const stopIdSplitted = stop.gtfsId.split(':');
       return new URL(`${baseURL}${parseInt(stopIdSplitted[1], 10)}.pdf`);
     },

--- a/app/configurations/timetableConfigUtils.js
+++ b/app/configurations/timetableConfigUtils.js
@@ -35,7 +35,7 @@ export default {
     ) {
       this.availableRouteTimetables = timetables;
     },
-    stopPdfUrlResolver: function stopPdfUrlResolver(baseURL, stop, date) {
+    stopPdfUrlResolver: function stopPdfUrlResolver(baseURL, stop, date, lang) {
       const stopId = stop.gtfsId.split(':')[1];
       // From YYYYMMDD to YYYY-MM-DD
       const formattedDate = date.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3');
@@ -44,6 +44,7 @@ export default {
       const url = new URL(`${baseURL}&${defaultSearchParams}`);
       url.searchParams.append('props[stopId]', stopId);
       url.searchParams.append('props[date]', formattedDate);
+      url.searchParams.append('props[lang]', lang);
       return url;
     },
   },
@@ -57,7 +58,7 @@ export default {
       const routeNumber = route.shortName.replace(/\D/g, '');
       return new URL(`${baseURL}${routeNumber}.html`);
     },
-    stopPdfUrlResolver: function stopPdfUrlResolver(baseURL, stop, date) {
+    stopPdfUrlResolver: function stopPdfUrlResolver(baseURL, stop, date, lang) {
       const stopIdSplitted = stop.gtfsId.split(':');
       return new URL(`${baseURL}${parseInt(stopIdSplitted[1], 10)}.pdf`);
     },

--- a/test/unit/component/Timetable.test.js
+++ b/test/unit/component/Timetable.test.js
@@ -48,6 +48,7 @@ const props = {
     ],
   },
   date: '20231031',
+  language: 'en',
 };
 
 describe('<Timetable />', () => {

--- a/test/unit/component/Timetable.test.js
+++ b/test/unit/component/Timetable.test.js
@@ -47,6 +47,7 @@ const props = {
       },
     ],
   },
+  date: '20231031',
 };
 
 describe('<Timetable />', () => {

--- a/test/unit/util/timetableConfigUtils.test.js
+++ b/test/unit/util/timetableConfigUtils.test.js
@@ -42,13 +42,15 @@ describe('timetableConfigUtils', () => {
       const timetableHandler = timetables.default.HSL;
       const stop = { gtfsId: 'HSL:1122127' };
       const date = '20231031';
+      const lang = 'en';
       const url = timetableHandler.stopPdfUrlResolver(
         hslStopTimetableURL,
         stop,
         date,
+        lang,
       );
       expect(url.href).to.equal(
-        `${hslStopTimetableURL}&props%5BisSummerTimetable%5D=false&props%5BprintTimetablesAsA4%5D=true&props%5BprintTimetablesAsGreyscale%5D=false&props%5Btemplate%5D=default&props%5BshowAddressInfo%5D=false&props%5BshowPrintButton%5D=true&props%5Bredirect%5D=false&template=default&props%5BstopId%5D=1122127&props%5Bdate%5D=2023-10-31`,
+        `${hslStopTimetableURL}&props%5BisSummerTimetable%5D=false&props%5BprintTimetablesAsA4%5D=true&props%5BprintTimetablesAsGreyscale%5D=false&props%5Btemplate%5D=default&props%5BshowAddressInfo%5D=false&props%5BshowPrintButton%5D=true&props%5Bredirect%5D=false&template=default&props%5BstopId%5D=1122127&props%5Bdate%5D=2023-10-31&props%5Blang%5D=en`,
       );
     });
     it('should resolve correctly for tampere instance', () => {

--- a/test/unit/util/timetableConfigUtils.test.js
+++ b/test/unit/util/timetableConfigUtils.test.js
@@ -38,21 +38,18 @@ describe('timetableConfigUtils', () => {
   });
   describe('stopPdfUrlResolver', () => {
     it('should resolve correctly for HSL instance', () => {
+      const hslStopTimetableURL = 'https://timetabletest.com/?foo=bar';
       const timetableHandler = timetables.default.HSL;
       const stop = { gtfsId: 'HSL:1122127' };
-      const url = timetableHandler.stopPdfUrlResolver(baseTimetableURL, stop);
-      expect(url.href).to.equal(`${baseTimetableURL}1122127.pdf`);
-    });
-    it('should resolve correctly for HSL instance with authentication param', () => {
-      const timetableHandler = timetables.default.HSL;
-      const stop = { gtfsId: 'HSL:1122127' };
+      const date = '20231031';
       const url = timetableHandler.stopPdfUrlResolver(
-        baseTimetableURL,
+        hslStopTimetableURL,
         stop,
-        'foo',
-        'bar',
+        date,
       );
-      expect(url.href).to.equal(`${baseTimetableURL}1122127.pdf?foo=bar`);
+      expect(url.href).to.equal(
+        `${hslStopTimetableURL}&props%5BisSummerTimetable%5D=false&props%5BprintTimetablesAsA4%5D=true&props%5BprintTimetablesAsGreyscale%5D=false&props%5Btemplate%5D=default&props%5BshowAddressInfo%5D=false&props%5BshowPrintButton%5D=true&props%5Bredirect%5D=false&template=default&props%5BstopId%5D=1122127&props%5Bdate%5D=2023-10-31`,
+      );
     });
     it('should resolve correctly for tampere instance', () => {
       const timetableHandler = timetables.default.tampere;


### PR DESCRIPTION
## Proposed Changes

  - Use new HSL stop timetable endpoint for weekly timetables
  - Rendering of an invalid stop page (stop doesn't exist) in timetable view, now leads to 404 instead of error being thrown

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
