### PR TITLE
DT-6589 & DT-6587: Navigator shows notifications for expired legs and we should disallow close for canceled routes

### DIFF
--- a/app/component/itinerary/navigator/NaviCardContainer.js
+++ b/app/component/itinerary/navigator/NaviCardContainer.js
@@ -97,11 +97,11 @@ function NaviCardContainer(
       }
     }
     if (incomingMessages.size || legChanged) {
-      // Handle messages when new messages arrives or leg is changed.
+      // Handle messages when new messages arrives.
 
-      // Current active messages. Filter away legChange messages when leg changes.
+      // Current active messages. Filter away expired messages.
       const previousValidMessages = legChanged
-        ? activeMessages.filter(m => m.expiresOn !== 'legChange')
+        ? activeMessages.filter(m => m.expiresOn < time)
         : activeMessages;
 
       // handle messages that are updated.

--- a/app/component/itinerary/navigator/NaviMessage.js
+++ b/app/component/itinerary/navigator/NaviMessage.js
@@ -6,7 +6,10 @@ import { configShape } from '../../../util/shapes';
 
 import Icon from '../../Icon';
 
-function NaviMessage({ severity, children, index, handleRemove }, { config }) {
+function NaviMessage(
+  { severity, children, index, handleRemove, hideClose },
+  { config },
+) {
   const [removingIndex, setRemovingIndex] = useState(null);
 
   const handleRemoveClick = () => {
@@ -45,17 +48,19 @@ function NaviMessage({ severity, children, index, handleRemove }, { config }) {
     >
       <Icon img={iconId} height={1.4} width={1.4} color={color} />
       {children}
-      <button
-        type="button"
-        className="info-close"
-        onClick={() => handleRemoveClick()}
-      >
-        <Icon
-          img="notification-close"
-          className="notification-close"
-          color={config.colors.primary}
-        />
-      </button>
+      {!hideClose && (
+        <button
+          type="button"
+          className="info-close"
+          onClick={() => handleRemoveClick()}
+        >
+          <Icon
+            img="notification-close"
+            className="notification-close"
+            color={config.colors.primary}
+          />
+        </button>
+      )}
     </div>
   );
 }
@@ -65,6 +70,11 @@ NaviMessage.propTypes = {
   children: PropTypes.node.isRequired,
   index: PropTypes.number.isRequired,
   handleRemove: PropTypes.func.isRequired,
+  hideClose: PropTypes.bool,
+};
+
+NaviMessage.defaultProps = {
+  hideClose: false,
 };
 
 NaviMessage.contextTypes = {

--- a/app/component/itinerary/navigator/NaviStack.js
+++ b/app/component/itinerary/navigator/NaviStack.js
@@ -12,6 +12,7 @@ const NaviStack = ({ messages, handleRemove, topPosition }) => {
           severity={notification.severity}
           index={index}
           handleRemove={handleRemove}
+          hideClose={notification.hideClose}
         >
           {notification.content}
         </NaviMessage>

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -222,6 +222,7 @@ export const getItineraryAlerts = (legs, intl, messages, location, router) => {
           severity: 'ALERT',
           content,
           id: `canceled-${legId}`,
+          hideClose: true,
         });
       }
     });
@@ -246,6 +247,7 @@ export const getItineraryAlerts = (legs, intl, messages, location, router) => {
         severity: 'ALERT',
         content,
         id: transferId,
+        hideClose: true,
       });
     }
   }

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -68,7 +68,7 @@ export const getAdditionalMessages = (leg, time, intl, config, messages) => {
 };
 
 export const getTransitLegState = (leg, intl, messages, time) => {
-  const { start, realtimeState, from, mode, legId, route } = leg;
+  const { start, realtimeState, from, mode, legId, route, end } = leg;
   const { scheduledTime, estimated } = start;
   if (mode === 'WALK') {
     return null;
@@ -139,7 +139,7 @@ export const getTransitLegState = (leg, intl, messages, time) => {
     severity = 'INFO';
   }
   const state = severity
-    ? [{ severity, content, id: legId, expiresOn: 'legChange' }]
+    ? [{ severity, content, id: legId, expiresOn: legTime(end) }]
     : [];
   return state;
 };

--- a/app/component/itinerary/navigator/navigator.scss
+++ b/app/component/itinerary/navigator/navigator.scss
@@ -178,7 +178,8 @@
       margin-bottom: var(--space-s);
 
       .extension-divider {
-        border: 1px solid #ddd;
+        height: 1px;
+        background: #ddd;
         width: 85%;
         margin-left: 35px;
         margin-top: var(--space-s);


### PR DESCRIPTION
## Proposed Changes

  - Navigator uses time to determine when the transitLegState notification should expire
  - Hide close button in notification when there is journey breaking notification (cancelled, no route available..) 
  -  Made the divider line thinner in main card as designed.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
