### PR TITLE
DT-4031: Timepicker improvements

### DIFF
--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -39,6 +39,6 @@
     "react": "^16.13.0",
     "react-autosuggest": "^10.0.0",
     "react-modal": "~3.11.2",
-    "react-select": "4.3.0"
+    "react-select": "5.8.0"
   }
 }

--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
@@ -409,6 +409,7 @@ function Datetimepicker({
                   label={i18next.t('date', translationSettings)}
                   disableTyping
                   timeZone={timeZone}
+                  datePicker
                 />
               </span>
               <span className={styles['combobox-right']}>

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
@@ -18,6 +18,7 @@ import styles from './styles.scss';
  * @param {string} label                Text to show as input label
  * @param {node} icon                   JSX for icon to show in input
  * @param {boolean} disableTyping       Set to true to disable typing in the input
+ * @param {boolean} datePicker          Is the picker DatePicer or TimePicker
  *
  * @example
  * <DesktopDatetimepicker
@@ -29,6 +30,7 @@ import styles from './styles.scss';
  *   id="timeinput"
  *   icon="<Icon />"
  *   disableTyping={false} // can be omitted if not true
+ *   datePicker={true} // can be omitted if not true
  */
 function DesktopDatetimepicker({
   value,
@@ -41,6 +43,7 @@ function DesktopDatetimepicker({
   icon,
   disableTyping,
   timeZone,
+  datePicker,
 }) {
   moment.tz.setDefault(timeZone);
   const [displayValue, changeDisplayValue] = useState(getDisplay(value));
@@ -61,9 +64,16 @@ function DesktopDatetimepicker({
     }
     onChange(asNumber);
   };
-
+  function isValidInput(str) {
+    const clockRegex = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
+    const regex = /[a-zA-Z§ÄäÖö\s]/g;
+    if (regex.test(str)) {
+      return false;
+    }
+    return clockRegex.test(str) || str.length < 5;
+  }
   const onInputChange = (newValue, { action }) => {
-    if (disableTyping) {
+    if (disableTyping || !isValidInput(newValue)) {
       return;
     }
     if (action === 'input-change') {
@@ -83,7 +93,7 @@ function DesktopDatetimepicker({
   const filterOptions = (option, input) => {
     const hour = input.length <= 2 ? input : input.split(':')[0];
     const isValidHour = /^([0-1]?[0-9]|2[0-3])$/.test(hour);
-    const comp = input.length === 1 ? '0'.concat(input) : input;
+    const comp = hour.length === 1 ? '0'.concat(input) : input;
     return isValidHour
       ? option.label.split(':')[0] === comp.split(':')[0]
       : true;
@@ -140,6 +150,9 @@ function DesktopDatetimepicker({
           inputValue={!disableTyping && displayValue}
           value={closestOption}
           filterOption={(option, input) => {
+            if (datePicker) {
+              return true;
+            }
             if (input.length < 1 || input.length > 5) {
               return true;
             }
@@ -188,11 +201,13 @@ DesktopDatetimepicker.propTypes = {
   icon: PropTypes.node.isRequired,
   disableTyping: PropTypes.bool,
   timeZone: PropTypes.string,
+  datePicker: PropTypes.bool,
 };
 
 DesktopDatetimepicker.defaultProps = {
   disableTyping: false,
   timeZone: 'Europe/Helsinki',
+  datePicker: false,
 };
 
 export default DesktopDatetimepicker;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
@@ -80,6 +80,14 @@ function DesktopDatetimepicker({
   );
   const inputId = `${id}-input`;
   const labelId = `${id}-label`;
+  const filterOptions = (option, input) => {
+    const hour = input.length <= 2 ? input : input.split(':')[0];
+    const isValidHour = /^([0-1]?[0-9]|2[0-3])$/.test(hour);
+    const comp = input.length === 1 ? '0'.concat(input) : input;
+    return isValidHour
+      ? option.label.split(':')[0] === comp.split(':')[0]
+      : true;
+  };
   return (
     <>
       <label className={styles['combobox-container']} htmlFor={inputId}>
@@ -131,7 +139,12 @@ function DesktopDatetimepicker({
           onInputChange={onInputChange}
           inputValue={!disableTyping && displayValue}
           value={closestOption}
-          filterOption={() => true}
+          filterOption={(option, input) => {
+            if (input.length < 1 || input.length > 5) {
+              return true;
+            }
+            return filterOptions(option, input);
+          }}
           controlShouldRenderValue={disableTyping}
           tabSelectsValue={false}
           placeholder=""

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
@@ -18,7 +18,7 @@ import styles from './styles.scss';
  * @param {string} label                Text to show as input label
  * @param {node} icon                   JSX for icon to show in input
  * @param {boolean} disableTyping       Set to true to disable typing in the input
- * @param {boolean} datePicker          Is the picker DatePicer or TimePicker
+ * @param {boolean} datePicker          Is the picker DatePicker or TimePicker
  *
  * @example
  * <DesktopDatetimepicker

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,7 +1895,7 @@ __metadata:
     react: ^16.13.0
     react-autosuggest: ^10.0.0
     react-modal: ~3.11.2
-    react-select: 4.3.0
+    react-select: 5.8.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Proposed Changes
 These changes are only for dateTimePicker in desktop mode.
  - Timepicker suggests now times by hour. For example If user types `12` Timepicker shows suggestion list `12.00,` `12.15`,` 12.30`, `12.45`. It filters values only by hour.
  - Timepicker does not allow text.
  - max length of time picker time is 5 digits. `HH:MM`. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
