### PR TITLE
Add 'Stations' search target

### DIFF
--- a/app/component/EmbeddedSearchGenerator.js
+++ b/app/component/EmbeddedSearchGenerator.js
@@ -13,7 +13,12 @@ import { isBrowser } from '../util/browser';
 
 const LocationSearch = withSearchContext(DTAutosuggest, true);
 
-const locationSearchTargets = ['Locations', 'CurrentPosition', 'Stops'];
+const locationSearchTargets = [
+  'Locations',
+  'CurrentPosition',
+  'Stations',
+  'Stops',
+];
 const sources = ['Favourite', 'History', 'Datasource'];
 
 const languages = [

--- a/app/component/FavouritesContainer.js
+++ b/app/component/FavouritesContainer.js
@@ -325,7 +325,7 @@ class FavouritesContainer extends React.Component {
     const isLoading =
       this.props.favouriteStatus === FavouriteStore.STATUS_FETCHING_OR_UPDATING;
     const { requireLoggedIn, isLoggedIn } = this.props;
-    const targets = ['Locations', 'CurrentPosition', 'MapPosition'];
+    const targets = ['Locations', 'Stations', 'CurrentPosition', 'MapPosition'];
     const { fontWeights } = this.context.config;
     const favouritePlaces = this.props.favourites.filter(
       item => item.type === 'place',

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -299,7 +299,7 @@ class IndexPage extends React.Component {
     const origin = this.pendingOrigin || this.props.origin;
     const destination = this.pendingDestination || this.props.destination;
     const sources = ['Favourite', 'History', 'Datasource'];
-    const stopAndRouteSearchTargets = ['Stops', 'Routes'];
+    const stopAndRouteSearchTargets = ['Stations', 'Stops', 'Routes'];
     let locationSearchTargets = [
       'Locations',
       'CurrentPosition',
@@ -314,8 +314,8 @@ class IndexPage extends React.Component {
       ];
     } else {
       // default setup
+      locationSearchTargets.push('Stations');
       locationSearchTargets.push('Stops');
-
       if (useCitybikes(config.vehicleRental?.networks, config)) {
         stopAndRouteSearchTargets.push('VehicleRentalStations');
         locationSearchTargets.push('VehicleRentalStations');

--- a/app/component/StopsNearYouPage.js
+++ b/app/component/StopsNearYouPage.js
@@ -828,7 +828,7 @@ class StopsNearYouPage extends React.Component {
       modeSet: this.context.config.iconModeSet,
       getAutoSuggestIcons: this.context.config.getAutoSuggestIcons,
     };
-    const targets = ['Locations', 'Stops'];
+    const targets = ['Locations', 'Stations', 'Stops'];
     if (
       useCitybikes(
         this.context.config.vehicleRental?.networks,

--- a/app/component/StopsNearYouSearch.js
+++ b/app/component/StopsNearYouSearch.js
@@ -45,7 +45,7 @@ function StopsNearYouSearch(
           targets={
             mode === 'CITYBIKE'
               ? ['VehicleRentalStations']
-              : ['Stops', 'Routes']
+              : ['Stops', 'Stations', 'Routes']
           }
           isMobile={isMobile}
           selectHandler={selectHandler} // prop for context handler

--- a/app/component/map/MapWithTracking.js
+++ b/app/component/map/MapWithTracking.js
@@ -117,7 +117,6 @@ class MapWithTrackingStateHandler extends React.Component {
     this.state = {
       mapTracking: props.mapTracking,
       settingsOpen: false,
-      refreshTrigger: 0,
     };
     this.naviProps = {};
   }
@@ -165,10 +164,7 @@ class MapWithTrackingStateHandler extends React.Component {
       setTimeout(() => {
         this.ignoreNavigation = false;
       }, 500);
-      this.setState(prevState => ({
-        mapTracking: true,
-        refreshTrigger: prevState.refreshTrigger + 1,
-      }));
+      this.setState({ mapTracking: true });
     }
     if (this.props.onMapTracking) {
       this.props.onMapTracking();

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/README.md
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/README.md
@@ -73,7 +73,7 @@ const getAutoSuggestIcons: {
      return ['citybike-stop-digitransit', '#f2b62d'];
   }
 }
-const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, VehicleRentalStation, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
+const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Stations, Routes, VehicleRentalStation, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
 const sources = ['Favourite', 'History', 'Datasource'] // Defines where you are searching. all available are: Favourite, History (previously searched searches), and Datasource. Leave empty to use all sources.
 <DTAutosuggestPanel
    appElement={appElement} // Required. Root element's id. Needed for react-modal component.

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "3.0.9",
+  "version": "4.0.0",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^2.0.8",
+    "@digitransit-component/digitransit-component-autosuggest": "^3.0.0",
     "@digitransit-component/digitransit-component-icon": "^1.0.1",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.2.6",

--- a/digitransit-component/packages/digitransit-component-autosuggest/README.md
+++ b/digitransit-component/packages/digitransit-component-autosuggest/README.md
@@ -60,7 +60,7 @@ const getAutoSuggestIcons: {
 }
 const transportMode = undefined;
 const placeholder = "stop-near-you";
-const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, VehicleRentalStation, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
+const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Stations, Routes, VehicleRentalStation, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
 const sources = ['Favourite', 'History', 'Datasource'] // Defines where you are searching. all available are: Favourite, History (previously searched searches) and Datasource. Leave empty to use all sources.
 return (
  <DTAutosuggest

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "2.0.8",
+  "version": "3.0.0",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [
@@ -29,7 +29,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": "^2.0.3",
+    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": "^3.0.0",
     "@digitransit-search-util/digitransit-search-util-get-label": "^1.0.0",
     "@digitransit-search-util/digitransit-search-util-uniq-by-label": "^2.0.0",
     "@hsl-fi/hooks": "^1.2.4"

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -219,7 +219,7 @@ const getSuggestionValue = suggestion => {
  * }
  * const transportMode = undefined;
  * const placeholder = "stop-near-you";
- * const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. all available options are Locations, Stops, Routes, VehicleRentalStations, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
+ * const targets = ['Locations', 'Stops', 'Routes']; // Defines what you are searching. Options are Locations, Stops, Stations, Routes, VehicleRentalStations, FutureRoutes, MapPosition and CurrentPosition. Leave empty to search all targets.
  * const sources = ['Favourite', 'History', 'Datasource'] // Defines where you are searching. all available are: Favourite, History (previously searched searches) and Datasource. Leave empty to use all sources.
  * return (
  *  <DTAutosuggest
@@ -598,26 +598,24 @@ class DTAutosuggest extends React.Component {
           // do not let component cast unnecessary requests
           return;
         }
+        const { targets } = this.props;
+        const useAll = isEmpty(targets);
         const isLocationSearch =
-          isEmpty(this.props.targets) ||
-          this.props.targets.includes('Locations');
-        let targets;
+          isEmpty(targets) || targets.includes('Locations');
+        let newTargets;
         if (this.state.ownPlaces) {
-          targets = ['Locations'];
-          if (
-            isEmpty(this.props.targets) ||
-            this.props.targets.includes('Stops')
-          ) {
-            targets.push('Stops');
+          newTargets = ['Locations'];
+          if (useAll || targets.includes('Stops')) {
+            newTargets.push('Stops');
           }
-          if (
-            isEmpty(this.props.targets) ||
-            this.props.targets.includes('VehicleRentalStations')
-          ) {
-            targets.push('VehicleRentalStations');
+          if (useAll || targets.includes('Stations')) {
+            newTargets.push('Stations');
           }
-        } else if (!isEmpty(this.props.targets)) {
-          targets = [...this.props.targets];
+          if (useAll || targets.includes('VehicleRentalStations')) {
+            newTargets.push('VehicleRentalStations');
+          }
+        } else if (!useAll) {
+          newTargets = [...targets];
           // in desktop, favorites are accessed via sub search
           if (
             isLocationSearch &&
@@ -625,7 +623,7 @@ class DTAutosuggest extends React.Component {
             (isEmpty(this.props.sources) ||
               this.props.sources.includes('Favourite'))
           ) {
-            targets.push('SelectFromOwnLocations');
+            newTargets.push('SelectFromOwnLocations');
           }
         }
         // remove  location favourites in desktop search (collection item replaces it in target array)
@@ -642,7 +640,7 @@ class DTAutosuggest extends React.Component {
           );
 
         executeSearch(
-          targets,
+          newTargets,
           sources,
           this.props.transportMode,
           this.props.searchContext,

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -14,8 +14,8 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^2.0.8",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^3.0.8",
+    "@digitransit-component/digitransit-component-autosuggest": "^3.0.0",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^4.0.0",
     "@digitransit-component/digitransit-component-control-panel": "^2.0.0",
     "@digitransit-component/digitransit-component-favourite-bar": "2.0.5",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^2.0.2",

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
@@ -234,7 +234,7 @@ const routeLayers = [
   'route-AIRPLANE',
   'route-FUNICULAR',
 ];
-const locationLayers = ['favouritePlace', 'venue', 'address', 'street'];
+const locationLayers = ['venue', 'address', 'street'];
 const parkingLayers = ['carpark', 'bikepark'];
 const stopLayers = ['stop', 'station'];
 
@@ -347,14 +347,7 @@ export function getSearchResults(
     }
     if (allSources || sources.includes('History')) {
       const locationHistory = getOldSearches(context, 'endpoint');
-      const dropLayers = [
-        'currentPosition',
-        'selectFromMap',
-        'futureRoute',
-        'ownLocations',
-        'bikestation',
-        'back',
-      ];
+      const dropLayers = ['bikestation'];
       dropLayers.push(...stopLayers);
       dropLayers.push(...routeLayers);
       dropLayers.push(...parkingLayers);
@@ -391,15 +384,7 @@ export function getSearchResults(
     }
     if (allSources || sources.includes('History')) {
       const history = getOldSearches(context);
-      const dropLayers = [
-        'currentPosition',
-        'selectFromMap',
-        'futureRoute',
-        'ownLocations',
-        'favouritePlace',
-        'bikestation',
-        'back',
-      ];
+      const dropLayers = ['bikestation'];
       dropLayers.push(...stopLayers);
       dropLayers.push(...routeLayers);
       dropLayers.push(...locationLayers);
@@ -484,15 +469,7 @@ export function getSearchResults(
         }
         return true;
       });
-      const dropLayers = [
-        'currentPosition',
-        'selectFromMap',
-        'futureRoute',
-        'ownLocations',
-        'favouritePlace',
-        'bikestation',
-        'back',
-      ];
+      const dropLayers = ['bikestation'];
       dropLayers.push(...routeLayers);
       dropLayers.push(...locationLayers);
       dropLayers.push(...parkingLayers);
@@ -532,17 +509,7 @@ export function getSearchResults(
     );
     if (allSources || sources.includes('History')) {
       const routeHistory = getOldSearches(context);
-      const dropLayers = [
-        'currentPosition',
-        'selectFromMap',
-        'futureRoute',
-        'favouritePlace',
-        'bikestation',
-        'bikepark',
-        'carpark',
-        'ownLocations',
-        'back',
-      ];
+      const dropLayers = ['bikestation'];
       if (transportMode) {
         dropLayers.push(...routeLayers.filter(i => !(i === transportMode)));
       }
@@ -592,15 +559,7 @@ export function getSearchResults(
     }
     if (allSources || sources.includes('History')) {
       const history = getOldSearches(context);
-      const dropLayers = [
-        'currentPosition',
-        'selectFromMap',
-        'futureRoute',
-        'ownLocations',
-        'favouritePlace',
-        'back',
-      ];
-      dropLayers.push(...stopLayers);
+      const dropLayers = [...stopLayers];
       dropLayers.push(...routeLayers);
       dropLayers.push(...locationLayers);
       dropLayers.push(...parkingLayers);

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
@@ -396,7 +396,6 @@ export function getSearchResults(
         'ownLocations',
         'favouritePlace',
         'bikestation',
-        'vehicleRentalStation',
         'back',
         'stop',
         'station',
@@ -490,7 +489,7 @@ export function getSearchResults(
         'futureRoute',
         'ownLocations',
         'favouritePlace',
-        'vehicleRentalStation',
+        'bikestation',
         'back',
       ];
       dropLayers.push(...routeLayers);
@@ -503,10 +502,6 @@ export function getSearchResults(
         dropLayers.push('station');
       }
       if (transportMode) {
-        if (transportMode !== 'route-CITYBIKE') {
-          dropLayers.push('vehicleRentalStation');
-          dropLayers.push('bikestation');
-        }
         searchComponents.push(
           filterOldSearches(stopHistory, input, dropLayers).then(result =>
             filterResults ? filterResults(result, mode) : result,
@@ -543,16 +538,13 @@ export function getSearchResults(
         'favouritePlace',
         'stop',
         'station',
+        'bikestation',
         'bikepark',
         'carpark',
         'ownLocations',
         'back',
       ];
       if (transportMode) {
-        if (transportMode !== 'route-CITYBIKE') {
-          dropLayers.push('vehicleRentalStation');
-          dropLayers.push('bikestation');
-        }
         dropLayers.push(...routeLayers.filter(i => !(i === transportMode)));
       }
       dropLayers.push(...locationLayers);

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
@@ -392,9 +392,10 @@ export function getSearchResults(
     }
   }
 
-  if (allTargets || targets.includes('Stops') || targets.includes('Stations')) {
-    const useStops = targets.includes('Stops');
-    const useStations = targets.includes('Stations');
+  const useStops = targets.includes('Stops');
+  const useStations = targets.includes('Stations');
+
+  if (allTargets || useStops || useStations) {
     if (sources.includes('Favourite')) {
       const favouriteStops = getFavouriteStops(context);
       let stopsAndStations;

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
@@ -232,6 +232,7 @@ const routeLayers = [
   'route-FERRY',
   'route-SUBWAY',
   'route-AIRPLANE',
+  'route-FUNICULAR',
 ];
 const locationLayers = ['favouritePlace', 'venue', 'address', 'street'];
 const parkingLayers = ['carpark', 'bikepark'];

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
@@ -167,9 +167,12 @@ function getBackSuggestion() {
   ]);
 }
 
-function filterFavouriteStops(stopsAndStations, input) {
-  return stopsAndStations.then(stops => {
-    return filterMatchingToInput(stops, input, [
+function filterFavouriteStops(stopsAndStations, input, useStops, useStations) {
+  return stopsAndStations.then(stopsStations => {
+    const candidates = stopsStations.filter(s =>
+      s.type === 'stop' ? useStops : useStations,
+    );
+    return filterMatchingToInput(candidates, input, [
       'properties.name',
       'properties.name',
       'properties.address',
@@ -323,7 +326,7 @@ export function getSearchResults(
     }
 
     if (allSources || sources.includes('Datasource')) {
-      const geocodingLayers = ['station', 'venue', 'address', 'street'];
+      const geocodingLayers = ['venue', 'address', 'street'];
       const feedis = feedIDs.map(v => `gtfs${v}`);
       const geosources = geocodingSources.concat(feedis).join(',');
       searchComponents.push(
@@ -404,7 +407,9 @@ export function getSearchResults(
     }
   }
 
-  if (allTargets || targets.includes('Stops')) {
+  if (allTargets || targets.includes('Stops') || targets.includes('Stations')) {
+    const useStops = targets.includes('Stops');
+    const useStations = targets.includes('Stations');
     if (sources.includes('Favourite')) {
       const favouriteStops = getFavouriteStops(context);
       let stopsAndStations;
@@ -430,10 +435,18 @@ export function getSearchResults(
             return results;
           });
       }
-      searchComponents.push(filterFavouriteStops(stopsAndStations, input));
+      searchComponents.push(
+        filterFavouriteStops(stopsAndStations, input, useStops, useStations),
+      );
     }
     if (allSources || sources.includes('Datasource')) {
-      const geocodingLayers = ['stop', 'station'];
+      const geocodingLayers = [];
+      if (useStops) {
+        geocodingLayers.push('stop');
+      }
+      if (useStations) {
+        geocodingLayers.push('station');
+      }
       const searchParams =
         geocodingSize && geocodingSize !== 10 ? { size: geocodingSize } : {};
       if (geocodingSearchParams && geocodingSearchParams['boundary.country']) {
@@ -483,6 +496,12 @@ export function getSearchResults(
       dropLayers.push(...routeLayers);
       dropLayers.push(...locationLayers);
       dropLayers.push(...parkingLayers);
+      if (!useStops) {
+        dropLayers.push('stop');
+      }
+      if (!useStations) {
+        dropLayers.push('station');
+      }
       if (transportMode) {
         if (transportMode !== 'route-CITYBIKE') {
           dropLayers.push('vehicleRentalStation');
@@ -500,7 +519,6 @@ export function getSearchResults(
       }
     }
   }
-
   if (allTargets || targets.includes('Routes')) {
     if (sources.includes('Favourite')) {
       const favouriteRoutes = getFavouriteRoutes(context);

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/index.js
@@ -235,6 +235,8 @@ const routeLayers = [
 ];
 const locationLayers = ['favouritePlace', 'venue', 'address', 'street'];
 const parkingLayers = ['carpark', 'bikepark'];
+const stopLayers = ['stop', 'station'];
+
 /**
  * Executes the search
  *
@@ -349,13 +351,12 @@ export function getSearchResults(
         'selectFromMap',
         'futureRoute',
         'ownLocations',
-        'vehicleRentalStation',
-        'bikepark',
-        'carpark',
-        'stop',
+        'bikestation',
         'back',
       ];
+      dropLayers.push(...stopLayers);
       dropLayers.push(...routeLayers);
+      dropLayers.push(...parkingLayers);
       searchComponents.push(
         filterOldSearches(locationHistory, input, dropLayers),
       );
@@ -397,9 +398,8 @@ export function getSearchResults(
         'favouritePlace',
         'bikestation',
         'back',
-        'stop',
-        'station',
       ];
+      dropLayers.push(...stopLayers);
       dropLayers.push(...routeLayers);
       dropLayers.push(...locationLayers);
       searchComponents.push(filterOldSearches(history, input, dropLayers));
@@ -536,8 +536,6 @@ export function getSearchResults(
         'selectFromMap',
         'futureRoute',
         'favouritePlace',
-        'stop',
-        'station',
         'bikestation',
         'bikepark',
         'carpark',
@@ -547,7 +545,10 @@ export function getSearchResults(
       if (transportMode) {
         dropLayers.push(...routeLayers.filter(i => !(i === transportMode)));
       }
+      dropLayers.push(...stopLayers);
       dropLayers.push(...locationLayers);
+      dropLayers.push(...parkingLayers);
+
       searchComponents.push(
         filterOldSearches(routeHistory, input, dropLayers).then(results =>
           filterResults ? filterResults(results, mode, 'Routes') : results,
@@ -587,6 +588,23 @@ export function getSearchResults(
           return results;
         }),
       );
+    }
+    if (allSources || sources.includes('History')) {
+      const history = getOldSearches(context);
+      const dropLayers = [
+        'currentPosition',
+        'selectFromMap',
+        'futureRoute',
+        'ownLocations',
+        'favouritePlace',
+        'back',
+      ];
+      dropLayers.push(...stopLayers);
+      dropLayers.push(...routeLayers);
+      dropLayers.push(...locationLayers);
+      dropLayers.push(...parkingLayers);
+
+      searchComponents.push(filterOldSearches(history, input, dropLayers));
     }
   }
 

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-execute-search-immidiate",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "description": "digitransit-search-util execute-search-immidiate module",
   "main": "index.js",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,11 +1968,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@^3.0.8, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@^4.0.0, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^2.0.8
+    "@digitransit-component/digitransit-component-autosuggest": ^3.0.0
     "@digitransit-component/digitransit-component-icon": ^1.0.1
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.2.6
@@ -1988,11 +1988,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@^2.0.8, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@^3.0.0, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": ^2.0.3
+    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": ^3.0.0
     "@digitransit-search-util/digitransit-search-util-get-label": ^1.0.0
     "@digitransit-search-util/digitransit-search-util-uniq-by-label": ^2.0.0
     "@hsl-fi/hooks": ^1.2.4
@@ -2166,8 +2166,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^2.0.8
-    "@digitransit-component/digitransit-component-autosuggest-panel": ^3.0.8
+    "@digitransit-component/digitransit-component-autosuggest": ^3.0.0
+    "@digitransit-component/digitransit-component-autosuggest-panel": ^4.0.0
     "@digitransit-component/digitransit-component-control-panel": ^2.0.0
     "@digitransit-component/digitransit-component-favourite-bar": 2.0.5
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^2.0.2
@@ -2203,7 +2203,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-execute-search-immidiate@^2.0.3, @digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate":
+"@digitransit-search-util/digitransit-search-util-execute-search-immidiate@^3.0.0, @digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate"
   dependencies:


### PR DESCRIPTION
Previously it was not possible to search stations only using digitransit search libraries. Stations were always searched as a part of 'Stops' or 'Locations' search. This is somewhat inconsistent behavior.

This PR adds a dedicated 'Stations' search target. This change makes it easier to use other than Digitransit Pelias search service with the UI.