### PR TITLE
DT-6182 fix missing bicycle-only journeys

### DIFF
--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -439,15 +439,14 @@ export function mergeBikeTransitPlans(bikeParkPlan, bikeTransitPlan) {
  * Combine a scooter edge with the main transit edges.
  */
 export function mergeScooterTransitPlan(scooterPlan, transitPlan) {
-  const scooterTransitEdges = scooterEdges(scooterPlan?.edges);
-  const publicTransitEdges = transitEdges(transitPlan?.edges);
+  const scooterTransitEdges = scooterEdges(scooterPlan.edges);
   const maxTransitEdges =
-    scooterTransitEdges.length > 0 ? 4 : publicTransitEdges.length;
+    scooterTransitEdges.length > 0 ? 4 : transitPlan.edges.length;
 
   return {
     edges: [
       ...scooterTransitEdges.slice(0, 1),
-      ...publicTransitEdges.slice(0, maxTransitEdges),
+      ...transitPlan.edges.slice(0, maxTransitEdges),
     ]
       .sort((a, b) => {
         return a.node.end > b.node.end;


### PR DESCRIPTION
## Proposed Changes

  - Journeys with only bicycle and walking were missing from the journey list because of faulty filtering at scooter merge.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
