### PR TITLE
Optimize stops near you rendering a bit

### DIFF
--- a/app/component/StopsNearYouMapContainer.js
+++ b/app/component/StopsNearYouMapContainer.js
@@ -77,6 +77,7 @@ const containerComponent = createPaginationContainer(
                   lon
                   name
                   patterns {
+                    id
                     route {
                       gtfsId
                       shortName
@@ -91,6 +92,7 @@ const containerComponent = createPaginationContainer(
                   }
                   stops {
                     patterns {
+                      id
                       route {
                         gtfsId
                         shortName

--- a/app/component/StopsNearYouMapContainer.js
+++ b/app/component/StopsNearYouMapContainer.js
@@ -77,7 +77,6 @@ const containerComponent = createPaginationContainer(
                   lon
                   name
                   patterns {
-                    id
                     route {
                       gtfsId
                       shortName
@@ -92,7 +91,6 @@ const containerComponent = createPaginationContainer(
                   }
                   stops {
                     patterns {
-                      id
                       route {
                         gtfsId
                         shortName

--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -96,7 +96,6 @@ class StopsNearYouPage extends React.Component {
     super(props);
     this.state = {
       phase: PH_START,
-      centerOfMap: null,
       centerOfMapChanged: false,
       showCityBikeTeaser: true,
       searchPosition: {},
@@ -235,22 +234,11 @@ class StopsNearYouPage extends React.Component {
     };
   };
 
-  setCenterOfMap = (mapElement, e) => {
+  setCenterOfMap = mapElement => {
     let location;
     if (!mapElement) {
-      if (distance(this.state.searchPosition, this.props.position) > 100) {
-        // user has pressed locate me after moving on the map via the search box
-        return this.setState({
-          centerOfMap: this.props.position,
-          centerOfMapChanged: true,
-        });
-      }
-      return this.setState({
-        centerOfMap: this.props.position,
-        centerOfMapChanged: false,
-      });
-    }
-    if (this.props.breakpoint === 'large') {
+      location = this.props.position;
+    } else if (this.props.breakpoint === 'large') {
       const centerOfMap = mapElement.leafletElement.getCenter();
       location = { lat: centerOfMap.lat, lon: centerOfMap.lng };
     } else {
@@ -265,25 +253,17 @@ class StopsNearYouPage extends React.Component {
       ]);
       location = { lat: point.lat, lon: point.lng };
     }
-    if (distance(location, this.state.searchPosition) > 100) {
-      // user has scrolled over 100 meters on the map
-      if (e || this.state.centerOfMapChanged) {
-        return this.setState({
-          centerOfMap: location,
-          centerOfMapChanged: true,
-        });
-      }
+    this.centerOfMap = location;
+    const changed = distance(location, this.state.searchPosition) > 100;
+    if (changed !== this.state.centerOfMapChanged) {
+      this.setState({ centerOfMapChanged: changed });
     }
-    return this.setState({
-      centerOfMap: location,
-      centerOfMapChanged: false,
-    });
   };
 
   updateLocation = () => {
-    const { centerOfMap } = this.state;
+    const { centerOfMap } = this;
     const { mode } = this.props.match.params;
-    if (centerOfMap && centerOfMap.lat && centerOfMap.lon) {
+    if (centerOfMap?.lat && centerOfMap?.lon) {
       let phase = PH_USEMAPCENTER;
       let type = 'CenterOfMap';
       if (centerOfMap.type === 'CurrentLocation') {
@@ -799,10 +779,10 @@ class StopsNearYouPage extends React.Component {
       ...this.props.match.location,
       pathname: path,
     });
+    this.centerOfMap = null;
     this.setState({
       phase: PH_USEDEFAULTPOS,
       searchPosition: item,
-      centerOfMap: null,
       centerOfMapChanged: false,
     });
   };

--- a/app/component/map/StopsNearYouMap.js
+++ b/app/component/map/StopsNearYouMap.js
@@ -314,7 +314,6 @@ function StopsNearYouMap(
           });
         });
     });
-    patterns = uniqBy(patterns, p => p.id);
     patterns = uniqBy(patterns, p => p.patternGeometry?.points || '');
     const lines = patterns
       .filter(p => p.patternGeometry)


### PR DESCRIPTION
Stops near you view has bad  update flow and the whole page is rendered constantly. This is problematic, because the map  collects thousands of route patterns and decodes thousands of geometry points from each pattern. Such computation is very expensive. 

This PR introduces two fixes which mitigate the problems partly:
1. View navigation no longer always triggers full page render. Only when refecth stops button should appear/disapper, rendering occurs.
2. Polyline  conversion to leaflet objects is now done in the effect which monitors relevant changes.  Previously, every render cycle  executed the heavy  computation.

In the future, the view should be split into smaller components with sensible data dependencies. For example, map does not need re-rendering when departure times change.
