### PR TITLE
Set custom minZooms for configs covering large areas

### DIFF
--- a/app/configurations/config.varely.js
+++ b/app/configurations/config.varely.js
@@ -88,6 +88,10 @@ export default configMerger(walttiConfig, {
     [maxLon, minLat],
   ],
 
+  map: {
+    minZoom: 7,
+  },
+
   menu: {
     copyright: { label: `© Seutu+ ${walttiConfig.YEAR}` },
     content: [

--- a/app/configurations/config.walttiOpas.js
+++ b/app/configurations/config.walttiOpas.js
@@ -135,6 +135,10 @@ export default configMerger(walttiConfig, {
     [23.1, 60.6],
   ],
 
+  map: {
+    minZoom: 6,
+  },
+
   showDisclaimer: true,
 
 });


### PR DESCRIPTION
## Proposed Changes

  - Updates varely and waltti opas configs to allow users (and automatic zooming) to zoom out more.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
