### PR TITLE
DT-6204: Open App button opens app with invalid date set

### DIFF
--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -417,7 +417,7 @@ export default {
 
   useTicketIcons: true,
   ticketPurchaseLink: function purchaseTicketLink(ticket) {
-    return `https://open.app.hsl.fi/zoneTicketWizard/TICKET_TYPE_SINGLE_TICKET/${ticket}/adult/?utm_campaign=reittiopas&utm_medium=reittiopasohjaus`;
+    return `https://open.app.hsl.fi/zoneTicketWizard/TICKET_TYPE_SINGLE_TICKET/${ticket}/adult/-/?utm_campaign=reittiopas&utm_medium=reittiopasohjaus`;
   },
 
   trafficNowLink: {


### PR DESCRIPTION
## Proposed Changes

  - Added a missing value (-) for the validityStartAt param. Now the date is valid (Current time).
  - For now this is the best way to fix the issue. Application team are refactoring the validityStartAt accepted values for more browser url friendly format. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
