### PR TITLE
DT-6242: Citybike configurations from the citybike configuration

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -163,40 +163,21 @@ export function getNamedConfiguration(configName) {
     }
   }
   if (conf.cityBike && allCitybikes?.length) {
-    const network = allCitybikes.find(
-      cb => conf.cityBike[cb.networkName] !== null,
-    );
-    let confCitybike;
     if (configName === 'matka') {
       allCitybikes.forEach(cb => {
-        let obj;
-        if (cb.smoove) {
-          obj = cb.smoove;
-        } else if (cb.vantaa) {
-          obj = cb.vantaa;
-        } else {
-          obj = cb;
-        }
-        const net = conf.cityBike.networks[obj.networkName];
-        if (net) {
-          net.enabled = obj.enabled;
-          net.season = obj.season;
+        const confCityBike = conf.cityBike.networks[cb.networkName];
+        if (confCityBike) {
+          confCityBike.enabled = cb.enabled;
+          confCityBike.season = cb.season;
         }
       });
-    } else if (configName === 'hsl') {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const [key, value] of Object.entries(network)) {
-        confCitybike = conf.cityBike.networks[key];
-        confCitybike.enabled = value.enabled;
-        confCitybike.season = value.season;
-      }
     } else {
-      confCitybike = conf.cityBike.networks[network.networkName];
-
-      if (confCitybike) {
-        confCitybike.enabled = network.enabled;
-        confCitybike.season = network.season;
-      }
+      const networks = allCitybikes.filter(cb => configName === cb.config);
+      networks.forEach(network => {
+        const confCityBike = conf.cityBike.networks[network.networkName];
+        confCityBike.enabled = network.enabled;
+        confCityBike.season = network.season;
+      });
     }
   }
   if (!process.env.OIDC_CLIENT_ID && conf.allowLogin) {

--- a/app/config.js
+++ b/app/config.js
@@ -179,7 +179,7 @@ export function getNamedConfiguration(configName) {
       });
     } else {
       const seasonDefinitions = citybikeSeasonDefinitions.filter(
-        seasonDef => configName === seasonDef.config,
+        seasonDef => configName === seasonDef.configName,
       );
       seasonDefinitions.forEach(seasonDef => {
         const confCitybike = conf.cityBike.networks[seasonDef.networkName];

--- a/app/config.js
+++ b/app/config.js
@@ -19,6 +19,11 @@ if (defaultConfig.themeMap) {
   });
 }
 
+let allCitybikes;
+export function setAvailableCitybikes(citybikes) {
+  allCitybikes = [...citybikes];
+}
+
 let allZones;
 export function setAssembledZones(zoneLayer) {
   allZones = { ...zoneLayer };
@@ -157,7 +162,43 @@ export function getNamedConfiguration(configName) {
       }
     }
   }
+  if (conf.cityBike && allCitybikes?.length) {
+    const network = allCitybikes.find(
+      cb => conf.cityBike[cb.networkName] !== null,
+    );
+    let confCitybike;
+    if (configName === 'matka') {
+      allCitybikes.forEach(cb => {
+        let obj;
+        if (cb.smoove) {
+          obj = cb.smoove;
+        } else if (cb.vantaa) {
+          obj = cb.vantaa;
+        } else {
+          obj = cb;
+        }
+        const net = conf.cityBike.networks[obj.networkName];
+        if (net) {
+          net.enabled = obj.enabled;
+          net.season = obj.season;
+        }
+      });
+    } else if (configName === 'hsl') {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const [key, value] of Object.entries(network)) {
+        confCitybike = conf.cityBike.networks[key];
+        confCitybike.enabled = value.enabled;
+        confCitybike.season = value.season;
+      }
+    } else {
+      confCitybike = conf.cityBike.networks[network.networkName];
 
+      if (confCitybike) {
+        confCitybike.enabled = network.enabled;
+        confCitybike.season = network.season;
+      }
+    }
+  }
   if (!process.env.OIDC_CLIENT_ID && conf.allowLogin) {
     return {
       ...conf,

--- a/app/config.js
+++ b/app/config.js
@@ -165,18 +165,18 @@ export function getNamedConfiguration(configName) {
   if (conf.cityBike && allCitybikes?.length) {
     if (configName === 'matka') {
       allCitybikes.forEach(cb => {
-        const confCityBike = conf.cityBike.networks[cb.networkName];
-        if (confCityBike) {
-          confCityBike.enabled = cb.enabled;
-          confCityBike.season = cb.season;
+        const confCitybike = conf.cityBike.networks[cb.networkName];
+        if (confCitybike) {
+          confCitybike.enabled = cb.enabled;
+          confCitybike.season = cb.season;
         }
       });
     } else {
       const networks = allCitybikes.filter(cb => configName === cb.config);
       networks.forEach(network => {
-        const confCityBike = conf.cityBike.networks[network.networkName];
-        confCityBike.enabled = network.enabled;
-        confCityBike.season = network.season;
+        const confCitybike = conf.cityBike.networks[network.networkName];
+        confCitybike.enabled = network.enabled;
+        confCitybike.season = network.season;
       });
     }
   }

--- a/app/config.js
+++ b/app/config.js
@@ -162,8 +162,10 @@ export function getNamedConfiguration(configName) {
       }
     }
   }
-  if (conf.cityBike && allCitybikes?.length) {
-    if (configName === 'matka') {
+  if (conf.cityBike && allCitybikes?.length && !conf.cityBike.seasonSet) {
+    conf.cityBike.seasonSet = true;
+
+    if (conf.cityBike.useAllSeasons) {
       allCitybikes.forEach(cb => {
         const confCitybike = conf.cityBike.networks[cb.networkName];
         if (confCitybike) {

--- a/app/config.js
+++ b/app/config.js
@@ -19,9 +19,9 @@ if (defaultConfig.themeMap) {
   });
 }
 
-let allCitybikes;
-export function setAvailableCitybikes(citybikes) {
-  allCitybikes = [...citybikes];
+let citybikeSeasonDefinitions;
+export function setAvailableCitybikeConfigurations(seasonDefs) {
+  citybikeSeasonDefinitions = [...seasonDefs];
 }
 
 let allZones;
@@ -162,23 +162,29 @@ export function getNamedConfiguration(configName) {
       }
     }
   }
-  if (conf.cityBike && allCitybikes?.length && !conf.cityBike.seasonSet) {
+  if (
+    conf.cityBike &&
+    citybikeSeasonDefinitions?.length &&
+    !conf.cityBike.seasonSet
+  ) {
     conf.cityBike.seasonSet = true;
 
     if (conf.cityBike.useAllSeasons) {
-      allCitybikes.forEach(cb => {
-        const confCitybike = conf.cityBike.networks[cb.networkName];
+      citybikeSeasonDefinitions.forEach(seasonDef => {
+        const confCitybike = conf.cityBike.networks[seasonDef.networkName];
         if (confCitybike) {
-          confCitybike.enabled = cb.enabled;
-          confCitybike.season = cb.season;
+          confCitybike.enabled = seasonDef.enabled;
+          confCitybike.season = seasonDef.season;
         }
       });
     } else {
-      const networks = allCitybikes.filter(cb => configName === cb.config);
-      networks.forEach(network => {
-        const confCitybike = conf.cityBike.networks[network.networkName];
-        confCitybike.enabled = network.enabled;
-        confCitybike.season = network.season;
+      const seasonDefinitions = citybikeSeasonDefinitions.filter(
+        seasonDef => configName === seasonDef.config,
+      );
+      seasonDefinitions.forEach(seasonDef => {
+        const confCitybike = conf.cityBike.networks[seasonDef.networkName];
+        confCitybike.enabled = seasonDef.enabled;
+        confCitybike.season = seasonDef.season;
       });
     }
   }

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -170,6 +170,7 @@ export default {
   suggestBikeMaxDistance: 2000000,
 
   cityBike: {
+    useAllSeasons: true,
     networks: {
       smoove: HSLConfig.cityBike.networks.smoove,
       vantaa: HSLConfig.cityBike.networks.vantaa,

--- a/app/util/modeUtils.js
+++ b/app/util/modeUtils.js
@@ -10,7 +10,7 @@ import { isDevelopmentEnvironment } from './envUtils';
 
 export function isCitybikeSeasonActive(season) {
   if (!season) {
-    return true;
+    return false;
   }
   const currentDate = new Date();
 

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "language": "javascript"
   },
   "dependencies": {
+    "@azure/cosmos": "^4.0.0",
     "@babel/core": "7.23.9",
     "@babel/preset-env": "7.23.9",
     "@babel/preset-react": "7.23.3",

--- a/server/server.js
+++ b/server/server.js
@@ -405,7 +405,7 @@ function buildCitybikeConfig(cb, networkName, configName) {
   };
 }
 
-function handleCityBikes(schedules, configName) {
+function handleCitybikes(schedules, configName) {
   const bikes = schedules.filter(
     cb => cb.region.toLowerCase() === configName || cb.config === configName,
   );
@@ -429,7 +429,7 @@ function handleCityBikes(schedules, configName) {
   });
   return cbConfigurations;
 }
-function fetchCityBikeConfigurations() {
+function fetchCitybikeConfigurations() {
   if (!process.env.CITYBIKE_DB_CONN_STRING || !process.env.CITYBIKE_DATABASE) {
     return Promise.resolve();
   }
@@ -449,7 +449,7 @@ function fetchCityBikeConfigurations() {
           if (cityBike && Object.keys(cityBike).length > 0) {
             promises.push(
               new Promise(resolve => {
-                resolve(handleCityBikes(schedules, configName));
+                resolve(handleCitybikes(schedules, configName));
               }),
             );
           }
@@ -484,7 +484,7 @@ Promise.all([
   setUpAvailableRouteTimetables(),
   setUpAvailableTickets(),
   collectGeoJsonZones(),
-  fetchCityBikeConfigurations(),
+  fetchCitybikeConfigurations(),
 ]).then(startServer);
 
 module.exports.app = app;

--- a/server/server.js
+++ b/server/server.js
@@ -412,8 +412,9 @@ function handleCitybikeSeasonConfigurations(schedules, configName) {
       seasonDef.config === configName,
   );
   const configurations = [];
-  seasonDefinitions.forEach(def => buildCitybikeConfig(def, configName));
-
+  seasonDefinitions.forEach(def =>
+    configurations.push(buildCitybikeConfig(def, configName)),
+  );
   return configurations;
 }
 function fetchCitybikeConfigurations() {

--- a/server/server.js
+++ b/server/server.js
@@ -393,9 +393,8 @@ function buildCitybikeConfig(seasonDef, configName) {
   const [endDay, endMonth, endYear] = inSeason[1].split('.');
   const [preDay, preMonth, preYear] = seasonDef.preSeason.split('.');
   return {
-    config: configName,
+    configName: seasonDef.configName,
     networkName: seasonDef.networkName,
-    region: seasonDef.region,
     enabled: seasonDef.enabled,
     season: {
       preSeasonStart: parseDate(preYear, preMonth, preDay),
@@ -407,9 +406,7 @@ function buildCitybikeConfig(seasonDef, configName) {
 
 function handleCitybikeSeasonConfigurations(schedules, configName) {
   const seasonDefinitions = schedules.filter(
-    seasonDef =>
-      seasonDef.region.toLowerCase() === configName ||
-      seasonDef.config === configName,
+    seasonDef => seasonDef.configName === configName,
   );
   const configurations = [];
   seasonDefinitions.forEach(def =>
@@ -448,7 +445,10 @@ function fetchCitybikeConfigurations() {
         const seasonDefinitions = definitions
           .filter(seasonDef => Object.keys(seasonDef).length > 0)
           .flat()
-          .filter((v, i, a) => a.findIndex(v2 => v2.region === v.region) === i);
+          .filter(
+            (v, i, a) =>
+              a.findIndex(v2 => v2.networkName === v.networkName) === i,
+          );
         console.log(
           `fetched: ${seasonDefinitions.length} citybike season configuration`,
         );

--- a/test/unit/component/MapLayersDialogContent.test.js
+++ b/test/unit/component/MapLayersDialogContent.test.js
@@ -192,6 +192,11 @@ describe('<MapLayersDialogContent />', () => {
   });
 
   it('should update the citybike layer', () => {
+    const today = new Date();
+    const yesterday = new Date(today);
+    const tomorrow = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    tomorrow.setDate(tomorrow.getDate() + 1);
     let mapLayers = {
       citybike: false,
       stop: {},
@@ -213,9 +218,9 @@ describe('<MapLayersDialogContent />', () => {
             foo: {
               enabled: true,
               season: {
-                start: new Date(),
-                end: new Date(),
-                preSeasonStart: new Date(),
+                start: today,
+                end: tomorrow,
+                preSeasonStart: yesterday,
               },
             },
           },

--- a/test/unit/component/MapLayersDialogContent.test.js
+++ b/test/unit/component/MapLayersDialogContent.test.js
@@ -212,6 +212,11 @@ describe('<MapLayersDialogContent />', () => {
           networks: {
             foo: {
               enabled: true,
+              season: {
+                start: new Date(),
+                end: new Date(),
+                preSeasonStart: new Date(),
+              },
             },
           },
         },
@@ -234,7 +239,6 @@ describe('<MapLayersDialogContent />', () => {
       .find('.option-checkbox.large input')
       .at(0)
       .simulate('change', { target: { checked: true } });
-
     expect(mapLayers.citybike).to.equal(true);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,7 +70,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/core-auth@npm:^1.3.0":
+"@azure/core-auth@npm:^1.3.0, @azure/core-auth@npm:^1.4.0":
   version: 1.6.0
   resolution: "@azure/core-auth@npm:1.6.0"
   dependencies:
@@ -124,6 +124,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/core-rest-pipeline@npm:^1.2.0":
+  version: 1.14.0
+  resolution: "@azure/core-rest-pipeline@npm:1.14.0"
+  dependencies:
+    "@azure/abort-controller": ^2.0.0
+    "@azure/core-auth": ^1.4.0
+    "@azure/core-tracing": ^1.0.1
+    "@azure/core-util": ^1.3.0
+    "@azure/logger": ^1.0.0
+    http-proxy-agent: ^5.0.0
+    https-proxy-agent: ^5.0.0
+    tslib: ^2.2.0
+  checksum: 7cb839d0cd5695db52f1bfd1a54d98f22d58a4c19e88412bb92a930076a2d9750064a4227aeb7e2973a647ce69b05b6129f65e0c95f36d0128a2e021ba155d6c
+  languageName: node
+  linkType: hard
+
 "@azure/core-tracing@npm:1.0.0-preview.13":
   version: 1.0.0-preview.13
   resolution: "@azure/core-tracing@npm:1.0.0-preview.13"
@@ -134,13 +150,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/core-util@npm:^1.1.0, @azure/core-util@npm:^1.1.1, @azure/core-util@npm:^1.2.0":
+"@azure/core-tracing@npm:^1.0.0, @azure/core-tracing@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@azure/core-tracing@npm:1.0.1"
+  dependencies:
+    tslib: ^2.2.0
+  checksum: ae4309f8ab0b52c37f699594d58ee095782649f538bd6a0ee03e3fea042f55df7ad95c2e6dec22f5b8c3907e4bcf98d6ca98faaf480d446b73d41bbc1519d891
+  languageName: node
+  linkType: hard
+
+"@azure/core-util@npm:^1.1.0, @azure/core-util@npm:^1.1.1, @azure/core-util@npm:^1.2.0, @azure/core-util@npm:^1.3.0":
   version: 1.7.0
   resolution: "@azure/core-util@npm:1.7.0"
   dependencies:
     "@azure/abort-controller": ^2.0.0
     tslib: ^2.2.0
   checksum: a393c7d64a7738289b14b5d9ec04e48e5db8e8154341024623b68f6cebf5921858bedd6f85e224253edfcf72af70a44877840cf94b348bd5f3d319a8d6e2ce4b
+  languageName: node
+  linkType: hard
+
+"@azure/cosmos@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@azure/cosmos@npm:4.0.0"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-auth": ^1.3.0
+    "@azure/core-rest-pipeline": ^1.2.0
+    "@azure/core-tracing": ^1.0.0
+    debug: ^4.1.1
+    fast-json-stable-stringify: ^2.1.0
+    jsbi: ^3.1.3
+    node-abort-controller: ^3.0.0
+    priorityqueuejs: ^1.0.0
+    semaphore: ^1.0.5
+    tslib: ^2.2.0
+    universal-user-agent: ^6.0.0
+    uuid: ^8.3.0
+  checksum: 81a11c8c757c62bf3c6edde8ba9335cd86c301660df5091157a8f5c94858be3d490d931ed91f25bc2f970a426c536b361f42f503569d7222c0750eb0fc1ed506
   languageName: node
   linkType: hard
 
@@ -5400,6 +5446,13 @@ __metadata:
   version: 1.1.2
   resolution: "@tootallnate/once@npm:1.1.2"
   checksum: e1fb1bbbc12089a0cb9433dc290f97bddd062deadb6178ce9bcb93bb7c1aecde5e60184bc7065aec42fe1663622a213493c48bbd4972d931aae48315f18e1be9
+  languageName: node
+  linkType: hard
+
+"@tootallnate/once@npm:2":
+  version: 2.0.0
+  resolution: "@tootallnate/once@npm:2.0.0"
+  checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
   languageName: node
   linkType: hard
 
@@ -10907,6 +10960,7 @@ __metadata:
   dependencies:
     "@axe-core/react": ^4.7.3
     "@axe-core/webdriverjs": ^4.7.3
+    "@azure/cosmos": ^4.0.0
     "@azure/storage-blob": ^12.8.0
     "@babel/cli": 7.23.9
     "@babel/core": 7.23.9
@@ -15086,6 +15140,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-proxy-agent@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "http-proxy-agent@npm:5.0.0"
+  dependencies:
+    "@tootallnate/once": 2
+    agent-base: 6
+    debug: 4
+  checksum: e2ee1ff1656a131953839b2a19cd1f3a52d97c25ba87bd2559af6ae87114abf60971e498021f9b73f9fd78aea8876d1fb0d4656aac8a03c6caa9fc175f22b786
+  languageName: node
+  linkType: hard
+
 "http-proxy-agent@npm:^7.0.0":
   version: 7.0.0
   resolution: "http-proxy-agent@npm:7.0.0"
@@ -17289,6 +17354,13 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
+  languageName: node
+  linkType: hard
+
+"jsbi@npm:^3.1.3":
+  version: 3.2.5
+  resolution: "jsbi@npm:3.2.5"
+  checksum: 642d1bb139ad1c1e96c4907eb159565e980a0d168487626b493d0d0b7b341da0e43001089d3b21703fe17b18a7a6c0f42c92026f71d54471ed0a0d1b3015ec0f
   languageName: node
   linkType: hard
 
@@ -19718,6 +19790,13 @@ __metadata:
   dependencies:
     semver: ^7.3.5
   checksum: 260caae87299bb2fac6a269ba5dd378dbe1d99030396832fca7199b6cb5fd46556d2ec0d431f4a76ab2d53e49948047543afe3f1d70d0e6ebad04d33139650da
+  languageName: node
+  linkType: hard
+
+"node-abort-controller@npm:^3.0.0":
+  version: 3.1.1
+  resolution: "node-abort-controller@npm:3.1.1"
+  checksum: 2c340916af9710328b11c0828223fc65ba320e0d082214a211311bf64c2891028e42ef276b9799188c4ada9e6e1c54cf7a0b7c05dd9d59fcdc8cd633304c8047
   languageName: node
   linkType: hard
 
@@ -22502,6 +22581,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"priorityqueuejs@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "priorityqueuejs@npm:1.0.0"
+  checksum: 9400c3fdebca6ceedce7f42343611aca1860de4fd15e40d1ef71436aab0f29cff779dcbfef535901b424d01232090f2b2d442be6958d3e67262495a5197c4528
+  languageName: node
+  linkType: hard
+
 "proc-log@npm:^3.0.0":
   version: 3.0.0
   resolution: "proc-log@npm:3.0.0"
@@ -24913,6 +24999,13 @@ __metadata:
     "@types/node-forge": ^1.3.0
     node-forge: ^1
   checksum: 38b91c56f1d7949c0b77f9bbe4545b19518475cae15e7d7f0043f87b1626710b011ce89879a88969651f650a19d213bb15b7d5b4c2877df9eeeff7ba8f8b9bfa
+  languageName: node
+  linkType: hard
+
+"semaphore@npm:^1.0.5":
+  version: 1.1.0
+  resolution: "semaphore@npm:1.1.0"
+  checksum: d2445d232ad9959048d4748ef54eb01bc7b60436be2b42fb7de20c4cffacf70eafeeecd3772c1baf408cfdce3805fa6618a4389590335671f18cde54ef3cfae4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

  - UI:s that utilize citybikes will fetch season configuration from external source instead of old way that the configuration resided in config files
  - In order to use this new functionality, new env variables need to be set: `CITYBIKE_DB_CONN_STRING `and `CITYBIKE_DATABASE`
  - Configurations that can be changed from the external source are
    - enabled: should we show the citybikes in our UI at all
    - season. An object containing dates for `preSeason`, `start` and `end`.
    
    
   - Please note that `showCitybieNetwork` function in `modeUtils.js` contains `isDevelopmentEnvironment(config)` check. 
      -  Citybikes will show up in your UI regardles of the season settings if this is not modified, or the data is verified in somewhere else

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
