### PR TITLE
DT-6257: Mobile time picker does not allow user to type . in input field

### DIFF
--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
@@ -49,9 +49,7 @@ function MobileTimepicker({
           e.target.setSelectionRange(0, 0); // set caret to start of input
         }}
         onChange={event => {
-          let newValue = event.target.value.includes('.')
-            ? event.target.value.replace('.', ':')
-            : event.target.value;
+          let newValue = event.target.value.replace('.', ':');
 
           const valid = validateInput(newValue);
           setValidInput(valid);

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
@@ -18,7 +18,7 @@ function MobileTimepicker({
   timeZone,
 }) {
   const [inputValue, changeInputValue] = useState(getDisplay(value));
-  const [invalidInput, setinvalidInput] = useState(false);
+  const [isValidInput, setValidInput] = useState(true);
   moment.tz.setDefault(timeZone);
   const inputId = `${id}-input`;
   const labelId = `${id}-label`;
@@ -28,6 +28,7 @@ function MobileTimepicker({
       timeInputRef.current.focus();
     }
   }, []);
+  const showError = !isValidInput;
   return (
     <label className={styles['input-container']} htmlFor={inputId}>
       <span>{icon}</span>
@@ -41,7 +42,7 @@ function MobileTimepicker({
         maxLength="6"
         className={cx(
           styles['time-input-mobile'],
-          invalidInput ? 'mobile-datetimepicker-invalid-input' : '',
+          showError ? 'mobile-datetimepicker-invalid-input' : '',
         )}
         value={inputValue}
         onFocus={e => {
@@ -53,7 +54,7 @@ function MobileTimepicker({
             : event.target.value;
 
           const valid = validateInput(newValue);
-          setinvalidInput(valid);
+          setValidInput(valid);
           if (
             // number typed as first char => clear rest of the input
             newValue.match(/[0-9]{3}:[0-9]{2}/) &&

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
@@ -48,7 +48,10 @@ function MobileTimepicker({
           e.target.setSelectionRange(0, 0); // set caret to start of input
         }}
         onChange={event => {
-          let newValue = event.target.value;
+          let newValue = event.target.value.includes('.')
+            ? event.target.value.replace('.', ':')
+            : event.target.value;
+
           const valid = validateInput(newValue);
           setinvalidInput(valid);
           if (

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/utils.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/utils.js
@@ -36,11 +36,11 @@ const validateClock = (hours, minutes) => {
 export function validateInput(inputValue) {
   // We don't accept seconds in the input
   if (inputValue.split(':').length > 2) {
-    return true;
+    return false;
   }
   if (inputValue.length <= 2) {
     // Too many options, don't  validate
-    return false;
+    return true;
   }
   if (inputValue.length === 3) {
     let hours;
@@ -51,7 +51,7 @@ export function validateInput(inputValue) {
       hours = inputValue.substring(0, inputValue.length - 1);
       minutes = inputValue.substring(inputValue.length - 1 || 0);
       if (Number(minutes) > 5) {
-        return true;
+        return false;
       }
     } else {
       // This is how basically moment handles string formatting.
@@ -70,9 +70,9 @@ export function validateInput(inputValue) {
       } else {
         [hours, minutes] = [values[0], values[1].concat(values[2])];
       }
-      return !validateClock(hours, minutes);
+      return validateClock(hours, minutes);
     }
-    return !validateClock(hours, minutes);
+    return validateClock(hours, minutes);
   }
   if (inputValue.length === 5 || inputValue.length === 4) {
     const values = inputValue.split(':');
@@ -83,12 +83,12 @@ export function validateInput(inputValue) {
       minutes.length === 1 &&
       Number(minutes) > 5
     ) {
-      return true;
+      return false;
     }
 
-    return !validateClock(hours, minutes);
+    return validateClock(hours, minutes);
   }
-  return false;
+  return true;
 }
 
 export const getTs = (inputValue, currentTimestamp) => {

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/utils.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/utils.js
@@ -34,6 +34,10 @@ const validateClock = (hours, minutes) => {
 };
 
 export function validateInput(inputValue) {
+  // We don't accept seconds in the input
+  if (inputValue.split(':').length > 2) {
+    return true;
+  }
   if (inputValue.length <= 2) {
     // Too many options, don't  validate
     return false;


### PR DESCRIPTION
## Proposed Changes

Mobile timepicker improvements: 

  - Instead of alllowing period, change the marking to colon.
  - Do not accept multiple colons, since we do not accept seconds in our input.
  - Code cleanup: `validateInput` now returns true if the input is valid.
## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
