### PR TITLE
DT-6423 fix date selector of stop page

### DIFF
--- a/app/component/StopTimetablePage.js
+++ b/app/component/StopTimetablePage.js
@@ -48,11 +48,8 @@ class StopTimetablePage extends React.Component {
       <TimetableContainer
         stop={this.props.stop}
         date={this.state.date}
-        propsForDateSelect={{
-          startDate: unixToYYYYMMDD(unixTime(), this.context.config),
-          selectedDate: this.state.date,
-          onDateChange: this.onDateChange,
-        }}
+        startDate={unixToYYYYMMDD(unixTime(), this.context.config)}
+        onDateChange={this.onDateChange}
       />
     );
   }

--- a/app/component/StopTimetablePage.js
+++ b/app/component/StopTimetablePage.js
@@ -28,12 +28,12 @@ class StopTimetablePage extends React.Component {
   }
 
   onDateChange = value => {
+    this.setState({ date: value });
     this.props.relay.refetch(
       {
         date: value,
       },
       null,
-      () => this.setState({ date: value }),
     );
   };
 

--- a/app/component/TerminalTimetablePage.js
+++ b/app/component/TerminalTimetablePage.js
@@ -34,12 +34,12 @@ class TerminalTimetablePage extends React.Component {
   }
 
   onDateChange = value => {
+    this.setState({ date: value });
     this.props.relay.refetch(
       {
         date: value,
       },
       null,
-      () => this.setState({ date: value }),
     );
   };
 

--- a/app/component/TerminalTimetablePage.js
+++ b/app/component/TerminalTimetablePage.js
@@ -48,11 +48,8 @@ class TerminalTimetablePage extends React.Component {
       <TimetableContainer
         stop={this.props.station}
         date={this.state.date}
-        propsForDateSelect={{
-          startDate: unixToYYYYMMDD(unixTime(), this.context.config),
-          selectedDate: this.state.date,
-          onDateChange: this.onDateChange,
-        }}
+        startDate={unixToYYYYMMDD(unixTime(), this.context.config)}
+        onDateChange={this.onDateChange}
       />
     );
   }

--- a/app/component/Timetable.js
+++ b/app/component/Timetable.js
@@ -82,17 +82,10 @@ class Timetable extends React.Component {
         }),
       ).isRequired,
     }).isRequired,
-    propsForDateSelect: PropTypes.shape({
-      startDate: PropTypes.string,
-      selectedDate: PropTypes.string,
-      onDateChange: PropTypes.func,
-    }).isRequired,
-    date: PropTypes.string,
+    startDate: PropTypes.string.isRequired,
+    onDateChange: PropTypes.func.isRequired,
+    date: PropTypes.string.isRequired,
     language: PropTypes.string.isRequired,
-  };
-
-  static defaultProps = {
-    date: undefined,
   };
 
   static contextTypes = {
@@ -183,7 +176,7 @@ class Timetable extends React.Component {
   };
 
   dateForPrinting = () => {
-    const selectedDate = moment(this.props.propsForDateSelect.selectedDate);
+    const selectedDate = moment(this.props.date);
     return (
       <div className="printable-date-container">
         <div className="printable-date-icon">
@@ -331,9 +324,7 @@ class Timetable extends React.Component {
       }${locationType.toLowerCase()}/${this.props.stop.gtfsId}`;
     const timeTableRows = this.createTimeTableRows(timetableMap);
     const timeDifferenceDays = moment
-      .duration(
-        moment(this.props.propsForDateSelect.selectedDate).diff(moment()),
-      )
+      .duration(moment(this.props.date).diff(moment()))
       .asDays();
     return (
       <>
@@ -349,10 +340,10 @@ class Timetable extends React.Component {
             ) : null}
             <div className="timetable-topbar">
               <DateSelect
-                startDate={this.props.propsForDateSelect.startDate}
-                selectedDate={this.props.propsForDateSelect.selectedDate}
+                startDate={this.props.startDate}
+                selectedDate={this.props.date}
                 onDateChange={e => {
-                  this.props.propsForDateSelect.onDateChange(e);
+                  this.props.onDateChange(e);
                   const showRoutes = this.state.showRoutes.length
                     ? this.state.showRoutes.join(',')
                     : undefined;

--- a/test/unit/component/Timetable.test.js
+++ b/test/unit/component/Timetable.test.js
@@ -12,11 +12,8 @@ import * as timetables from '../../../app/configurations/timetableConfigUtils';
 const stopIdNumber = '1140199';
 
 const props = {
-  propsForDateSelect: {
-    startDate: '20190110',
-    selectedDate: '20190110',
-    onDateChange: () => {},
-  },
+  startDate: '20190110',
+  onDateChange: () => {},
   stop: {
     gtfsId: `HSL:${stopIdNumber}`,
     locationType: 'STOP',


### PR DESCRIPTION
Date selector did not update whenever relay found timetable from cache (e.g. when selecting same date second time).