### PR TITLE
DT-6400 analytics for scooters

### DIFF
--- a/app/component/itinerary/BicycleLeg.js
+++ b/app/component/itinerary/BicycleLeg.js
@@ -375,9 +375,9 @@ export default function BicycleLeg(
             <div
               role="button"
               tabIndex="0"
-              onClick={() => openSettings(true)}
+              onClick={() => openSettings(true, true)}
               onKeyPress={e =>
-                isKeyboardSelectionEvent(e) && openSettings(true)
+                isKeyboardSelectionEvent(e) && openSettings(true, true)
               }
               className="itinerary-transit-leg-route-bike"
             >

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -867,7 +867,7 @@ export default function ItineraryPage(props, context) {
     router.replace(newLocationState);
   };
 
-  const showSettingsPanel = open => {
+  const showSettingsPanel = (open, changeScooterSettings) => {
     addAnalyticsEvent({
       event: 'sendMatomoEvent',
       category: 'ItinerarySettings',
@@ -880,6 +880,7 @@ export default function ItineraryPage(props, context) {
         ...settingsState,
         settingsOpen: true,
         settingsOnOpen: getSettings(config),
+        changeScooterSettings,
       });
       if (breakpoint !== 'large') {
         router.push({
@@ -892,6 +893,17 @@ export default function ItineraryPage(props, context) {
       }
       return;
     }
+    if (
+      settingsState.changeScooterSettings &&
+      settingsState.settingsOnOpen.scooterNetworks.length <
+        getSettings(config).scooterNetworks.length
+    ) {
+      addAnalyticsEvent({
+        category: 'ItinerarySettings',
+        action: 'SettingsEnableScooterNetwork',
+        name: 'AfterOnlyScooterRoutesFound',
+      });
+    }
 
     const settingsChanged = !isEqual(
       settingsState.settingsOnOpen,
@@ -903,6 +915,7 @@ export default function ItineraryPage(props, context) {
       ...settingsState,
       settingsOpen: false,
       settingsChanged,
+      changeScooterSettings: false,
     });
 
     if (settingsChanged && detailView) {

--- a/app/component/itinerary/customizesearch/RentalNetworkSelector.js
+++ b/app/component/itinerary/customizesearch/RentalNetworkSelector.js
@@ -57,6 +57,7 @@ const RentalNetworkSelector = (
                 const newNetworks = updateVehicleNetworks(
                   getCitybikeNetworks(config),
                   network.networkName,
+                  network.type,
                 );
                 const newSettings = { allowedBikeRentalNetworks: newNetworks };
                 executeAction(saveRoutingSettings, newSettings);

--- a/app/component/itinerary/customizesearch/ScooterNetworkSelector.js
+++ b/app/component/itinerary/customizesearch/ScooterNetworkSelector.js
@@ -56,6 +56,7 @@ const ScooterNetworkSelector = (
                 const newNetworks = updateVehicleNetworks(
                   getScooterNetworks(config),
                   network.networkName,
+                  network.type,
                 );
                 const newSettings = { scooterNetworks: newNetworks };
                 executeAction(saveRoutingSettings, newSettings);

--- a/app/util/vehicleRentalUtils.js
+++ b/app/util/vehicleRentalUtils.js
@@ -138,7 +138,7 @@ const addAnalytics = (action, name) => {
  * @returns the updated citybike networks
  */
 
-export const updateVehicleNetworks = (currentSettings, newValue) => {
+export const updateVehicleNetworks = (currentSettings, newValue, type) => {
   let chosenNetworks;
 
   if (currentSettings) {
@@ -154,7 +154,7 @@ export const updateVehicleNetworks = (currentSettings, newValue) => {
   if (Array.isArray(currentSettings) && Array.isArray(chosenNetworks)) {
     const action = `Settings${
       currentSettings.length > chosenNetworks.length ? 'Disable' : 'Enable'
-    }CityBikeNetwork`;
+    }${type === 'citybike' ? 'CityBikeNetwork' : 'ScooterNetwork'}`;
     addAnalytics(action, newValue);
   }
   return chosenNetworks;

--- a/app/util/vehicleRentalUtils.js
+++ b/app/util/vehicleRentalUtils.js
@@ -139,23 +139,21 @@ const addAnalytics = (action, name) => {
 
 export const updateVehicleNetworks = (networks, networkName, type) => {
   let updatedNetworks;
+  let toggleAction;
 
-  if (networks) {
-    updatedNetworks = networks.find(
-      o => o.toLowerCase() === networkName.toLowerCase(),
-    )
-      ? without(networks, networkName, networkName.toUpperCase())
-      : networks.concat([networkName]);
+  if (networks.find(o => o.toLowerCase() === networkName.toLowerCase())) {
+    updatedNetworks = without(networks, networkName, networkName.toUpperCase());
+    toggleAction = 'Disable';
   } else {
-    updatedNetworks = [networkName];
+    updatedNetworks = networks.concat([networkName]);
+    toggleAction = 'Enable';
   }
 
-  if (Array.isArray(networks) && Array.isArray(updatedNetworks)) {
-    const action = `Settings${
-      networks.length > updatedNetworks.length ? 'Disable' : 'Enable'
-    }${type === 'citybike' ? 'CityBikeNetwork' : 'ScooterNetwork'}`;
-    addAnalytics(action, networkName);
-  }
+  const action = `Settings${toggleAction}${
+    type === 'citybike' ? 'CityBikeNetwork' : 'ScooterNetwork'
+  }`;
+  addAnalytics(action, networkName);
+
   return updatedNetworks;
 };
 

--- a/app/util/vehicleRentalUtils.js
+++ b/app/util/vehicleRentalUtils.js
@@ -131,33 +131,33 @@ const addAnalytics = (action, name) => {
  * Updates the list of allowed networks either by removing or adding.
  * Note: legacy settings had network names always in uppercase letters.
  *
- * @param currentSettings the current settings
- * @param newValue the network to be added/removed
+ * @param networks the previously selected networks
+ * @param networkName the network to be added/removed
  * @param config The configuration for the software installation
  * @param isUsingCitybike if citybike is enabled
  * @returns the updated citybike networks
  */
 
-export const updateVehicleNetworks = (currentSettings, newValue, type) => {
-  let chosenNetworks;
+export const updateVehicleNetworks = (networks, networkName, type) => {
+  let updatedNetworks;
 
-  if (currentSettings) {
-    chosenNetworks = currentSettings.find(
-      o => o.toLowerCase() === newValue.toLowerCase(),
+  if (networks) {
+    updatedNetworks = networks.find(
+      o => o.toLowerCase() === networkName.toLowerCase(),
     )
-      ? without(currentSettings, newValue, newValue.toUpperCase())
-      : currentSettings.concat([newValue]);
+      ? without(networks, networkName, networkName.toUpperCase())
+      : networks.concat([networkName]);
   } else {
-    chosenNetworks = [newValue];
+    updatedNetworks = [networkName];
   }
 
-  if (Array.isArray(currentSettings) && Array.isArray(chosenNetworks)) {
+  if (Array.isArray(networks) && Array.isArray(updatedNetworks)) {
     const action = `Settings${
-      currentSettings.length > chosenNetworks.length ? 'Disable' : 'Enable'
+      networks.length > updatedNetworks.length ? 'Disable' : 'Enable'
     }${type === 'citybike' ? 'CityBikeNetwork' : 'ScooterNetwork'}`;
-    addAnalytics(action, newValue);
+    addAnalytics(action, networkName);
   }
-  return chosenNetworks;
+  return updatedNetworks;
 };
 
 export const getVehicleMinZoomOnStopsNearYou = (config, override) => {

--- a/app/util/vehicleRentalUtils.js
+++ b/app/util/vehicleRentalUtils.js
@@ -133,8 +133,7 @@ const addAnalytics = (action, name) => {
  *
  * @param networks the previously selected networks
  * @param networkName the network to be added/removed
- * @param config The configuration for the software installation
- * @param isUsingCitybike if citybike is enabled
+ * @param type the type of the network
  * @returns the updated citybike networks
  */
 


### PR DESCRIPTION
## Proposed Changes

- Citybike and scooter setting analytics separated.
- Analytics event for selecting scooter settings after getting a relaxed scooter journey, using the settings button in the relaxed scooter itinerary and then selecting scooters. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
