### PR TITLE
Optimize notification requests to favourite service

### DIFF
--- a/app/component/AppBarHsl.js
+++ b/app/component/AppBarHsl.js
@@ -37,7 +37,7 @@ const AppBarHsl = ({ lang, user, favourites }, context) => {
         setBanners(data),
       );
     }
-  }, []);
+  }, [lang]);
 
   useEffect(() => {
     if (config.URL.FONTCOUNTER && config.NODE_ENV === 'production') {
@@ -103,10 +103,16 @@ const AppBarHsl = ({ lang, user, favourites }, context) => {
       : {};
 
   const siteHeaderRef = useRef(null);
+  const notificationTime = useRef(0);
 
   useEffect(() => {
-    // Refetch notifications
-    siteHeaderRef.current?.fetchNotifications();
+    const now = Date.now();
+    // refresh only once per 5 seconds
+    if (now - notificationTime.current > 5000) {
+      // Refetch notifications
+      siteHeaderRef.current?.fetchNotifications();
+      notificationTime.current = now;
+    }
   }, [favourites]);
 
   return (

--- a/app/component/FavouriteVehicleRentalStationContainer.js
+++ b/app/component/FavouriteVehicleRentalStationContainer.js
@@ -10,10 +10,7 @@ const FavouriteVehicleRentalStationContainer = connectToStores(
   (context, { vehicleRentalStation }) => ({
     favourite: context
       .getStore('FavouriteStore')
-      .isFavouriteVehicleRentalStation(
-        vehicleRentalStation.stationId,
-        vehicleRentalStation.network,
-      ),
+      .isFavourite(vehicleRentalStation.stationId, 'bikeStation'),
     isFetching: context.getStore('FavouriteStore').getStatus() === 'fetching',
     addFavourite: () => {
       context.executeAction(saveFavourite, {
@@ -29,10 +26,7 @@ const FavouriteVehicleRentalStationContainer = connectToStores(
         action: 'MarkBikeRentalStationAsFavourite',
         name: !context
           .getStore('FavouriteStore')
-          .isFavouriteVehicleRentalStation(
-            vehicleRentalStation.stationId,
-            vehicleRentalStation.network,
-          ),
+          .isFavourite(vehicleRentalStation.stationId, 'bikeStation'),
       });
     },
     deleteFavourite: () => {
@@ -48,10 +42,7 @@ const FavouriteVehicleRentalStationContainer = connectToStores(
         action: 'MarkBikeRentalStationAsFavourite',
         name: !context
           .getStore('FavouriteStore')
-          .isFavouriteVehicleRentalStation(
-            vehicleRentalStation.stationId,
-            vehicleRentalStation.network,
-          ),
+          .isFavourite(vehicleRentalStation.stationId, 'bikeStation'),
       });
     },
     requireLoggedIn: !context.config.allowFavouritesFromLocalstorage,

--- a/app/store/FavouriteStore.js
+++ b/app/store/FavouriteStore.js
@@ -109,10 +109,14 @@ export default class FavouriteStore extends Store {
   }
 
   isFavourite(id, type) {
-    const ids = this.favourites
-      .filter(favourite => favourite.type === type)
-      .map(favourite => favourite.gtfsId || favourite.gid);
-    return includes(ids, id);
+    for (let i = 0; i < this.favourites.length; i++) {
+      const favourite = this.favourites[i];
+      const fid = favourite.gtfsId || favourite.gid;
+      if (favourite.type === type && fid === id) {
+        return true;
+      }
+    }
+    return false;
   }
 
   isFavouriteVehicleRentalStation(id, network) {

--- a/app/store/FavouriteStore.js
+++ b/app/store/FavouriteStore.js
@@ -133,10 +133,6 @@ export default class FavouriteStore extends Store {
     this.emitChange();
   }
 
-  storeFavourites() {
-    setFavouriteStorage(this.favourites);
-  }
-
   getFavourites() {
     return this.mappedFavourites;
   }
@@ -253,13 +249,13 @@ export default class FavouriteStore extends Store {
           onFail();
           if (this.config.allowFavouritesFromLocalstorage) {
             this.set(newFavourites);
-            this.storeFavourites();
+            setFavouriteStorage(this.favourites);
           }
           this.fetchComplete();
         });
     } else {
       this.set(newFavourites);
-      this.storeFavourites();
+      setFavouriteStorage(this.favourites);
     }
   }
 
@@ -289,13 +285,13 @@ export default class FavouriteStore extends Store {
           onFail();
           if (this.config.allowFavouritesFromLocalstorage) {
             this.set(mapped);
-            this.storeFavourites();
+            setFavouriteStorage(this.favourites);
           }
           this.fetchComplete();
         });
     } else {
       this.set(mapped);
-      this.storeFavourites();
+      setFavouriteStorage(this.favourites);
     }
   }
 
@@ -325,13 +321,13 @@ export default class FavouriteStore extends Store {
           onFail();
           if (this.config.allowFavouritesFromLocalstorage) {
             this.set(newFavourites);
-            this.storeFavourites();
+            setFavouriteStorage(this.favourites);
           }
           this.fetchComplete();
         });
     } else {
       this.set(newFavourites);
-      this.storeFavourites();
+      setFavouriteStorage(this.favourites);
     }
   }
 

--- a/app/store/FavouriteStore.js
+++ b/app/store/FavouriteStore.js
@@ -47,7 +47,6 @@ export default class FavouriteStore extends Store {
   static FETCH_FAILED = 'fetch-failed';
 
   favourites = [];
-  mappedFavourites = [];
 
   config = {};
 
@@ -57,8 +56,7 @@ export default class FavouriteStore extends Store {
     super(dispatcher);
     this.config = dispatcher.getContext().config;
     if (!this.config.allowLogin) {
-      this.favourites = getFavouriteStorage();
-      this.mappedFavourites = mapFromStore(this.favourites);
+      this.favourites = mapFromStore(getFavouriteStorage());
     } else {
       this.status = FavouriteStore.STATUS_FETCHING_OR_UPDATING;
     }
@@ -80,8 +78,7 @@ export default class FavouriteStore extends Store {
   }
 
   set(favs) {
-    this.favourites = favs;
-    this.mappedFavourites = mapFromStore(this.favourites);
+    this.favourites = mapFromStore(favs);
     this.fetchComplete();
   }
 
@@ -109,8 +106,8 @@ export default class FavouriteStore extends Store {
   }
 
   isFavourite(id, type) {
-    for (let i = 0; i < this.mappedFavourites.length; i++) {
-      const favourite = this.mappedFavourites[i];
+    for (let i = 0; i < this.favourites.length; i++) {
+      const favourite = this.favourites[i];
       const fid = favourite.gtfsId || favourite.gid || favourite.stationId;
       if (favourite.type === type && fid === id) {
         return true;
@@ -122,54 +119,51 @@ export default class FavouriteStore extends Store {
   clearFavourites() {
     clearFavouriteStorage();
     this.favourites = [];
-    this.mappedFavourites = [];
     this.storeFavourites();
     this.emitChange();
   }
 
   getFavourites() {
-    return this.mappedFavourites;
+    return this.favourites;
   }
 
   getByGtfsId(gtfsId, type) {
     return find(
-      this.mappedFavourites,
+      this.favourites,
       favourite => gtfsId === favourite.gtfsId && type === favourite.type,
     );
   }
 
   getByStationIdAndNetworks(stationId, network) {
     return find(
-      this.mappedFavourites,
+      this.favourites,
       favourite =>
         stationId === favourite.stationId && network === favourite.network,
     );
   }
 
   getRouteGtfsIds() {
-    return this.mappedFavourites
+    return this.favourites
       .filter(favourite => favourite.type === 'route')
       .map(favourite => favourite.gtfsId);
   }
 
   getStopsAndStations() {
-    return this.mappedFavourites.filter(
+    return this.favourites.filter(
       favourite => favourite.type === 'stop' || favourite.type === 'station',
     );
   }
 
   getStops() {
-    return this.mappedFavourites.filter(favourite => favourite.type === 'stop');
+    return this.favourites.filter(favourite => favourite.type === 'stop');
   }
 
   getLocations() {
-    return this.mappedFavourites.filter(
-      favourite => favourite.type === 'place',
-    );
+    return this.favourites.filter(favourite => favourite.type === 'place');
   }
 
   getVehicleRentalStations() {
-    return this.mappedFavourites.filter(
+    return this.favourites.filter(
       favourite => favourite.type === 'bikeStation',
     );
   }
@@ -216,9 +210,9 @@ export default class FavouriteStore extends Store {
     if (data.type === 'bikeStation') {
       data = mapVehicleRentalToStore(data);
     }
-    const newFavourites = this.favourites.slice();
+    const newFavourites = mapToStore(this.favourites);
     const editIndex = findIndex(
-      this.favourites,
+      newFavourites,
       item => data.favouriteId === item.favouriteId,
     );
     if (editIndex >= 0) {
@@ -243,13 +237,13 @@ export default class FavouriteStore extends Store {
           onFail();
           if (this.config.allowFavouritesFromLocalstorage) {
             this.set(newFavourites);
-            setFavouriteStorage(this.favourites);
+            setFavouriteStorage(newFavourites);
           }
           this.fetchComplete();
         });
     } else {
       this.set(newFavourites);
-      setFavouriteStorage(this.favourites);
+      setFavouriteStorage(newFavourites);
     }
   }
 
@@ -279,13 +273,13 @@ export default class FavouriteStore extends Store {
           onFail();
           if (this.config.allowFavouritesFromLocalstorage) {
             this.set(mapped);
-            setFavouriteStorage(this.favourites);
+            setFavouriteStorage(mapped);
           }
           this.fetchComplete();
         });
     } else {
       this.set(mapped);
-      setFavouriteStorage(this.favourites);
+      setFavouriteStorage(mapped);
     }
   }
 
@@ -302,7 +296,7 @@ export default class FavouriteStore extends Store {
       throw new Error(`Favourite is not an object:${JSON.stringify(data)}`);
     }
     this.fetchingOrUpdating();
-    const newFavourites = this.favourites.filter(
+    const newFavourites = mapToStore(this.favourites).filter(
       favourite => favourite.favouriteId !== data.favouriteId,
     );
     if (this.config.allowLogin) {
@@ -315,13 +309,13 @@ export default class FavouriteStore extends Store {
           onFail();
           if (this.config.allowFavouritesFromLocalstorage) {
             this.set(newFavourites);
-            setFavouriteStorage(this.favourites);
+            setFavouriteStorage(newFavourites);
           }
           this.fetchComplete();
         });
     } else {
       this.set(newFavourites);
-      setFavouriteStorage(this.favourites);
+      setFavouriteStorage(newFavourites);
     }
   }
 

--- a/app/store/FavouriteStore.js
+++ b/app/store/FavouriteStore.js
@@ -1,5 +1,4 @@
 import Store from 'fluxible/addons/BaseStore';
-import includes from 'lodash/includes';
 import find from 'lodash/find';
 import findIndex from 'lodash/findIndex';
 import isEmpty from 'lodash/isEmpty';
@@ -48,6 +47,7 @@ export default class FavouriteStore extends Store {
   static FETCH_FAILED = 'fetch-failed';
 
   favourites = [];
+  mappedFavourites = [];
 
   config = {};
 
@@ -109,24 +109,14 @@ export default class FavouriteStore extends Store {
   }
 
   isFavourite(id, type) {
-    for (let i = 0; i < this.favourites.length; i++) {
-      const favourite = this.favourites[i];
-      const fid = favourite.gtfsId || favourite.gid;
+    for (let i = 0; i < this.mappedFavourites.length; i++) {
+      const favourite = this.mappedFavourites[i];
+      const fid = favourite.gtfsId || favourite.gid || favourite.stationId;
       if (favourite.type === type && fid === id) {
         return true;
       }
     }
     return false;
-  }
-
-  isFavouriteVehicleRentalStation(id, network) {
-    const ids = this.favourites
-      .filter(
-        favourite =>
-          favourite.type === 'bikeStation' && favourite.networks[0] === network,
-      )
-      .map(favourite => `${favourite.networks[0]}:${favourite.stationId}`);
-    return includes(ids, id);
   }
 
   clearFavourites() {


### PR DESCRIPTION
A recent change in favourites store introduced a new bug, making the store to deliver a new set of favourites in every  read. In addition to that, favourite store got updated once when  favorites were read. These together caused a burst of 4-7 favorite service requests when UI was loaded, and one call more in each page mount.

 Now UI fetches notifiers only once. New fetch happens only if favourites genuinely change.
