### PR TITLE
Fix issue with script when SUBSCRIPTION_KEY was not specified

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,16 +1,20 @@
 # Using scripts
 
-## Before using:
+## Before using
 ```
 source ui.sh
 ```
 ## Usage examples
 
-Using remote instance of OTP with subscription key.
+Using remote instance of OTP with subscription key:
 ```
 SUBSCRIPTION_KEY=<your_subscription_key> ui hsl
 ```
-Using local instance of OTP on port `9080`.
+Using local instance of OTP on port `9080`:
 ```
-uiotp matka
+SUBSCRIPTION_KEY=<your_subscription_key> uiotp matka
+```
+In case you do not need features usable with a subscription key when running a local instance of OTP on port `9080`:
+```
+NO_SUBSCRIPTION_KEY=true uiotp matka
 ```

--- a/scripts/ui.sh
+++ b/scripts/ui.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 ui () {
+    if [ "$SUBSCRIPTION_KEY" = "" -a "$NO_SUBSCRIPTION_KEY" != "true" ]; then
+        echo "In order to use the UI you need to set the SUBSCRIPTION_KEY environment variable."
+        echo "If you want to run the UI without a subscription key, set NO_SUBSCRIPTION_KEY=true."
+        return 1 2>/dev/null
+    fi
     CONFIG=$1 API_SUBSCRIPTION_QUERY_PARAMETER_NAME=digitransit-subscription-key API_SUBSCRIPTION_HEADER_NAME=digitransit-subscription-key API_SUBSCRIPTION_TOKEN=$SUBSCRIPTION_KEY yarn run dev
 }
 


### PR DESCRIPTION
The SUBSCRIPTION_KEY is required even when running a local instance of OTP with the UI, for example, for loading the map.