### PR TITLE
DT-6182 no scooter plan when walk is better

### DIFF
--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -472,7 +472,7 @@ export function mergeScooterTransitPlan(scooterPlan, transitPlan) {
   if (
     transitPlanEdges.length === 1 &&
     transitPlanEdges[0].node.legs.every(leg => leg.mode === 'WALK') &&
-    transitPlanEdges[0].node.end < scooterTransitEdges?.[0]?.node.end
+    transitPlanEdges[0].node.end < scooterTransitEdges[0]?.node.end
   ) {
     return transitPlan;
   }

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -468,6 +468,15 @@ export function mergeScooterTransitPlan(scooterPlan, transitPlan) {
   const maxTransitEdges =
     scooterTransitEdges.length > 0 ? 4 : transitPlanEdges.length;
 
+  // special case: if transitplan only has one walk itinerary, don't show scooter plan if it arrives later.
+  if (
+    transitPlanEdges.length === 1 &&
+    transitPlanEdges[0].node.legs.every(leg => leg.mode === 'WALK') &&
+    transitPlanEdges[0].node.end < scooterTransitEdges?.[0]?.node.end
+  ) {
+    return transitPlan;
+  }
+
   return {
     edges: [
       ...scooterTransitEdges.slice(0, 1),


### PR DESCRIPTION
## Proposed Changes

  - Don't show scooter routes that arrive later than walking. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
