### PR TITLE
Fetch assembed zones via CDN

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -21,7 +21,7 @@ if (defaultConfig.themeMap) {
 
 let allZones;
 export function setAssembledZones(zoneLayer) {
-  allZones = zoneLayer;
+  allZones = { ...zoneLayer };
 }
 
 function addMetaData(config) {
@@ -81,6 +81,12 @@ function addMetaData(config) {
   }
 }
 
+function mapGeoJsonPaths(url, config) {
+  const appPathPrefix = config.URL.ASSET_URL || '';
+  const mapUrl = u => (u.startsWith('http') ? u : appPathPrefix + u);
+  return typeof url === 'string' ? mapUrl(url) : url.map(u => mapUrl(u));
+}
+
 export function getNamedConfiguration(configName) {
   if (!configs[configName]) {
     let additionalConfig;
@@ -126,13 +132,10 @@ export function getNamedConfiguration(configName) {
 
     addMetaData(config); // add dynamic metadata content
 
-    const appPathPrefix = config.URL.ASSET_URL || '';
-    if (config.geoJson && Array.isArray(config.geoJson.layers)) {
+    if (config.geoJson?.layers) {
       for (let i = 0; i < config.geoJson.layers.length; i++) {
         const layer = config.geoJson.layers[i];
-        if (layer.url.indexOf('http') !== 0) {
-          layer.url = appPathPrefix + layer.url;
-        }
+        layer.url = mapGeoJsonPaths(layer.url, config);
       }
     }
     configs[configName] = config;
@@ -143,6 +146,7 @@ export function getNamedConfiguration(configName) {
     if (!conf.geoJson?.layers?.find(l => l.name === allZones.name)) {
       const zoneLayer = {
         ...allZones,
+        url: mapGeoJsonPaths(allZones.url, conf),
         isOffByDefault: conf.useAssembledGeoJsonZones === 'isOffByDefault',
       };
       if (!conf.geoJson) {

--- a/app/config.js
+++ b/app/config.js
@@ -83,7 +83,8 @@ function addMetaData(config) {
 
 function mapGeoJsonPaths(url, config) {
   const appPathPrefix = config.URL.ASSET_URL || '';
-  const mapUrl = u => (u.startsWith('http') ? u : appPathPrefix + u);
+  const mapUrl = u =>
+    u.startsWith('http') || u.startsWith('//') ? u : appPathPrefix + u;
   return typeof url === 'string' ? mapUrl(url) : url.map(u => mapUrl(u));
 }
 

--- a/app/store/GeoJsonStore.js
+++ b/app/store/GeoJsonStore.js
@@ -87,7 +87,7 @@ class GeoJsonStore extends Store {
     let id;
     let urlArr;
     if (Array.isArray(url)) {
-      [id] = url;
+      id = `${url[0]}-array`;
       urlArr = url;
     } else {
       id = url;


### PR DESCRIPTION
Zone assembly bypassed the mapping code which converts ui asset paths to CDN. Now the same mapping is applied to dynamically injected zone layer as well. 