### PR TITLE
Improve journey tracking on navigator map

### DIFF
--- a/app/component/itinerary/NaviContainer.js
+++ b/app/component/itinerary/NaviContainer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql, fetchQuery } from 'react-relay';
 import { itineraryShape, relayShape } from '../../util/shapes';
@@ -37,13 +37,16 @@ function NaviContainer({
 }) {
   const [realTimeLegs, setRealTimeLegs] = useState(itinerary.legs);
   const [time, setTime] = useState(Date.now());
+  const locationOK = useRef(true);
 
   // update view after every 10 seconds
   useEffect(() => {
     checkPositioningPermission().then(permission => {
-      if (permission.state === 'granted') {
+      locationOK.current = permission.state === 'granted';
+      if (locationOK.current) {
         mapRef?.enableMapTracking();
       }
+      setTime(Date.now()); // force refresh
     });
     const interval = setInterval(() => {
       setTime(Date.now());
@@ -103,7 +106,9 @@ function NaviContainer({
       <NaviTop
         itinerary={itinerary}
         realTimeLegs={realTimeLegs}
-        focusToLeg={mapRef?.state.mapTracking ? null : focusToLeg}
+        focusToLeg={
+          mapRef?.state.mapTracking || locationOK.current ? null : focusToLeg
+        }
         time={time}
       />{' '}
       <NaviBottom setNavigation={setNavigation} arrival={arrivalTime} />

--- a/app/component/itinerary/NaviTop.js
+++ b/app/component/itinerary/NaviTop.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape } from 'react-intl';
 import { itineraryShape, legShape, configShape } from '../../util/shapes';
@@ -9,6 +9,12 @@ import NaviStack from './NaviStack';
 import { timeStr } from '../../util/timeUtils';
 
 const TRANSFER_SLACK = 60000;
+
+function getFirstLastLegs(legs) {
+  const first = legs[0];
+  const last = legs[legs.length - 1];
+  return { first, last };
+}
 
 function findTransferProblem(legs) {
   for (let i = 1; i < legs.length - 1; i++) {
@@ -155,6 +161,7 @@ function NaviTop(
   const [currentLeg, setCurrentLeg] = useState(null);
   const [show, setShow] = useState(true);
   const [notifications, setNotifications] = useState([]);
+  const focusRef = useRef(false);
 
   const handleClick = () => {
     setShow(!show);
@@ -182,12 +189,27 @@ function NaviTop(
             leg => legTime(leg.start) > legTime(l.start),
           );
         }
-        focusToLeg?.(newLeg, false);
+        // focus to a changed leg if not tracking location
+        focusToLeg?.(newLeg);
         if (nextLeg) {
           notifs.push(getScheduleInfo(nextLeg, intl));
         }
       }
       setCurrentLeg(newLeg);
+    }
+    if (!focusRef.current && focusToLeg) {
+      // handle initial focus when not tracking
+      if (newLeg) {
+        focusToLeg(newLeg);
+      } else {
+        const { first, last } = getFirstLastLegs(realTimeLegs);
+        if (time < legTime(first.start)) {
+          focusToLeg(first);
+        } else {
+          focusToLeg(last);
+        }
+      }
+      focusRef.current = true;
     }
     const problems = getAlerts(realTimeLegs, intl);
     if (problems.length > 0) {
@@ -200,8 +222,7 @@ function NaviTop(
     }
   }, [time]);
 
-  const first = realTimeLegs[0];
-  const last = realTimeLegs[realTimeLegs.length - 1];
+  const { first, last } = getFirstLastLegs(realTimeLegs);
 
   let info;
   if (time < legTime(first.start)) {

--- a/app/component/itinerary/NaviTop.js
+++ b/app/component/itinerary/NaviTop.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape } from 'react-intl';
-import { itineraryShape, legShape, configShape } from '../../util/shapes';
+import { legShape, configShape } from '../../util/shapes';
 import { legTime, legTimeStr } from '../../util/legUtils';
 import NaviLeg from './NaviLeg';
 import Icon from '../Icon';
@@ -154,10 +154,7 @@ const getAlerts = (realTimeLegs, intl) => {
   return alerts;
 };
 
-function NaviTop(
-  { itinerary, focusToLeg, time, realTimeLegs },
-  { intl, config },
-) {
+function NaviTop({ focusToLeg, time, realTimeLegs }, { intl, config }) {
   const [currentLeg, setCurrentLeg] = useState(null);
   const [show, setShow] = useState(true);
   const [notifications, setNotifications] = useState([]);
@@ -185,7 +182,7 @@ function NaviTop(
         if (!newLeg.transitLeg) {
           // When the component is first rendered, there is no currentLeg
           const l = currentLeg || newLeg;
-          nextLeg = itinerary.legs.find(
+          nextLeg = realTimeLegs.find(
             leg => legTime(leg.start) > legTime(l.start),
           );
         }
@@ -234,7 +231,7 @@ function NaviTop(
     );
   } else if (currentLeg) {
     if (!currentLeg.transitLeg) {
-      nextLeg = itinerary.legs.find(
+      nextLeg = realTimeLegs.find(
         leg => legTime(leg.start) > legTime(currentLeg.start),
       );
       info = <NaviLeg leg={currentLeg} nextLeg={nextLeg} />;
@@ -277,7 +274,6 @@ function NaviTop(
 }
 
 NaviTop.propTypes = {
-  itinerary: itineraryShape.isRequired,
   focusToLeg: PropTypes.func,
   time: PropTypes.number.isRequired,
   realTimeLegs: PropTypes.arrayOf(legShape).isRequired,

--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -117,6 +117,7 @@ class MapWithTrackingStateHandler extends React.Component {
     this.state = {
       mapTracking: props.mapTracking,
       settingsOpen: false,
+      refreshTrigger: 0,
     };
     this.naviProps = {};
   }
@@ -132,7 +133,10 @@ class MapWithTrackingStateHandler extends React.Component {
 
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(newProps) {
-    if (newProps.mapTracking !== this.state.mapTracking) {
+    if (
+      newProps.mapTracking !== undefined &&
+      newProps.mapTracking !== this.state.mapTracking
+    ) {
       this.setState({ mapTracking: newProps.mapTracking });
     }
   }
@@ -154,9 +158,12 @@ class MapWithTrackingStateHandler extends React.Component {
     if (!this.props.position.hasLocation) {
       this.context.executeAction(startLocationWatch);
     }
-    this.setState({
-      mapTracking: true,
-    });
+    if (!this.state.mapTracking) {
+      this.setState(prevState => ({
+        mapTracking: true,
+        refreshTrigger: prevState.refreshTrigger + 1,
+      }));
+    }
     if (this.props.onMapTracking) {
       this.props.onMapTracking();
     }

--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -132,15 +132,8 @@ class MapWithTrackingStateHandler extends React.Component {
 
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(newProps) {
-    let newState;
-
-    if (newProps.mapTracking && !this.state.mapTracking) {
-      newState = { ...newState, mapTracking: true };
-    } else if (newProps.mapTracking === false && this.state.mapTracking) {
-      newState = { ...newState, mapTracking: false };
-    }
-    if (newState) {
-      this.setState(newState);
+    if (newProps.mapTracking !== this.state.mapTracking) {
+      this.setState({ mapTracking: newProps.mapTracking });
     }
   }
 

--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -159,6 +159,12 @@ class MapWithTrackingStateHandler extends React.Component {
       this.context.executeAction(startLocationWatch);
     }
     if (!this.state.mapTracking) {
+      // enabling tracking will trigger same navigation events as user navigation
+      // this hack prevents those events from clearing tracking
+      this.ignoreNavigation = true;
+      setTimeout(() => {
+        this.ignoreNavigation = false;
+      }, 500);
       this.setState(prevState => ({
         mapTracking: true,
         refreshTrigger: prevState.refreshTrigger + 1,
@@ -363,12 +369,6 @@ class MapWithTrackingStateHandler extends React.Component {
                   if (this.state.mapTracking) {
                     this.disableMapTracking();
                   } else {
-                    // enabling tracking will trigger same navigation events as user navigation
-                    // this hack prevents those events from clearing tracking
-                    this.ignoreNavigation = true;
-                    setTimeout(() => {
-                      this.ignoreNavigation = false;
-                    }, 500);
                     this.enableMapTracking();
                   }
                 }}

--- a/app/component/routepage/FuzzyTripLink.js
+++ b/app/component/routepage/FuzzyTripLink.js
@@ -133,11 +133,12 @@ FuzzyTripLink.propTypes = {
   trip: tripShape,
   vehicle: vehicleShape.isRequired,
   stopName: PropTypes.string.isRequired,
-  nextStopName: PropTypes.string.isRequired,
+  nextStopName: PropTypes.string,
 };
 
 FuzzyTripLink.defaultProps = {
   trip: undefined,
+  nextStopName: undefined,
 };
 
 FuzzyTripLink.contextTypes = {


### PR DESCRIPTION
- Navigator does not focus first to leg and then to user, when geolocation is allowed
- Location tracking on map succeeds and stays on when allowed
- If geolocation is not allowed, navigator always focuses to an appropriate leg, even if journey has not started yet
- Code refactoring
