### PR TITLE
Fix showing vehicle rental stations on map if there are unknown networks

### DIFF
--- a/app/component/map/tile-layer/VehicleRentalStations.js
+++ b/app/component/map/tile-layer/VehicleRentalStations.js
@@ -192,6 +192,7 @@ class VehicleRentalStations {
   };
 
   shouldShowStation = (id, network) =>
+    this.config.vehicleRental.networks[network] &&
     (this.config.vehicleRental.networks[network].showRentalStations ===
       undefined ||
       this.config.vehicleRental.networks[network].showRentalStations) &&


### PR DESCRIPTION
## Proposed Changes

  - Fix displaying of vehicle rental stations on map in case there is an unknown network

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
