### PR TITLE
DT-6225: Use transferPenalty to avoid transfers

### DIFF
--- a/app/component/CustomizeSearchNew.js
+++ b/app/component/CustomizeSearchNew.js
@@ -108,7 +108,7 @@ class CustomizeSearch extends React.Component {
               <TransferOptionsSection
                 defaultSettings={this.defaultSettings}
                 currentSettings={currentSettings}
-                walkBoardCostHigh={config.walkBoardCostHigh}
+                transferPenaltyHigh={config.transferPenaltyHigh}
               />
             </div>
           </div>

--- a/app/component/customizesearch/TransferOptionsSection.js
+++ b/app/component/customizesearch/TransferOptionsSection.js
@@ -6,11 +6,11 @@ import { saveRoutingSettings } from '../../action/SearchSettingsActions';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 
 const TransferOptionsSection = (
-  { defaultSettings, walkBoardCostHigh, currentSettings },
+  { defaultSettings, transferPenaltyHigh, currentSettings },
   { executeAction },
 ) => {
   const avoidTransfers =
-    currentSettings.walkBoardCost !== defaultSettings.walkBoardCost;
+    currentSettings.transferPenalty !== defaultSettings.transferPenalty;
   return (
     <div className="mode-option-container toggle-container avoid-transfers-container">
       <label htmlFor="settings-toggle-transfers" className="settings-header">
@@ -23,9 +23,9 @@ const TransferOptionsSection = (
           toggled={avoidTransfers}
           onToggle={() => {
             executeAction(saveRoutingSettings, {
-              walkBoardCost: avoidTransfers
-                ? defaultSettings.walkBoardCost
-                : walkBoardCostHigh,
+              transferPenalty: avoidTransfers
+                ? defaultSettings.transferPenalty
+                : transferPenaltyHigh,
             });
             addAnalyticsEvent({
               category: 'ItinerarySettings',
@@ -43,9 +43,10 @@ const TransferOptionsSection = (
 TransferOptionsSection.propTypes = {
   defaultSettings: PropTypes.shape({
     walkBoardCost: PropTypes.number.isRequired,
+    transferPenalty: PropTypes.number.isRequired,
   }).isRequired,
   currentSettings: PropTypes.object.isRequired,
-  walkBoardCostHigh: PropTypes.number.isRequired,
+  transferPenaltyHigh: PropTypes.number.isRequired,
 };
 
 TransferOptionsSection.contextTypes = {

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -194,6 +194,7 @@ export default {
     walkBoardCost: 120,
     walkReluctance: 1.8,
     walkSpeed: 1.2,
+    transferPenalty: 0,
     includeBikeSuggestions: true,
     includeParkAndRideSuggestions: false,
     includeCarSuggestions: false,
@@ -216,7 +217,7 @@ export default {
     bikeSpeed: [2.77, 4.15, 5.55, 6.94, 8.33],
   },
 
-  walkBoardCostHigh: 1600,
+  transferPenaltyHigh: 1600,
 
   suggestWalkMaxDistance: 10000,
   suggestBikeMaxDistance: 30000,

--- a/app/store/localStorage.js
+++ b/app/store/localStorage.js
@@ -107,6 +107,10 @@ export function setCustomizedSettings(data) {
       data.walkBoardCost,
       oldSettings.walkBoardCost,
     ),
+    transferPenalty: getNumberValueOrDefault(
+      data.transferPenalty,
+      oldSettings.transferPenalty,
+    ),
     walkReluctance: getNumberValueOrDefault(
       data.walkReluctance,
       oldSettings.walkReluctance,


### PR DESCRIPTION
## Proposed Changes

  - Previously walkBoardCost parameter was used to avoid transfers but this made all public transport expensive even on first boarding. This PR makes use of the transferPenalty parameter to make the first transit leg cheaper.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
