### PR TITLE
DT-6392 use correct default prop value for map location tracking

### DIFF
--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -98,7 +98,7 @@ class MapWithTrackingStateHandler extends React.Component {
     mapRef: undefined,
     children: undefined,
     leafletObjs: undefined,
-    mapTracking: false,
+    mapTracking: undefined,
     onStartNavigation: undefined,
     onEndNavigation: undefined,
     onMapTracking: undefined,


### PR DESCRIPTION
Default prop mapTracking=false means that tracking should be turned off.  Correct default value is undefined, which keeps existing tracking state.