### PR TITLE
DT-6494 Show ticket prices in mobile according to config

### DIFF
--- a/app/component/itinerary/MobileTicketPurchaseInformation.js
+++ b/app/component/itinerary/MobileTicketPurchaseInformation.js
@@ -22,7 +22,9 @@ export default function MobileTicketPurchaseInformation(
     config.availableTickets,
   );
   const price =
-    fare.price > 0 ? `${fare.price.toFixed(2)} €`.replace('.', ',') : '';
+    config.showTicketPrice && fare.price > 0
+      ? `${fare.price.toFixed(2)} €`.replace('.', ',')
+      : '';
 
   const faresInfo = () => {
     const header = `${intl.formatMessage({

--- a/app/configurations/config.lahti.js
+++ b/app/configurations/config.lahti.js
@@ -176,7 +176,7 @@ export default configMerger(walttiConfig, {
   showTicketInformation: true,
   useTicketIcons: true,
   ticketLink: 'https://www.lsl.fi/liput-ja-hinnat/',
-  showTicketPrice: true,
+  showTicketPrice: false,
 
   showTicketLinkOnlyWhenTesting: true,
   settingsForFeatureTesting: {


### PR DESCRIPTION
## Proposed Changes

  - Use showticket config for mobile prices 
  - Turn off Lahti ticket price showing

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
