### PR TITLE
DT-6197: Show all options when opening picker

### DIFF
--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
@@ -48,7 +48,7 @@ function DesktopDatetimepicker({
   moment.tz.setDefault(timeZone);
   const [displayValue, changeDisplayValue] = useState(getDisplay(value));
   const [typing, setTyping] = useState(false);
-
+  const [showAllOptions, setShowAllOptions] = useState(true);
   useEffect(() => changeDisplayValue(getDisplay(value)), [value]);
 
   // newValue is string
@@ -73,7 +73,13 @@ function DesktopDatetimepicker({
     return clockRegex.test(str) || str.length < 5;
   }
   const onInputChange = (newValue, { action }) => {
-    if (disableTyping || !isValidInput(newValue)) {
+    if (action === 'menu-close') {
+      setShowAllOptions(true);
+    } else if (showAllOptions) {
+      setShowAllOptions(false);
+    }
+
+    if (disableTyping || (newValue && !isValidInput(newValue))) {
       return;
     }
     if (action === 'input-change') {
@@ -150,7 +156,7 @@ function DesktopDatetimepicker({
           inputValue={!disableTyping && displayValue}
           value={closestOption}
           filterOption={(option, input) => {
-            if (datePicker) {
+            if (datePicker || showAllOptions) {
               return true;
             }
             if (input.length < 1 || input.length > 5) {


### PR DESCRIPTION
## Proposed Changes

  - Time picker will show all options when user opens the time picker
  - `showAllOptions` state determines when we should show user all options in time picker.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
