### PR TITLE
DT-6603 Add configurable RouteNumber text limit in itinerary list

### DIFF
--- a/app/component/RouteNumber.js
+++ b/app/component/RouteNumber.js
@@ -18,7 +18,7 @@ function RouteNumber(props, context) {
   // Perform text-related processing
   let filteredText = props.text;
   if (
-    props.isInItineraryList &&
+    props.shortenLongText &&
     context.config.disabledLegTextModes?.includes(mode) &&
     props.className.includes('line')
   ) {
@@ -26,15 +26,15 @@ function RouteNumber(props, context) {
   }
   const textFieldIsText = typeof filteredText === 'string'; // can be also react node
   if (
-    props.isInItineraryList &&
-    context.config.shortenLongTextInItineraryListThreshold &&
+    props.shortenLongText &&
+    context.config.shortenLongTextThreshold &&
     filteredText &&
     textFieldIsText &&
-    filteredText.length > context.config.shortenLongTextInItineraryListThreshold
+    filteredText.length > context.config.shortenLongTextThreshold
   ) {
     filteredText = `${filteredText.substring(
       0,
-      context.config.shortenLongTextInItineraryListThreshold - 3,
+      context.config.shortenLongTextThreshold - 3,
     )}...`;
   }
   const longText =
@@ -250,7 +250,7 @@ RouteNumber.propTypes = {
   card: PropTypes.bool,
   appendClass: PropTypes.string,
   occupancyStatus: PropTypes.string,
-  isInItineraryList: PropTypes.bool,
+  shortenLongText: PropTypes.bool,
 };
 
 RouteNumber.defaultProps = {
@@ -274,7 +274,7 @@ RouteNumber.defaultProps = {
   color: undefined,
   duration: undefined,
   occupancyStatus: undefined,
-  isInItineraryList: false,
+  shortenLongText: false,
 };
 
 RouteNumber.contextTypes = {

--- a/app/component/RouteNumber.js
+++ b/app/component/RouteNumber.js
@@ -282,5 +282,4 @@ RouteNumber.contextTypes = {
   config: configShape.isRequired,
 };
 
-RouteNumber.displayName = 'RouteNumber';
 export default RouteNumber;

--- a/app/component/RouteNumber.js
+++ b/app/component/RouteNumber.js
@@ -12,15 +12,43 @@ const LONG_ROUTE_NUMBER_LENGTH = 6;
 
 function RouteNumber(props, context) {
   const mode = props.mode.toLowerCase();
-  const { alertSeverityLevel, color, withBicycle, withCar, text } = props;
+  const { alertSeverityLevel, color, withBicycle, withCar } = props;
   const isScooter = mode === TransportMode.Scooter.toLowerCase();
-  const textIsText = typeof text === 'string'; // can be also react node
+
+  // Perform text-related processing
+  let filteredText = props.text;
+  if (
+    props.isInItineraryList &&
+    context.config.disabledLegTextModes?.includes(mode) &&
+    props.className.includes('line')
+  ) {
+    filteredText = '';
+  }
+  const textFieldIsText = typeof filteredText === 'string'; // can be also react node
+  if (
+    props.isInItineraryList &&
+    context.config.shortenLongTextInItineraryListThreshold &&
+    filteredText &&
+    textFieldIsText &&
+    filteredText.length > context.config.shortenLongTextInItineraryListThreshold
+  ) {
+    filteredText = `${filteredText.substring(
+      0,
+      context.config.shortenLongTextInItineraryListThreshold - 3,
+    )}...`;
+  }
   const longText =
-    text && textIsText && text.length >= LONG_ROUTE_NUMBER_LENGTH;
+    filteredText &&
+    textFieldIsText &&
+    filteredText.length >= LONG_ROUTE_NUMBER_LENGTH;
   // Checks if route only has letters without identifying numbers and
   // length doesn't fit in the tab view
   const hasNoShortName =
-    text && textIsText && /^([^0-9]*)$/.test(text) && text.length > 3;
+    filteredText &&
+    textFieldIsText &&
+    /^([^0-9]*)$/.test(filteredText) &&
+    filteredText.length > 3;
+
   const getColor = () => color || (props.isTransitLeg ? 'currentColor' : null);
 
   const getIcon = (
@@ -140,7 +168,7 @@ function RouteNumber(props, context) {
             )}
           </div>
         )}
-        {text && (
+        {filteredText && (
           <div
             className={cx(
               'vehicle-number-container-v'.concat(props.card ? '-map' : ''),
@@ -158,10 +186,10 @@ function RouteNumber(props, context) {
               )}
               style={{ color: !props.withBar && getColor() }}
             >
-              {props.text}
+              {filteredText}
             </span>
-            {textIsText && (
-              <span className="sr-only">{text?.toLowerCase()}</span>
+            {textFieldIsText && (
+              <span className="sr-only">{filteredText?.toLowerCase()}</span>
             )}
           </div>
         )}
@@ -222,6 +250,7 @@ RouteNumber.propTypes = {
   card: PropTypes.bool,
   appendClass: PropTypes.string,
   occupancyStatus: PropTypes.string,
+  isInItineraryList: PropTypes.bool,
 };
 
 RouteNumber.defaultProps = {
@@ -245,6 +274,7 @@ RouteNumber.defaultProps = {
   color: undefined,
   duration: undefined,
   occupancyStatus: undefined,
+  isInItineraryList: false,
 };
 
 RouteNumber.contextTypes = {

--- a/app/component/RouteNumberContainer.js
+++ b/app/component/RouteNumberContainer.js
@@ -25,7 +25,7 @@ const RouteNumberContainer = (
       color={route.color ? `#${route.color}` : null}
       mode={mode !== undefined ? mode : route.mode}
       text={getLegText(route, config, interliningWithRoute)}
-      isInItineraryList
+      shortenLongText
       occupancyStatus={occupancyStatus}
       {...props}
     />

--- a/app/component/RouteNumberContainer.js
+++ b/app/component/RouteNumberContainer.js
@@ -5,52 +5,26 @@ import { getRouteText } from '../util/legUtils';
 import RouteNumber from './RouteNumber';
 
 const RouteNumberContainer = (
-  {
-    alertSeverityLevel,
-    interliningWithRoute,
-    className,
-    route,
-    isCallAgency,
-    occupancyStatus,
-    mode,
-    ...props
-  },
+  { interliningWithRoute, route, mode, ...props },
   { config },
 ) =>
   route && (
     <RouteNumber
-      alertSeverityLevel={alertSeverityLevel}
-      className={className}
-      isCallAgency={isCallAgency}
       color={route.color ? `#${route.color}` : null}
       mode={mode !== undefined ? mode : route.mode}
       text={getRouteText(route, config, interliningWithRoute)}
-      shortenLongText
-      occupancyStatus={occupancyStatus}
       {...props}
     />
   );
 
 RouteNumberContainer.propTypes = {
-  alertSeverityLevel: PropTypes.string,
   route: routeShape.isRequired,
   interliningWithRoute: PropTypes.string,
-  isCallAgency: PropTypes.bool,
-  vertical: PropTypes.bool,
-  className: PropTypes.string,
-  fadeLong: PropTypes.bool,
-  occupancyStatus: PropTypes.string,
   mode: PropTypes.string,
 };
 
 RouteNumberContainer.defaultProps = {
   interliningWithRoute: undefined,
-  alertSeverityLevel: undefined,
-  isCallAgency: false,
-  vertical: false,
-  fadeLong: false,
-  className: '',
-  occupancyStatus: undefined,
   mode: undefined,
 };
 
@@ -58,5 +32,4 @@ RouteNumberContainer.contextTypes = {
   config: configShape.isRequired,
 };
 
-RouteNumberContainer.displayName = 'RouteNumberContainer';
 export default RouteNumberContainer;

--- a/app/component/RouteNumberContainer.js
+++ b/app/component/RouteNumberContainer.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { routeShape, configShape } from '../util/shapes';
-import { getLegText } from '../util/legUtils';
+import { getRouteText } from '../util/legUtils';
 import RouteNumber from './RouteNumber';
 
 const RouteNumberContainer = (
@@ -24,7 +24,7 @@ const RouteNumberContainer = (
       isCallAgency={isCallAgency}
       color={route.color ? `#${route.color}` : null}
       mode={mode !== undefined ? mode : route.mode}
-      text={getLegText(route, config, interliningWithRoute)}
+      text={getRouteText(route, config, interliningWithRoute)}
       shortenLongText
       occupancyStatus={occupancyStatus}
       {...props}

--- a/app/component/RouteNumberContainer.js
+++ b/app/component/RouteNumberContainer.js
@@ -24,12 +24,8 @@ const RouteNumberContainer = (
       isCallAgency={isCallAgency}
       color={route.color ? `#${route.color}` : null}
       mode={mode !== undefined ? mode : route.mode}
-      text={
-        config.disabledLegTextModes?.includes(route.mode) &&
-        className.includes('line')
-          ? ''
-          : getLegText(route, config, interliningWithRoute)
-      }
+      text={getLegText(route, config, interliningWithRoute)}
+      isInItineraryList
       occupancyStatus={occupancyStatus}
       {...props}
     />

--- a/app/component/map/ItineraryLine.js
+++ b/app/component/map/ItineraryLine.js
@@ -7,7 +7,7 @@ import { isBrowser } from '../../util/browser';
 import { getMiddleOf } from '../../util/geo-utils';
 import {
   getInterliningLegs,
-  getLegText,
+  getRouteText,
   isCallAgencyLeg,
 } from '../../util/legUtils';
 import { getRouteMode } from '../../util/modeUtils';
@@ -175,7 +175,7 @@ class ItineraryLine extends React.Component {
             />,
           );
         } else if (leg.transitLeg) {
-          const name = getLegText(
+          const name = getRouteText(
             leg.route,
             this.context.config,
             interliningWithRoute,

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -857,5 +857,5 @@ export default {
   ],
   navigation: false,
   sendAnalyticsCustomEventGoals: false,
-  shortenLongTextInItineraryListThreshold: 10,
+  shortenLongTextThreshold: 10, // for route number in itinerary summary
 };

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -857,4 +857,5 @@ export default {
   ],
   navigation: false,
   sendAnalyticsCustomEventGoals: false,
+  shortenLongTextInItineraryListThreshold: 10,
 };

--- a/app/configurations/config.kela.js
+++ b/app/configurations/config.kela.js
@@ -156,5 +156,4 @@ export default {
   showCO2InItinerarySummary: false,
   useAssembledGeoJsonZones: 'isOnByDefault',
   locationSearchTargetsFromOTP: [], // remove stop/station location search
-  shortenLongTextInItineraryListThreshold: 10,
 };

--- a/app/configurations/config.kela.js
+++ b/app/configurations/config.kela.js
@@ -156,4 +156,5 @@ export default {
   showCO2InItinerarySummary: false,
   useAssembledGeoJsonZones: 'isOnByDefault',
   locationSearchTargetsFromOTP: [], // remove stop/station location search
+  shortenLongTextInItineraryListThreshold: 10,
 };

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -403,7 +403,7 @@ export default {
     FERRY: { showNotification: true },
   },
 
-  disabledLegTextModes: ['FERRY'],
+  disabledLegTextModes: ['ferry'],
 
   // Include both bike and park and bike and public, if bike is enabled
   includePublicWithBikePlan: true,

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -144,7 +144,7 @@ function continueWithBicycle(leg1, leg2) {
   return isBicycle1 && isBicycle2 && !leg1.to.vehicleParking;
 }
 
-export function getLegText(route, config, interliningWithRoute) {
+export function getRouteText(route, config, interliningWithRoute) {
   const showAgency = get(config, 'agency.show', false);
   if (interliningWithRoute && interliningWithRoute !== route.shortName) {
     return `${route.shortName} / ${interliningWithRoute}`;


### PR DESCRIPTION
This adds a configurable text limit to the `RouteNumber`s in the itinerary list.

Notes:
- I refactored `disabledLegTextMode` from `RouteNumberContainer` to `RouteNumber` for readibility
- Too long itineraries in the itinerary list already get the `...` icon when they are too long
- This adds a configurable maximum for the text's of singular itineraries