### PR TITLE
DT-6533 Improved navigator and local storage cooperation

### DIFF
--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -1,17 +1,15 @@
+import cx from 'classnames';
+import connectToStores from 'fluxible-addons-react/connectToStores';
+import { matchShape, routerShape } from 'found';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
-import cx from 'classnames';
-import { matchShape, routerShape } from 'found';
 import { FormattedMessage, intlShape } from 'react-intl';
-import connectToStores from 'fluxible-addons-react/connectToStores';
-import { configShape, itineraryShape, relayShape } from '../../util/shapes';
-import TicketInformation from './TicketInformation';
-import ItinerarySummary from './ItinerarySummary';
-import Legs from './Legs';
-import BackButton from '../BackButton';
-import StartNavi from './StartNavi';
-import MobileTicketPurchaseInformation from './MobileTicketPurchaseInformation';
+import { createFragmentContainer, graphql } from 'react-relay';
+import {
+  getFaresFromLegs,
+  shouldShowFareInfo,
+  shouldShowFarePurchaseInfo,
+} from '../../util/fareUtils';
 import {
   compressLegs,
   getTotalBikingDistance,
@@ -25,22 +23,24 @@ import {
   legContainsBikePark,
   legContainsRentalBike,
 } from '../../util/legUtils';
-import { BreakpointConsumer } from '../../util/withBreakpoint';
 import { streetHash } from '../../util/path';
-import {
-  getFaresFromLegs,
-  shouldShowFareInfo,
-  shouldShowFarePurchaseInfo,
-} from '../../util/fareUtils';
+import { configShape, itineraryShape, relayShape } from '../../util/shapes';
 import {
   getFormattedTimeDate,
   isToday,
   isTomorrow,
 } from '../../util/timeUtils';
-import VehicleRentalDurationInfo from './VehicleRentalDurationInfo';
+import { BreakpointConsumer } from '../../util/withBreakpoint';
+import BackButton from '../BackButton';
 import Emissions from './Emissions';
 import EmissionsInfo from './EmissionsInfo';
 import FareDisclaimer from './FareDisclaimer';
+import ItinerarySummary from './ItinerarySummary';
+import Legs from './Legs';
+import MobileTicketPurchaseInformation from './MobileTicketPurchaseInformation';
+import StartNavi from './StartNavi';
+import TicketInformation from './TicketInformation';
+import VehicleRentalDurationInfo from './VehicleRentalDurationInfo';
 
 class ItineraryDetails extends React.Component {
   static propTypes = {

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -42,7 +42,6 @@ import Emissions from './Emissions';
 import EmissionsInfo from './EmissionsInfo';
 import FareDisclaimer from './FareDisclaimer';
 
-/* eslint-disable prettier/prettier */
 class ItineraryDetails extends React.Component {
   static propTypes = {
     itinerary: itineraryShape.isRequired,

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -312,6 +312,7 @@ class ItineraryDetails extends React.Component {
             this.props.setNavigation && (
               <StartNavi
                 key="navigation"
+                itinerary={itinerary}
                 setNavigation={this.props.setNavigation}
               />
             ),

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -83,7 +83,7 @@ class ItineraryDetails extends React.Component {
       this.context.match.params.hash !== streetHash.walk &&
       this.context.match.params.hash !== streetHash.bike
     );
-  };
+  }
 
   getFutureText(startTime) {
     const refTime = Date.now();
@@ -96,7 +96,7 @@ class ItineraryDetails extends React.Component {
       });
     }
     return getFormattedTimeDate(startTime, 'dd D.M.');
-  };
+  }
 
   getExtraProps(itinerary) {
     const compressedItinerary = {
@@ -130,24 +130,36 @@ class ItineraryDetails extends React.Component {
       futureText,
       isMultiRow,
     };
-  };
+  }
 
   render() {
-    const { itinerary, currentLanguage, isMobile, bikeAndPublicItineraryCount } = this.props;
+    const {
+      itinerary,
+      currentLanguage,
+      isMobile,
+      bikeAndPublicItineraryCount,
+    } = this.props;
     const { config } = this.context;
     if (!itinerary?.legs[0]) {
       return null;
     }
     const fares = getFaresFromLegs(itinerary.legs, config);
     const extraProps = this.getExtraProps(itinerary);
-    const {biking, walking, driving, futureText, isMultiRow} = extraProps;
+    const { biking, walking, driving, futureText, isMultiRow } = extraProps;
     const legsWithRentalBike = compressLegs(itinerary.legs).filter(leg =>
       legContainsRentalBike(leg),
     );
-    const legswithBikePark = compressLegs(itinerary.legs).filter(leg => legContainsBikePark(leg));
-    const legsWithScooter = compressLegs(itinerary.legs).some(leg => leg.mode === 'SCOOTER');
+    const legswithBikePark = compressLegs(itinerary.legs).filter(leg =>
+      legContainsBikePark(leg),
+    );
+    const legsWithScooter = compressLegs(itinerary.legs).some(
+      leg => leg.mode === 'SCOOTER',
+    );
     const containsBiking = biking.duration > 0 && biking.distance > 0;
-    const showBikeBoardingInformation = containsBiking && bikeAndPublicItineraryCount > 0 && legswithBikePark.length === 0;
+    const showBikeBoardingInformation =
+      containsBiking &&
+      bikeAndPublicItineraryCount > 0 &&
+      legswithBikePark.length === 0;
     const rentalBikeNetworks = new Set();
     let showRentalBikeDurationWarning = false;
     if (legsWithRentalBike.length > 0) {
@@ -183,7 +195,10 @@ class ItineraryDetails extends React.Component {
 
     const externalOperatorJourneys = legsWithScooter;
 
-    if (shouldShowFareInfo(config) && (fares.some(fare => fare.isUnknown) || externalOperatorJourneys) ) {
+    if (
+      shouldShowFareInfo(config) &&
+      (fares.some(fare => fare.isUnknown) || externalOperatorJourneys)
+    ) {
       const found = {};
       itinerary.legs.forEach(leg => {
         if (config.modeDisclaimers?.[leg.mode] && !found[leg.mode]) {
@@ -201,13 +216,10 @@ class ItineraryDetails extends React.Component {
       });
 
       const info = config.callAgencyInfo?.[currentLanguage];
-      if (
-        info &&
-        itinerary.legs.some(leg => isCallAgencyPickupType(leg))
-      ) {
+      if (info && itinerary.legs.some(leg => isCallAgencyPickupType(leg))) {
         disclaimers.push(
           <FareDisclaimer
-	    key={disclaimers.length}
+            key={disclaimers.length}
             textId="separate-ticket-required-for-call-agency-disclaimer"
             href={info.callAgencyInfoLink}
             linkText={info.callAgencyInfoLinkText}
@@ -218,11 +230,13 @@ class ItineraryDetails extends React.Component {
       if (!disclaimers.length) {
         disclaimers.push(
           <FareDisclaimer
-	    key="faredisclaimer-separate-ticket-key"
+            key="faredisclaimer-separate-ticket-key"
             textId="separate-ticket-required-disclaimer"
             values={{
-              agencyName: typeof config.primaryAgencyName === 'string' ? config.primaryAgencyName :
-		config.primaryAgencyName?.[currentLanguage]
+              agencyName:
+                typeof config.primaryAgencyName === 'string'
+                  ? config.primaryAgencyName
+                  : config.primaryAgencyName?.[currentLanguage],
             }}
           />,
         );
@@ -238,10 +252,10 @@ class ItineraryDetails extends React.Component {
               number: itineraryIndex,
             }}
           />
-	</h2>
+        </h2>
         <BreakpointConsumer>
           {breakpoint => [
-	    breakpoint === 'large' && !this.props.hideTitle && (
+            breakpoint === 'large' && !this.props.hideTitle && (
               <div className="desktop-title" key="header">
                 <div className="title-container h2">
                   <BackButton
@@ -258,7 +272,7 @@ class ItineraryDetails extends React.Component {
                 </div>
               </div>
             ),
-	    <ItinerarySummary
+            <ItinerarySummary
               itinerary={itinerary}
               key="summary"
               walking={walking}
@@ -267,15 +281,14 @@ class ItineraryDetails extends React.Component {
               futureText={futureText}
               isMultiRow={isMultiRow}
               isMobile={isMobile}
-              hideBottomDivider={isMobile && shouldShowFarePurchaseInfo(
-                config,
-                breakpoint,
-                fares,
-              )}
+              hideBottomDivider={
+                isMobile &&
+                shouldShowFarePurchaseInfo(config, breakpoint, fares)
+              }
             />,
             showRentalBikeDurationWarning && (
               <VehicleRentalDurationInfo
-		key="rentaldurationinfo"
+                key="rentaldurationinfo"
                 networks={Array.from(rentalBikeNetworks)}
                 config={config}
               />
@@ -283,28 +296,28 @@ class ItineraryDetails extends React.Component {
             shouldShowFareInfo(config) &&
               (shouldShowFarePurchaseInfo(config, breakpoint, fares) ? (
                 <MobileTicketPurchaseInformation
-		  key="mobileticketpurchaseinformation"
+                  key="mobileticketpurchaseinformation"
                   fares={fares}
                   zones={getZones(itinerary.legs)}
                 />
               ) : (
                 <TicketInformation
-		  key="ticketinformation"
+                  key="ticketinformation"
                   fares={fares}
                   zones={getZones(itinerary.legs)}
                   legs={itinerary.legs}
                 />
               )),
 
-              this.props.setNavigation && (
-                <StartNavi
-                  key="navigation"
-                  setNavigation={this.props.setNavigation}
-                />
-              ),
+            this.props.setNavigation && (
+              <StartNavi
+                key="navigation"
+                setNavigation={this.props.setNavigation}
+              />
+            ),
             config.showCO2InItinerarySummary && !legsWithScooter && (
               <EmissionsInfo
-		key="emissionsummary"
+                key="emissionsummary"
                 itinerary={itinerary}
                 isMobile={isMobile}
               />
@@ -319,11 +332,11 @@ class ItineraryDetails extends React.Component {
                 className={cx('itinerary-main', {
                   'bp-large': breakpoint === 'large',
                 })}
-		key="legwrapper"
+                key="legwrapper"
               >
                 {disclaimers}
                 <Legs
-		  key="itinerarylegs"
+                  key="itinerarylegs"
                   fares={fares}
                   itinerary={itinerary}
                   focusToPoint={this.props.focusToPoint}
@@ -337,7 +350,7 @@ class ItineraryDetails extends React.Component {
               </div>
               {config.showCO2InItinerarySummary && !legsWithScooter && (
                 <Emissions
-		  key="emissionsinfo"
+                  key="emissionsinfo"
                   config={config}
                   itinerary={itinerary}
                   carEmissions={this.props.carEmissions}
@@ -354,7 +367,7 @@ class ItineraryDetails extends React.Component {
                   />
                 </div>
               )}
-              <div className="itinerary-empty-space" key="emptyspace"/>
+              <div className="itinerary-empty-space" key="emptyspace" />
             </div>,
           ]}
         </BreakpointConsumer>
@@ -447,14 +460,14 @@ const withRelay = createFragmentContainer(
             lat
             lon
             name
-            vehicleParking  {
+            vehicleParking {
               name
               vehicleParkingId
             }
             vehicleRentalStation {
               rentalNetwork {
-               networkId
-            }
+                networkId
+              }
               availableVehicles {
                 total
               }
@@ -469,7 +482,7 @@ const withRelay = createFragmentContainer(
               lon
               rentalUris {
                 android
-                ios 
+                ios
                 web
               }
               rentalNetwork {
@@ -507,7 +520,7 @@ const withRelay = createFragmentContainer(
               lon
               stationId
               rentalNetwork {
-               networkId
+                networkId
               }
               availableVehicles {
                 total
@@ -542,13 +555,13 @@ const withRelay = createFragmentContainer(
                 }
               }
             }
-            vehicleParking  {
-               vehicleParkingId
-               name
+            vehicleParking {
+              vehicleParkingId
+              name
             }
           }
           intermediatePlaces {
-            arrival  {
+            arrival {
               scheduledTime
               estimated {
                 time

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -17,7 +17,6 @@ import {
   getDialogState,
   getLatestNavigatorItinerary,
   setDialogState,
-  setLatestNavigatorItinerary,
 } from '../../store/localStorage';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 import { getWeatherData } from '../../util/apiUtils';
@@ -650,11 +649,6 @@ export default function ItineraryPage(props, context) {
       setMapState({ center: undefined, zoom: undefined, bounds: undefined });
       navigateMap();
       clearLatestNavigatorItinerary();
-    } else {
-      const { combinedEdges, selectedIndex } = getItinerarySelection();
-      if (combinedEdges[selectedIndex]?.node) {
-        setLatestNavigatorItinerary(combinedEdges[selectedIndex]?.node);
-      }
     }
     setNaviMode(isEnabled);
   };

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -745,7 +745,8 @@ export default function ItineraryPage(props, context) {
     updateLocalStorage(true);
     addFeedbackly(context);
 
-    if (isStoredItineraryRelevant(match)) {
+    const storedItinerary = getLatestNavigatorItinerary();
+    if (isStoredItineraryRelevant(storedItinerary, match)) {
       setNavigation(true);
     } else {
       clearLatestNavigatorItinerary();

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -70,7 +70,6 @@ import {
   setCurrentTimeToURL,
   settingsLimitRouting,
   stopClient,
-  storedParamsMatchURL,
   updateClient,
 } from './ItineraryPageUtils';
 import ItineraryTabs from './ItineraryTabs';
@@ -746,11 +745,9 @@ export default function ItineraryPage(props, context) {
     updateLocalStorage(true);
     addFeedbackly(context);
 
-    const { params: storedParams } = getLatestNavigatorItinerary();
-    if (
-      (hash === undefined || hash === null) &&
-      !storedParamsMatchURL(storedParams, match)
-    ) {
+    if (isStoredItineraryRelevant(match)) {
+      setNavigation(true);
+    } else {
       clearLatestNavigatorItinerary();
     }
 
@@ -774,9 +771,6 @@ export default function ItineraryPage(props, context) {
       makeRelaxedQuery();
       makeRelaxedScooterQuery();
     }
-    if (isStoredItineraryRelevant(match)) {
-      setNavigation(true);
-    }
   }, [
     settingsState.settingsChanged,
     params.from,
@@ -788,9 +782,6 @@ export default function ItineraryPage(props, context) {
   useEffect(() => {
     navigateMap();
     setMapState({ center: undefined, zoom: undefined, bounds: undefined });
-    if (isStoredItineraryRelevant(match)) {
-      setNavigation(true);
-    }
 
     if (detailView) {
       // If itinerary is not found in detail view, go back to summary view

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -768,9 +768,9 @@ export default function ItineraryPage(props, context) {
    * Enables naviMode immediately on itinerary selection if all of the following resolve as true:
    * a stored itinerary exists
    * the stored itinerary ends in future
-   * the stored itinerary to and from coordinates match those of current query
+   * the params stored along itinerary match those of the current query
    *
-   * Note: false value is not passed to function to prevent localStorage entry from being cleared
+   * Note: false value is not passed to setNavigation to prevent localStorage entry from being cleared
    */
   const setupNavigator = () => {
     const { itinerary: storedItinerary, params: storedParams } =

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -546,16 +546,16 @@ export function quitIteration(plan, newPlan, planParams, startTime) {
  * @param {matchShape} match matchContext with URL params
  * @returns true if stored itinerary was set with identical parameters
  */
-export const storedParamsMatchURL = (storedParams, match) => {
+const storedParamsMatchURL = (storedParams, match) => {
   if (!storedParams || !match) {
     return false;
   }
 
   return (
-    storedParams.from === match?.params?.from &&
-    storedParams.to === match?.params?.to &&
-    storedParams.time === match?.location?.query?.time &&
-    storedParams.arriveBy === match?.location?.query?.arriveBy
+    storedParams.from === match.params?.from &&
+    storedParams.to === match.params?.to &&
+    storedParams.time === match.location?.query?.time &&
+    storedParams.arriveBy === match.location?.query?.arriveBy
   );
 };
 
@@ -571,15 +571,17 @@ export const storedParamsMatchURL = (storedParams, match) => {
  * @returns true if Navigator can be initialized with stored itinerary
  */
 export const isStoredItineraryRelevant = match => {
+  /* eslint-disable eqeqeq */
   const { itinerary, params } = getLatestNavigatorItinerary();
   const {
-    params: { hash = null },
+    params: { hash, secondHash },
   } = match;
 
   return (
-    itinerary &&
-    Date.parse(itinerary.end) > Date.now() &&
-    storedParamsMatchURL(params, match) &&
-    params?.index === hash
+    (itinerary &&
+      Date.parse(itinerary.end) > Date.now() &&
+      storedParamsMatchURL(params, match) &&
+      params?.index == secondHash) ||
+    params?.index == hash
   );
 };

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -541,6 +541,7 @@ export function quitIteration(plan, newPlan, planParams, startTime) {
  * Checks if itinerary in local storage was set with identical URL parameters.
  *
  * Note: storedParams.hash is not compared
+ *
  * @param {{from: string, to: string, time: number, arriveBy: boolean}} storedParams
  * @param {matchShape} match matchContext with URL params
  * @returns true if stored itinerary was set with identical parameters
@@ -559,12 +560,13 @@ export const storedParamsMatchURL = (storedParams, match) => {
 };
 
 /**
- * Enables Navigator assisted journey to on itinerary selection if all of the following resolve as true:
- * a stored itinerary exists
- * the stored itinerary ends in future
- * the params stored along itinerary match those of the current query
+ * Enables Navigator assisted journey on itinerary selection if all of the following resolve as true:
+ * - a stored itinerary exists
+ * - the stored itinerary ends in future
+ * - the params stored along itinerary match those of the current query
  *
  * Note: Itinerary related hash param is also compared
+ *
  * @param {matchShape} match matchContext with URL params
  * @returns true if Navigator can be initialized with stored itinerary
  */

--- a/app/component/itinerary/StartNavi.js
+++ b/app/component/itinerary/StartNavi.js
@@ -21,7 +21,7 @@ const StartNavi = ({ setNavigation, itinerary }, context) => {
         to: match.params.to,
         arriveBy: match.location.query.arriveBy,
         time: match.location.query.time,
-        index: match.params.hash,
+        index: match.params.secondHash ?? match.params.hash,
       },
     });
   };

--- a/app/component/itinerary/StartNavi.js
+++ b/app/component/itinerary/StartNavi.js
@@ -21,7 +21,8 @@ const StartNavi = ({ setNavigation, itinerary }, context) => {
         to: match.params.to,
         arriveBy: match.location.query.arriveBy,
         time: match.location.query.time,
-        index: match.params.secondHash ?? match.params.hash,
+        hash: match.params.hash,
+        secondHash: match.params.secondHash,
       },
     });
   };

--- a/app/component/itinerary/StartNavi.js
+++ b/app/component/itinerary/StartNavi.js
@@ -1,18 +1,34 @@
+import { matchShape } from 'found';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
-import { configShape } from '../../util/shapes';
+import { setLatestNavigatorItinerary } from '../../store/localStorage';
+import { configShape, itineraryShape } from '../../util/shapes';
 import Icon from '../Icon';
 
-const StartNavi = ({ setNavigation }, context) => {
-  const { config, intl } = context;
+const StartNavi = ({ setNavigation, itinerary }, context) => {
+  const { config, intl, match } = context;
 
   const color =
     config.colors?.accessiblePrimary || config.colors?.primary || 'black';
 
+  const handleClick = () => {
+    setNavigation(true);
+    setLatestNavigatorItinerary({
+      itinerary,
+      params: {
+        from: match.params.from,
+        to: match.params.to,
+        arriveBy: match.location.query.arriveBy,
+        time: match.location.query.time,
+        index: match.params.hash,
+      },
+    });
+  };
+
   return (
     <div className="navi-start-container">
-      <button type="button" onClick={() => setNavigation(true)}>
+      <button type="button" onClick={handleClick}>
         <Icon img="icon-icon_navigation" color={color} height={2} width={2} />
         <div className="content">
           <FormattedMessage tagName="div" id="new-feature" />
@@ -32,11 +48,13 @@ const StartNavi = ({ setNavigation }, context) => {
 
 StartNavi.propTypes = {
   setNavigation: PropTypes.func.isRequired,
+  itinerary: itineraryShape.isRequired,
 };
 
 StartNavi.contextTypes = {
   config: configShape.isRequired,
   intl: intlShape.isRequired,
+  match: matchShape.isRequired,
 };
 
 export default StartNavi;

--- a/test/unit/views/ItineraryPage/ItineraryPageUtils.test.js
+++ b/test/unit/views/ItineraryPage/ItineraryPageUtils.test.js
@@ -1,0 +1,143 @@
+import { isStoredItineraryRelevant } from '../../../../app/component/itinerary/ItineraryPageUtils';
+
+describe('itineraryPageUtils', () => {
+  describe('isStoredItineraryRelevant', () => {
+    const TIME = 12345;
+    const ARRIVE_BY = false;
+    const INDEX = '0';
+    const TEN_MINUTES_FROM_NOW = new Date(Date.now() + 600000).toISOString();
+
+    let mockStoredItinerary;
+    let mockMatch;
+
+    beforeEach(() => {
+      mockStoredItinerary = {
+        itinerary: {
+          end: TEN_MINUTES_FROM_NOW,
+        },
+        params: {
+          from: 'foo',
+          to: 'bar',
+          arriveBy: ARRIVE_BY,
+          time: TIME,
+          hash: INDEX,
+          secondHash: undefined,
+        },
+      };
+
+      mockMatch = {
+        params: { from: 'foo', to: 'bar', hash: INDEX, secondHash: undefined },
+        location: { query: { time: TIME, arriveBy: ARRIVE_BY } },
+      };
+    });
+
+    it('should return true for equal params', () => {
+      expect(
+        isStoredItineraryRelevant(mockStoredItinerary, mockMatch),
+      ).to.equal(true);
+    });
+
+    it('should return true if stored index matches secondHash', () => {
+      expect(
+        isStoredItineraryRelevant(mockStoredItinerary, {
+          ...mockMatch,
+          hash: 'other',
+          secondHash: INDEX,
+        }),
+      ).to.equal(true);
+    });
+
+    it('should return true if arriveBy is undefined for both', () => {
+      const itineraryWithoutArriveBy = { ...mockStoredItinerary };
+      const matchWithoutArriveBy = { ...mockMatch };
+      itineraryWithoutArriveBy.params.arriveBy = undefined;
+      matchWithoutArriveBy.location.query.arriveBy = undefined;
+
+      expect(
+        isStoredItineraryRelevant(
+          itineraryWithoutArriveBy,
+          matchWithoutArriveBy,
+        ),
+      ).to.equal(true);
+    });
+
+    it('should return false for past itinerary', () => {
+      const TEN_MINUTES_IN_THE_PAST = new Date(
+        Date.now() + 600000,
+      ).toISOString();
+
+      expect(
+        isStoredItineraryRelevant(
+          {
+            ...mockStoredItinerary,
+            itinerary: { end: TEN_MINUTES_IN_THE_PAST },
+          },
+          mockMatch,
+        ),
+      ).to.equal(true);
+    });
+
+    it('should return false on index and hash mismatch if secondHash is undefined', () => {
+      const matchWithDifferentHash = { ...mockMatch };
+      matchWithDifferentHash.params.hash = '999';
+      matchWithDifferentHash.params.secondHash = undefined;
+
+      expect(
+        isStoredItineraryRelevant(mockStoredItinerary, matchWithDifferentHash),
+      ).to.equal(false);
+    });
+
+    it('should return false on index and hash mismatch if hash and secondHash are undefined', () => {
+      const matchWithDifferentHash = { ...mockMatch };
+      matchWithDifferentHash.params.hash = undefined;
+      matchWithDifferentHash.params.secondHash = undefined;
+
+      expect(
+        isStoredItineraryRelevant(mockStoredItinerary, matchWithDifferentHash),
+      ).to.equal(false);
+    });
+
+    it('should throw error if match is undefined', () => {
+      expect(() =>
+        isStoredItineraryRelevant(mockStoredItinerary, undefined),
+      ).to.throw(Error);
+    });
+
+    it('should not throw error if stored itinerary is empty object', () => {
+      expect(() => isStoredItineraryRelevant({}, mockMatch)).to.not.throw(
+        Error,
+      );
+      expect(isStoredItineraryRelevant({}, mockMatch)).to.equal(false);
+    });
+
+    it('should not throw error if stored itinerary is missing itinerary field', () => {
+      expect(() =>
+        isStoredItineraryRelevant(
+          { ...mockStoredItinerary, itinerary: undefined },
+          mockMatch,
+        ),
+      ).to.not.throw(Error);
+      expect(
+        isStoredItineraryRelevant(
+          { ...mockStoredItinerary, itinerary: undefined },
+          mockMatch,
+        ),
+      ).to.equal(false);
+    });
+
+    it('should not throw error if stored itinerary is missing itinerary field', () => {
+      expect(() =>
+        isStoredItineraryRelevant(
+          { ...mockStoredItinerary, params: undefined },
+          mockMatch,
+        ),
+      ).to.not.throw(Error);
+      expect(
+        isStoredItineraryRelevant(
+          { ...mockStoredItinerary, params: undefined },
+          mockMatch,
+        ),
+      ).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed Changes
Navigator is now more context aware:
  - If `from`, `to`, `time`, `arriveBy` and `hash` parameters are identical to those of the stored journey
    - Traversing to `ItineraryPage` detail view will automatically trigger the Navigator journey.
  - If `from`, `to`, `time` and `arriveBy` parameters are identical to those of the stored journey
    - Traversing to `ItineraryPage` list view does not necessarily purge the stored itinerary from memory.
      - Local storage entry is purged if user navigates to list view from active navigator journey either by using the arrow icon or by browsing back using browser history
    - Traversing to `ItineraryPage` detail view does not purge the stored itinerary from memory, but a Navigator journey is not triggered
  - If any of the parameters is different
    - Traversing to `ItineraryPage` list view or detail view will purge the stored Navigator journey from local storage

## Pull Request Check List

  - [x] A reasonable set of unit tests is included
  - [x] Console does not show new warnings/errors
  - [x] Changes are documented or they are self explanatory
  - [x] This pull request does not have any merge conflicts
  - [x] All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
