### PR TITLE
fix: geojson fetch race condition

### DIFF
--- a/app/component/MapLayersDialogContent.js
+++ b/app/component/MapLayersDialogContent.js
@@ -26,7 +26,10 @@ const mapLayersConfigShape = PropTypes.shape({
   geoJson: PropTypes.shape({
     layers: PropTypes.arrayOf(
       PropTypes.shape({
-        url: PropTypes.string.isRequired,
+        url: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.arrayOf(PropTypes.string),
+        ]).isRequired,
         name: PropTypes.shape({
           en: PropTypes.string,
           fi: PropTypes.string.isRequired,

--- a/app/config.js
+++ b/app/config.js
@@ -140,14 +140,16 @@ export function getNamedConfiguration(configName) {
   // inject zone geoJson if necessary
   const conf = configs[configName];
   if (conf.useAssembledGeoJsonZones && allZones) {
-    const zoneLayer = {
-      ...allZones,
-      isOffByDefault: conf.useAssembledGeoJsonZones === 'isOffByDefault',
-    };
-    if (!conf.geoJson) {
-      conf.geoJson = { layers: [zoneLayer] };
-    } else {
-      conf.geoJson.layers.push(zoneLayer);
+    if (!conf.geoJson?.layers?.find(l => l.name === allZones.name)) {
+      const zoneLayer = {
+        ...allZones,
+        isOffByDefault: conf.useAssembledGeoJsonZones === 'isOffByDefault',
+      };
+      if (!conf.geoJson) {
+        conf.geoJson = { layers: [zoneLayer] };
+      } else {
+        conf.geoJson.layers.push(zoneLayer);
+      }
     }
   }
 

--- a/app/store/GeoJsonStore.js
+++ b/app/store/GeoJsonStore.js
@@ -93,7 +93,17 @@ class GeoJsonStore extends Store {
       id = url;
       urlArr = [url];
     }
+    if (this.geoJsonData[id] === 'pending') {
+      for (let i = 0; i < 30; i++) {
+        /* eslint-disable no-await-in-loop, no-promise-executor-return */
+        await new Promise(resolve => setTimeout(resolve, 100));
+        if (this.geoJsonData[id] !== 'pending') {
+          break;
+        }
+      }
+    }
     if (!this.geoJsonData[id]) {
+      this.geoJsonData[id] = 'pending';
       const responses = await Promise.all(urlArr.map(u => getJson(u)));
       const mapped = responses.map(r => {
         if (metadata) {


### PR DESCRIPTION
For some reason, map loading triggers several requests to get zone data almost simultaneously. Delay duplicate requests until data arrives.
