### PR TITLE
DT-6503 Fix broken tickets

### DIFF
--- a/app/component/itinerary/PlanConnection.js
+++ b/app/component/itinerary/PlanConnection.js
@@ -69,7 +69,6 @@ const planConnection = graphql`
             mode
             distance
             transitLeg
-            id
             interlineWithPreviousLeg
             duration
             headsign

--- a/sass/themes/varely/_theme.scss
+++ b/sass/themes/varely/_theme.scss
@@ -12,7 +12,6 @@ $standalone-btn-color: $primary-color;
 $link-color: $primary-color;
 
 /* Component palette */
-$standalone-btn-color: #fff;
 $desktop-title-color: $primary-color;
 $desktop-title-arrow-icon-color: $white;
 $link-color: $primary-color;


### PR DESCRIPTION
Temporarily remove leg id from PlanConnectiin query. This breaks navigation realtime features, so we have to find a permanent fix in OTP side.

Also, remove white button color from varely theme.

