### PR TITLE
chore: temporarily map full status to crushed standing room only

### DIFF
--- a/app/component/CapacityModal.js
+++ b/app/component/CapacityModal.js
@@ -124,7 +124,7 @@ const CapacityModal = ({ config }) => {
           />
         </p>
       </section>
-      <section>
+      {/* <section>
         <div className="capacity-info-row">
           <div className="icon">
             <Icon
@@ -147,7 +147,7 @@ const CapacityModal = ({ config }) => {
             defaultMessage="No seats or standing room available"
           />
         </p>
-      </section>
+      </section> */}
     </div>
   );
 };

--- a/app/util/occupancyUtil.js
+++ b/app/util/occupancyUtil.js
@@ -10,7 +10,7 @@ export function mapStatus(status) {
     case 'EMPTY':
       return 'MANY_SEATS_AVAILABLE';
     case 'NOT_ACCEPTING_PASSENGERS':
-      return 'FULL';
+      return 'CRUSHED_STANDING_ROOM_ONLY';
     case 'MANY_SEATS_AVAILABLE':
       return 'MANY_SEATS_AVAILABLE';
     case 'FEW_SEATS_AVAILABLE':
@@ -20,7 +20,7 @@ export function mapStatus(status) {
     case 'CRUSHED_STANDING_ROOM_ONLY':
       return 'CRUSHED_STANDING_ROOM_ONLY';
     case 'FULL':
-      return 'FULL';
+      return 'CRUSHED_STANDING_ROOM_ONLY';
     default:
       return 'NO_DATA_AVAILABLE';
   }


### PR DESCRIPTION
## Proposed Changes

  - The bus transmitters are faulty and as the day goes, start to record higher occupancy numbers as the day goes. This is why we temporarily hide the full-icon explanation in the modal, and re-map "FULL" and "NOT_ACCEPTING_PASSENGERS" to "CRUSHED_STANDING_ROOM_ONLY
  - Modal content is commented out because this is not final

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
