### PR TITLE
DT-6476 Refactor navigation initializer into callback function

### DIFF
--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -53,7 +53,7 @@ class ItineraryDetails extends React.Component {
     currentLanguage: PropTypes.string,
     changeHash: PropTypes.func,
     openSettings: PropTypes.func.isRequired,
-    setNavigation: PropTypes.func,
+    onStartNavigatorCallback: PropTypes.func,
     bikeAndPublicItineraryCount: PropTypes.number,
     relayEnvironment: relayShape,
   };
@@ -65,7 +65,7 @@ class ItineraryDetails extends React.Component {
     bikeAndPublicItineraryCount: 0,
     carEmissions: undefined,
     relayEnvironment: undefined,
-    setNavigation: undefined,
+    onStartNavigatorCallback: undefined,
   };
 
   static contextTypes = {
@@ -308,11 +308,11 @@ class ItineraryDetails extends React.Component {
                 />
               )),
 
-            this.props.setNavigation && (
+            this.props.onStartNavigatorCallback && (
               <StartNavi
                 key="navigation"
                 itinerary={itinerary}
-                setNavigation={this.props.setNavigation}
+                onStartNavigatorCallback={this.props.onStartNavigatorCallback}
               />
             ),
             config.showCO2InItinerarySummary && !legsWithScooter && (

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -311,7 +311,6 @@ class ItineraryDetails extends React.Component {
             this.props.onStartNavigatorCallback && (
               <StartNavi
                 key="navigation"
-                itinerary={itinerary}
                 onStartNavigatorCallback={this.props.onStartNavigatorCallback}
               />
             ),

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -53,7 +53,7 @@ class ItineraryDetails extends React.Component {
     currentLanguage: PropTypes.string,
     changeHash: PropTypes.func,
     openSettings: PropTypes.func.isRequired,
-    onStartNavigatorCallback: PropTypes.func,
+    startNavigation: PropTypes.func,
     bikeAndPublicItineraryCount: PropTypes.number,
     relayEnvironment: relayShape,
   };
@@ -65,7 +65,7 @@ class ItineraryDetails extends React.Component {
     bikeAndPublicItineraryCount: 0,
     carEmissions: undefined,
     relayEnvironment: undefined,
-    onStartNavigatorCallback: undefined,
+    startNavigation: undefined,
   };
 
   static contextTypes = {
@@ -308,10 +308,10 @@ class ItineraryDetails extends React.Component {
                 />
               )),
 
-            this.props.onStartNavigatorCallback && (
+            this.props.startNavigation && (
               <StartNavi
                 key="navigation"
-                onStartNavigatorCallback={this.props.onStartNavigatorCallback}
+                startNavigation={this.props.startNavigation}
               />
             ),
             config.showCO2InItinerarySummary && !legsWithScooter && (

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -1199,7 +1199,7 @@ export default function ItineraryPage(props, context) {
           bikeAndPublicItineraryCount={bikePublicPlan.bikePublicItineraryCount}
           openSettings={showSettingsPanel}
           relayEnvironment={props.relayEnvironment}
-          startNavigator={navigateHook}
+          startNavigation={navigateHook}
         />
       );
     }

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -655,7 +655,7 @@ export default function ItineraryPage(props, context) {
     setNaviMode(isEnabled);
   };
 
-  const storeItineraryAndStartNavi = itinerary => {
+  const storeItineraryAndStartNavigation = itinerary => {
     setNavigation(true);
     setLatestNavigatorItinerary({
       itinerary,
@@ -1180,7 +1180,10 @@ export default function ItineraryPage(props, context) {
         Date.parse(combinedEdges[selectedIndex]?.node.end) < Date.now();
       const navigateHook =
         !desktop && config.experimental.navigation && !pastSearch
-          ? () => storeItineraryAndStartNavi(combinedEdges[selectedIndex]?.node)
+          ? () =>
+              storeItineraryAndStartNavigation(
+                combinedEdges[selectedIndex]?.node,
+              )
           : undefined;
       carEmissions = carEmissions ? Math.round(carEmissions) : undefined;
       content = (
@@ -1196,7 +1199,7 @@ export default function ItineraryPage(props, context) {
           bikeAndPublicItineraryCount={bikePublicPlan.bikePublicItineraryCount}
           openSettings={showSettingsPanel}
           relayEnvironment={props.relayEnvironment}
-          onStartNavigatorCallback={navigateHook}
+          onStartNavigator={navigateHook}
         />
       );
     }

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -1199,7 +1199,7 @@ export default function ItineraryPage(props, context) {
           bikeAndPublicItineraryCount={bikePublicPlan.bikePublicItineraryCount}
           openSettings={showSettingsPanel}
           relayEnvironment={props.relayEnvironment}
-          onStartNavigator={navigateHook}
+          startNavigator={navigateHook}
         />
       );
     }

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -17,6 +17,7 @@ import {
   getDialogState,
   getLatestNavigatorItinerary,
   setDialogState,
+  setLatestNavigatorItinerary,
 } from '../../store/localStorage';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 import { getWeatherData } from '../../util/apiUtils';
@@ -654,6 +655,21 @@ export default function ItineraryPage(props, context) {
     setNaviMode(isEnabled);
   };
 
+  const storeItineraryAndStartNavi = itinerary => {
+    setNavigation(true);
+    setLatestNavigatorItinerary({
+      itinerary,
+      params: {
+        from: params.from,
+        to: params.to,
+        arriveBy: query.arriveBy,
+        time: query.time,
+        hash,
+        secondHash,
+      },
+    });
+  };
+
   // save url-defined location to old searches
   function saveUrlSearch(endpoint) {
     const parts = endpoint.split('::'); // label::lat,lon
@@ -1164,7 +1180,7 @@ export default function ItineraryPage(props, context) {
         Date.parse(combinedEdges[selectedIndex]?.node.end) < Date.now();
       const navigateHook =
         !desktop && config.experimental.navigation && !pastSearch
-          ? setNavigation
+          ? () => storeItineraryAndStartNavi(combinedEdges[selectedIndex]?.node)
           : undefined;
       carEmissions = carEmissions ? Math.round(carEmissions) : undefined;
       content = (
@@ -1180,7 +1196,7 @@ export default function ItineraryPage(props, context) {
           bikeAndPublicItineraryCount={bikePublicPlan.bikePublicItineraryCount}
           openSettings={showSettingsPanel}
           relayEnvironment={props.relayEnvironment}
-          setNavigation={navigateHook}
+          onStartNavigatorCallback={navigateHook}
         />
       );
     }

--- a/app/component/itinerary/StartNavi.js
+++ b/app/component/itinerary/StartNavi.js
@@ -1,35 +1,18 @@
-import { matchShape } from 'found';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
-import { setLatestNavigatorItinerary } from '../../store/localStorage';
-import { configShape, itineraryShape } from '../../util/shapes';
+import { configShape } from '../../util/shapes';
 import Icon from '../Icon';
 
-const StartNavi = ({ setNavigation, itinerary }, context) => {
-  const { config, intl, match } = context;
+const StartNavi = ({ onStartNavigatorCallback }, context) => {
+  const { config, intl } = context;
 
   const color =
     config.colors?.accessiblePrimary || config.colors?.primary || 'black';
 
-  const handleClick = () => {
-    setNavigation(true);
-    setLatestNavigatorItinerary({
-      itinerary,
-      params: {
-        from: match.params.from,
-        to: match.params.to,
-        arriveBy: match.location.query.arriveBy,
-        time: match.location.query.time,
-        hash: match.params.hash,
-        secondHash: match.params.secondHash,
-      },
-    });
-  };
-
   return (
     <div className="navi-start-container">
-      <button type="button" onClick={handleClick}>
+      <button type="button" onClick={onStartNavigatorCallback}>
         <Icon img="icon-icon_navigation" color={color} height={2} width={2} />
         <div className="content">
           <FormattedMessage tagName="div" id="new-feature" />
@@ -48,14 +31,12 @@ const StartNavi = ({ setNavigation, itinerary }, context) => {
 };
 
 StartNavi.propTypes = {
-  setNavigation: PropTypes.func.isRequired,
-  itinerary: itineraryShape.isRequired,
+  onStartNavigatorCallback: PropTypes.func.isRequired,
 };
 
 StartNavi.contextTypes = {
   config: configShape.isRequired,
   intl: intlShape.isRequired,
-  match: matchShape.isRequired,
 };
 
 export default StartNavi;

--- a/app/component/itinerary/StartNavi.js
+++ b/app/component/itinerary/StartNavi.js
@@ -4,7 +4,7 @@ import { FormattedMessage, intlShape } from 'react-intl';
 import { configShape } from '../../util/shapes';
 import Icon from '../Icon';
 
-const StartNavi = ({ onStartNavigatorCallback }, context) => {
+const StartNavi = ({ startNavigation }, context) => {
   const { config, intl } = context;
 
   const color =
@@ -12,7 +12,7 @@ const StartNavi = ({ onStartNavigatorCallback }, context) => {
 
   return (
     <div className="navi-start-container">
-      <button type="button" onClick={onStartNavigatorCallback}>
+      <button type="button" onClick={startNavigation}>
         <Icon img="icon-icon_navigation" color={color} height={2} width={2} />
         <div className="content">
           <FormattedMessage tagName="div" id="new-feature" />
@@ -31,7 +31,7 @@ const StartNavi = ({ onStartNavigatorCallback }, context) => {
 };
 
 StartNavi.propTypes = {
-  onStartNavigatorCallback: PropTypes.func.isRequired,
+  startNavigation: PropTypes.func.isRequired,
 };
 
 StartNavi.contextTypes = {

--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -4,7 +4,7 @@ import { legTime } from '../../../util/legUtils';
 import { itineraryShape, relayShape } from '../../../util/shapes';
 import NaviBottom from './NaviBottom';
 import NaviCardContainer from './NaviCardContainer';
-import { useRealtimeLegs } from '../hooks/useRealtimeLegs';
+import { useRealtimeLegs } from './hooks/useRealtimeLegs';
 
 function NaviContainer(
   { itinerary, focusToLeg, relayEnvironment, setNavigation, mapRef },

--- a/app/component/itinerary/navigator/hooks/useRealtimeLegs.js
+++ b/app/component/itinerary/navigator/hooks/useRealtimeLegs.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { fetchQuery } from 'react-relay';
-import { checkPositioningPermission } from '../../../action/PositionActions';
-import { legQuery } from '../queries/LegQuery';
+import { checkPositioningPermission } from '../../../../action/PositionActions';
+import { legQuery } from '../../queries/LegQuery';
 
 const useRealtimeLegs = (initialLegs, mapRef, relayEnvironment) => {
   const [isPositioningAllowed, setPositioningAllowed] = useState(false);


### PR DESCRIPTION
## Proposed Changes
Refactors navigation initialization into a callback function passed down from `ItineraryPage`. The current implementation uses an unexpected itinerary version as it lacks some fragment properties (i.e. `headSign`) due to react-relay logic if the stored itinerary is the one passed down to `StartNavi` from `ItineraryDetails`

## Pull Request Check List

  - [ ] A reasonable set of unit tests is included
  - [x] Console does not show new warnings/errors
  - [x] Changes are documented or they are self explanatory
  - [x] This pull request does not have any merge conflicts
  - [x] All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
