### PR TITLE
DT-6352 start search from the user location when in the configured waltti area

### DIFF
--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -148,11 +148,7 @@ class IndexPage extends React.Component {
       !this.props.origin.address &&
       this.props.locationState?.hasLocation &&
       this.props.locationState;
-    if (
-      config.startSearchFromUserLocation &&
-      currentLocation &&
-      !currentLocation.isReverseGeocodingInProgress
-    ) {
+    if (currentLocation && !currentLocation.isReverseGeocodingInProgress) {
       const originPoint = [currentLocation.lon, currentLocation.lat];
       if (inside(originPoint, config.areaPolygon)) {
         this.context.executeAction(storeOrigin, currentLocation);

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -148,8 +148,11 @@ class IndexPage extends React.Component {
       !this.props.origin.address &&
       this.props.locationState?.hasLocation &&
       this.props.locationState;
-
-    if (config.startSearchFromUserLocation && currentLocation) {
+    if (
+      config.startSearchFromUserLocation &&
+      currentLocation &&
+      !currentLocation.isReverseGeocodingInProgress
+    ) {
       const originPoint = [currentLocation.lon, currentLocation.lat];
       if (inside(originPoint, config.areaPolygon)) {
         this.context.executeAction(storeOrigin, currentLocation);

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -242,4 +242,6 @@ export default {
       ? fareId.substring(fareId.indexOf(':') + 1)
       : '';
   },
+
+  startSearchFromUserLocation: true,
 };


### PR DESCRIPTION
## Proposed Changes

  - When user has already given the permission to use location, add current location as the starting point for a route search by default. 
  - Only do this if the user is within the configured service area of the instance. 
  - Configurable on/off in the instance settings, configured for all waltti instances.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
