### PR TITLE
DT-6357 fix itinerary selection bugs

### DIFF
--- a/app/component/StopTimetablePage.js
+++ b/app/component/StopTimetablePage.js
@@ -48,11 +48,8 @@ class StopTimetablePage extends React.Component {
       <TimetableContainer
         stop={this.props.stop}
         date={this.state.date}
-        propsForDateSelect={{
-          startDate: unixToYYYYMMDD(unixTime(), this.context.config),
-          selectedDate: this.state.date,
-          onDateChange: this.onDateChange,
-        }}
+        startDate={unixToYYYYMMDD(unixTime(), this.context.config)}
+        onDateChange={this.onDateChange}
       />
     );
   }

--- a/app/component/StopTimetablePage.js
+++ b/app/component/StopTimetablePage.js
@@ -28,12 +28,12 @@ class StopTimetablePage extends React.Component {
   }
 
   onDateChange = value => {
+    this.setState({ date: value });
     this.props.relay.refetch(
       {
         date: value,
       },
       null,
-      () => this.setState({ date: value }),
     );
   };
 

--- a/app/component/SwipeableTabs.js
+++ b/app/component/SwipeableTabs.js
@@ -63,13 +63,8 @@ const handleKeyPress = (e, reactSwipeEl) => {
 };
 
 export default class SwipeableTabs extends React.Component {
-  constructor(props) {
-    super();
-    this.state = { tabIndex: props.tabIndex };
-  }
-
   static propTypes = {
-    tabIndex: PropTypes.number,
+    tabIndex: PropTypes.number.isRequired,
     tabs: PropTypes.arrayOf(PropTypes.node).isRequired,
     onSwipe: PropTypes.func.isRequired,
     hideArrows: PropTypes.bool,
@@ -82,7 +77,6 @@ export default class SwipeableTabs extends React.Component {
   static defaultProps = {
     hideArrows: false,
     navigationOnBottom: false,
-    tabIndex: 0,
     classname: undefined,
   };
 
@@ -100,7 +94,7 @@ export default class SwipeableTabs extends React.Component {
   }
 
   tabBalls = tabsLength => {
-    const tabIndex = parseInt(this.state.tabIndex, 10);
+    const tabIndex = parseInt(this.props.tabIndex, 10);
     const onLeft = tabIndex;
     const onRight = tabsLength - tabIndex - 1;
     let tabBalls = [];
@@ -161,17 +155,15 @@ export default class SwipeableTabs extends React.Component {
           )}
           tabIndex={0}
           className={`swipe-tab-ball ${
-            index === this.state.tabIndex ? 'selected' : ''
+            index === this.props.tabIndex ? 'selected' : ''
           } ${ball.smaller ? 'decreasing-small' : ''} ${
             ball.small ? 'decreasing' : ''
           } ${ball.hidden ? 'hidden' : ''}`}
           onClick={() => {
-            this.setState({ tabIndex: index });
             this.props.onSwipe(index);
           }}
           onKeyDown={e => {
             if (isKeyboardSelectionEvent(e)) {
-              this.setState({ tabIndex: index });
               this.props.onSwipe(index);
             }
           }}
@@ -247,7 +239,6 @@ export default class SwipeableTabs extends React.Component {
                   callback: i => {
                     // force transition after animation should be over because animation can randomly fail sometimes
                     setTimeout(() => {
-                      this.setState({ tabIndex: i });
                       this.props.onSwipe(i);
                     }, 300);
                   },
@@ -262,11 +253,7 @@ export default class SwipeableTabs extends React.Component {
             </div>
           </ScrollableWrapper>
         )}
-        <div
-          className={`swipe-header-container ${this.props.classname} ${
-            this.state.scrolled && !navigationOnBottom ? 'scrolled' : ''
-          }`}
-        >
+        <div className={`swipe-header-container ${this.props.classname}`}>
           {this.props.classname === 'swipe-desktop-view' && (
             <div className="desktop-view-divider" />
           )}
@@ -282,7 +269,7 @@ export default class SwipeableTabs extends React.Component {
             {!hideArrows && (
               <div
                 className={cx('swipe-button-container', {
-                  active: !(disabled || this.state.tabIndex <= 0),
+                  active: !(disabled || this.props.tabIndex <= 0),
                 })}
               >
                 <div
@@ -301,7 +288,7 @@ export default class SwipeableTabs extends React.Component {
                   <Icon
                     img="icon-icon_arrow-collapse--left"
                     className={`itinerary-arrow-icon ${
-                      disabled || this.state.tabIndex <= 0 ? 'disabled' : ''
+                      disabled || this.props.tabIndex <= 0 ? 'disabled' : ''
                     }`}
                   />
                 </div>
@@ -322,7 +309,7 @@ export default class SwipeableTabs extends React.Component {
             {!hideArrows && (
               <div
                 className={cx('swipe-button-container', {
-                  active: !(disabled || this.state.tabIndex >= tabs.length - 1),
+                  active: !(disabled || this.props.tabIndex >= tabs.length - 1),
                 })}
               >
                 <div
@@ -341,7 +328,7 @@ export default class SwipeableTabs extends React.Component {
                   <Icon
                     img="icon-icon_arrow-collapse--right"
                     className={`itinerary-arrow-icon ${
-                      disabled || this.state.tabIndex >= tabs.length - 1
+                      disabled || this.props.tabIndex >= tabs.length - 1
                         ? 'disabled'
                         : ''
                     }`}
@@ -361,7 +348,6 @@ export default class SwipeableTabs extends React.Component {
                   callback: i => {
                     // force transition after animation should be over because animation can randomly fail sometimes
                     setTimeout(() => {
-                      this.setState({ tabIndex: i });
                       this.props.onSwipe(i);
                     }, 300);
                   },

--- a/app/component/TerminalTimetablePage.js
+++ b/app/component/TerminalTimetablePage.js
@@ -34,12 +34,12 @@ class TerminalTimetablePage extends React.Component {
   }
 
   onDateChange = value => {
+    this.setState({ date: value });
     this.props.relay.refetch(
       {
         date: value,
       },
       null,
-      () => this.setState({ date: value }),
     );
   };
 

--- a/app/component/TerminalTimetablePage.js
+++ b/app/component/TerminalTimetablePage.js
@@ -48,11 +48,8 @@ class TerminalTimetablePage extends React.Component {
       <TimetableContainer
         stop={this.props.station}
         date={this.state.date}
-        propsForDateSelect={{
-          startDate: unixToYYYYMMDD(unixTime(), this.context.config),
-          selectedDate: this.state.date,
-          onDateChange: this.onDateChange,
-        }}
+        startDate={unixToYYYYMMDD(unixTime(), this.context.config)}
+        onDateChange={this.onDateChange}
       />
     );
   }

--- a/app/component/Timetable.js
+++ b/app/component/Timetable.js
@@ -82,17 +82,10 @@ class Timetable extends React.Component {
         }),
       ).isRequired,
     }).isRequired,
-    propsForDateSelect: PropTypes.shape({
-      startDate: PropTypes.string,
-      selectedDate: PropTypes.string,
-      onDateChange: PropTypes.func,
-    }).isRequired,
-    date: PropTypes.string,
+    startDate: PropTypes.string.isRequired,
+    onDateChange: PropTypes.func.isRequired,
+    date: PropTypes.string.isRequired,
     language: PropTypes.string.isRequired,
-  };
-
-  static defaultProps = {
-    date: undefined,
   };
 
   static contextTypes = {
@@ -183,7 +176,7 @@ class Timetable extends React.Component {
   };
 
   dateForPrinting = () => {
-    const selectedDate = moment(this.props.propsForDateSelect.selectedDate);
+    const selectedDate = moment(this.props.date);
     return (
       <div className="printable-date-container">
         <div className="printable-date-icon">
@@ -331,9 +324,7 @@ class Timetable extends React.Component {
       }${locationType.toLowerCase()}/${this.props.stop.gtfsId}`;
     const timeTableRows = this.createTimeTableRows(timetableMap);
     const timeDifferenceDays = moment
-      .duration(
-        moment(this.props.propsForDateSelect.selectedDate).diff(moment()),
-      )
+      .duration(moment(this.props.date).diff(moment()))
       .asDays();
     return (
       <>
@@ -349,10 +340,10 @@ class Timetable extends React.Component {
             ) : null}
             <div className="timetable-topbar">
               <DateSelect
-                startDate={this.props.propsForDateSelect.startDate}
-                selectedDate={this.props.propsForDateSelect.selectedDate}
+                startDate={this.props.startDate}
+                selectedDate={this.props.date}
                 onDateChange={e => {
-                  this.props.propsForDateSelect.onDateChange(e);
+                  this.props.onDateChange(e);
                   const showRoutes = this.state.showRoutes.length
                     ? this.state.showRoutes.join(',')
                     : undefined;

--- a/app/component/itinerary/ItineraryListContainer.js
+++ b/app/component/itinerary/ItineraryListContainer.js
@@ -77,14 +77,12 @@ function ItineraryListContainer(
   };
 
   const onSelectActive = index => {
-    const subpath = getSubPath('');
     if (activeIndex === index) {
       onSelectImmediately(index);
     } else {
       router.replace({
         ...match.location,
         state: { selectedItineraryIndex: index },
-        pathname: `${getItineraryPagePath(params.from, params.to)}${subpath}`,
       });
 
       addAnalyticsEvent({

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -503,6 +503,9 @@ export default function ItineraryPage(props, context) {
         laterEdges: [...state.laterEdges, ...edges],
       });
     }
+    if (arriveBy) {
+      resetItineraryPageSelection();
+    }
   };
 
   const onEarlier = async () => {
@@ -554,7 +557,6 @@ export default function ItineraryPage(props, context) {
       return;
     }
     ariaRef.current = 'itinerary-page.itineraries-loaded';
-
     const newState = {
       ...state,
       loadingMore: undefined,
@@ -584,6 +586,9 @@ export default function ItineraryPage(props, context) {
         ...separators,
         earlierEdges: [...edges, ...state.earlierEdges],
       });
+    }
+    if (!arriveBy) {
+      resetItineraryPageSelection();
     }
   };
 

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -30,13 +30,25 @@ import { getTotalBikingDistance, compressLegs } from '../../util/legUtils';
 export function getSelectedItineraryIndex(
   { pathname, state } = {},
   edges = [],
-  defaultValue = 0,
 ) {
+  // path defines the selection in detail view
+  const lastURLSegment = pathname?.split('/').pop();
+  if (lastURLSegment !== '') {
+    const index = Number(pathname?.split('/').pop());
+    if (!Number.isNaN(index)) {
+      if (index >= edges.length) {
+        return 0;
+      }
+      return index;
+    }
+  }
+
+  // in summary view, look the location state
   if (state?.selectedItineraryIndex !== undefined) {
     if (state.selectedItineraryIndex < edges.length) {
       return state.selectedItineraryIndex;
     }
-    return defaultValue;
+    return 0;
   }
 
   /*
@@ -44,13 +56,6 @@ export function getSelectedItineraryIndex(
    * page by an external link, we check if an itinerary selection is
    * supplied in URL and make that the selection.
    */
-  const lastURLSegment = Number(pathname?.split('/').pop());
-  if (!Number.isNaN(lastURLSegment)) {
-    if (lastURLSegment >= edges.length) {
-      return defaultValue;
-    }
-    return lastURLSegment;
-  }
 
   return 0;
 }

--- a/test/unit/component/Timetable.test.js
+++ b/test/unit/component/Timetable.test.js
@@ -12,11 +12,8 @@ import * as timetables from '../../../app/configurations/timetableConfigUtils';
 const stopIdNumber = '1140199';
 
 const props = {
-  propsForDateSelect: {
-    startDate: '20190110',
-    selectedDate: '20190110',
-    onDateChange: () => {},
-  },
+  startDate: '20190110',
+  onDateChange: () => {},
   stop: {
     gtfsId: `HSL:${stopIdNumber}`,
     locationType: 'STOP',


### PR DESCRIPTION
- Swipeable tabs always rendered first itinerary after page load, although page path and swipe indicator declared something else. Fixed.
- Clicking earlier button on depart after mode, and later button in arrive before mode, now reset itinerary selection. It was strange that e.g. second itinerary of the new set got selected, not the first one.
- Code refactored to sinmpler and cleaner state
