### PR TITLE
Include more languages for moment in datetime picker

### DIFF
--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React, { useState, useEffect, useRef } from 'react';
 import moment from 'moment-timezone';
 import 'moment/locale/fi';
+import 'moment/locale/sv';
+import 'moment/locale/de';
 import uniqueId from 'lodash/uniqueId';
 import i18next from 'i18next';
 import Icon from '@digitransit-component/digitransit-component-icon';

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobilePickerModal.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobilePickerModal.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import moment from 'moment-timezone';
 import 'moment/locale/fi';
+import 'moment/locale/sv';
+import 'moment/locale/de';
 import uniqueId from 'lodash/uniqueId';
 import i18next from 'i18next';
 import Modal from 'react-modal';


### PR DESCRIPTION
## Proposed Changes

  - Include swedish and german for moment in the datetime picker
    - This fixes an issue for hsl.fi where swedish week day names were not shown

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
