### PR TITLE
Update old search store filtering

### DIFF
--- a/app/store/OldSearchesStore.js
+++ b/app/store/OldSearchesStore.js
@@ -1,7 +1,6 @@
 import Store from 'fluxible/addons/BaseStore';
 import cloneDeep from 'lodash/cloneDeep';
 import find from 'lodash/find';
-import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import orderBy from 'lodash/orderBy';
 import { getNameLabel } from '@digitransit-search-util/digitransit-search-util-uniq-by-label';
@@ -17,9 +16,6 @@ export const STORE_VERSION = 3;
  * The maximum amount of time in seconds a stored item will be returned.
  */
 export const STORE_PERIOD = 60 * 60 * 24 * 60; // 60 days
-
-const isCurrentLocationItem = item =>
-  get(item, 'item.type') === 'CurrentLocation';
 
 class OldSearchesStore extends Store {
   static storeName = 'OldSearchesStore';
@@ -42,9 +38,6 @@ class OldSearchesStore extends Store {
   }
 
   saveSearch(search) {
-    if (isCurrentLocationItem(search)) {
-      return;
-    }
     const { items } = this.getStorageObject();
 
     const key = getNameLabel(search.item.properties, true);
@@ -74,9 +67,6 @@ class OldSearchesStore extends Store {
   }
 
   removeSearch(search) {
-    if (isCurrentLocationItem(search)) {
-      return;
-    }
     const { items } = this.getStorageObject();
 
     const key = getNameLabel(search.item.properties, true);
@@ -103,8 +93,7 @@ class OldSearchesStore extends Store {
           (type ? item.type === type : true) &&
           (item.lastUpdated
             ? timestamp - item.lastUpdated < STORE_PERIOD
-            : true) &&
-          !isCurrentLocationItem(item),
+            : true),
       )
       .map(item => item.item);
   }
@@ -121,11 +110,8 @@ class OldSearchesStore extends Store {
   getOldSearchItems() {
     const { items } = this.getStorageObject();
     const timestamp = unixTime();
-    return items.filter(
-      item =>
-        (item.lastUpdated
-          ? timestamp - item.lastUpdated < STORE_PERIOD
-          : true) && !isCurrentLocationItem(item),
+    return items.filter(item =>
+      item.lastUpdated ? timestamp - item.lastUpdated < STORE_PERIOD : true,
     );
   }
 

--- a/app/store/localStorage.js
+++ b/app/store/localStorage.js
@@ -202,7 +202,13 @@ export function getFavouriteRoutesStorage() {
 }
 
 export function getOldSearchesStorage() {
-  return getItemAsJson('saved-searches', '{"items": []}');
+  const storage = getItemAsJson('saved-searches', '{"items": []}');
+  return {
+    ...storage,
+    items: storage.items.filter(
+      search => search.item.address !== 'SelectFromMap',
+    ),
+  };
 }
 
 export function setOldSearchesStorage(data) {

--- a/test/unit/OldSearchesStore.test.js
+++ b/test/unit/OldSearchesStore.test.js
@@ -80,26 +80,6 @@ const mockData = {
     },
     type: 'endpoint',
   },
-  currentLocation: {
-    item: {
-      type: 'CurrentLocation',
-      address: 'Mannerheimintie 1, Helsinki',
-      lat: 60.17020147545328,
-      lon: 24.937821437201357,
-      properties: {
-        labelId: 'Käytä nykyistä sijaintia',
-        layer: 'currentPosition',
-        address: 'Mannerheimintie 1, Helsinki',
-        lat: 60.17020147545328,
-        lon: 24.937821437201357,
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [24.937821437201357, 60.17020147545328],
-      },
-    },
-    type: 'endpoint',
-  },
 };
 
 describe('OldSearchesStore', () => {
@@ -236,25 +216,6 @@ describe('OldSearchesStore', () => {
       expect(oldSearches).to.not.be.empty;
       expect(oldSearches.length).to.equal(1);
     });
-
-    it('should ignore items of type "CurrentLocation" if they are found from the store', () => {
-      const timeStamp = moment('2019-06-19');
-      MockDate.set(timeStamp);
-      setOldSearchesStorage({
-        version: STORE_VERSION,
-        items: [
-          {
-            ...mockData.currentLocation,
-            count: 1,
-            lastUpdated: timeStamp.unix(),
-          },
-        ],
-      });
-
-      const store = new OldSearchesStore();
-      const searches = store.getOldSearches();
-      expect(searches).to.have.lengthOf(0);
-    });
   });
 
   describe('saveSearch(destination)', () => {
@@ -344,12 +305,6 @@ describe('OldSearchesStore', () => {
 
       const result = store.getOldSearches()[0];
       expect(result).to.deep.equal(newData.item);
-    });
-
-    it('should not save items of type "CurrentLocation"', () => {
-      const store = new OldSearchesStore();
-      store.saveSearch({ ...mockData.currentLocation });
-      expect(getOldSearchesStorage().items).to.deep.equal([]);
     });
   });
 });

--- a/test/unit/OldSearchesStore.test.js
+++ b/test/unit/OldSearchesStore.test.js
@@ -141,18 +141,11 @@ describe('OldSearchesStore', () => {
       setOldSearchesStorage({
         version: STORE_VERSION,
         items: [
-          {
-            type: 'endpoint',
-          },
-          {
-            type: 'route',
-          },
-          {
-            type: 'endpoint',
-          },
+          { item: {}, type: 'endpoint' },
+          { item: {}, type: 'route' },
+          { item: {}, type: 'endpoint' },
         ],
       });
-
       const store = new OldSearchesStore();
       const oldSearches = store.getOldSearches('endpoint');
       expect(oldSearches).to.not.be.empty;

--- a/test/unit/OldSearchesStore.test.js
+++ b/test/unit/OldSearchesStore.test.js
@@ -201,7 +201,7 @@ describe('OldSearchesStore', () => {
       MockDate.set(timestamp);
       setOldSearchesStorage({
         version: STORE_VERSION,
-        items: [{}],
+        items: [{ item: {} }],
       });
 
       const store = new OldSearchesStore();


### PR DESCRIPTION
FIlter SelectFromMap items, which hsl.fi seems to save, away from local storage.

This change protects our search component from invalid old searches. It no longer filters them all ther time.
