### PR TITLE
DT-6166: Fix UI crashing when timetable view does not have any stoptimes

### DIFF
--- a/app/component/TimeTableOptionsPanel.js
+++ b/app/component/TimeTableOptionsPanel.js
@@ -55,8 +55,12 @@ class TimeTableOptionsPanel extends React.Component {
         break;
       }
     }
-
-    let stopVehicle = this.props.stop.stoptimesForServiceDate[0].pattern.route.mode.toLowerCase();
+    // If stop/station is cancelled, or it has no departures from some other reason, stop.stoptimesForServiceDate length is 0.
+    // This check prevents UI from crashing
+    const len = this.props.stop.stoptimesForServiceDate.length;
+    let stopVehicle = len
+      ? this.props.stop.stoptimesForServiceDate[0].pattern?.route.mode.toLowerCase()
+      : null;
     if (stopVehicle === 'bus') {
       stopVehicle = this.props.stop.stoptimesForServiceDate.some(
         stopTime =>


### PR DESCRIPTION
## Proposed Changes

  - As title suggests. 
  - You can test this doing a station search in front page. Type Kerava ase and select the one that has old icon in suggestions. There is no departures. And if you click timetable section, without this fix UI will crash.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
