### PR TITLE
Proper rerouting logic and misc improvements

### DIFF
--- a/app/component/itinerary/navigator/NaviCardContainer.js
+++ b/app/component/itinerary/navigator/NaviCardContainer.js
@@ -181,11 +181,10 @@ function NaviCardContainer(
       // handle initial focus when not tracking
       if (currentLeg) {
         focusToLeg(currentLeg);
-        destCountRef.current = 0;
       } else if (time < legTime(firstLeg.start)) {
         focusToLeg(firstLeg);
       } else {
-        focusToLeg(lastLeg);
+        focusToLeg(nextLeg || lastLeg);
       }
       focusRef.current = true;
     }

--- a/app/component/itinerary/navigator/NaviCardContainer.js
+++ b/app/component/itinerary/navigator/NaviCardContainer.js
@@ -98,7 +98,7 @@ function NaviCardContainer(
       time,
       currentLeg,
       position,
-      match.params.location.to,
+      match.params.to,
     );
     router.push(path);
   };

--- a/app/component/itinerary/navigator/NaviCardContainer.js
+++ b/app/component/itinerary/navigator/NaviCardContainer.js
@@ -97,6 +97,7 @@ function NaviCardContainer(
     const path = itinerarySearchPath(
       time,
       currentLeg,
+      nextLeg,
       position,
       match.params.to,
     );

--- a/app/component/itinerary/navigator/NaviCardContainer.js
+++ b/app/component/itinerary/navigator/NaviCardContainer.js
@@ -11,6 +11,7 @@ import {
   getAdditionalMessages,
   getItineraryAlerts,
   getTransitLegState,
+  itinerarySearchPath,
   LEGTYPE,
   DESTINATION_RADIUS,
 } from './NaviUtils';
@@ -92,6 +93,16 @@ function NaviCardContainer(
       config,
     );
 
+  const makeNewItinerarySearch = () => {
+    const path = itinerarySearchPath(
+      time,
+      currentLeg,
+      position,
+      match.params.location.to,
+    );
+    router.push(path);
+  };
+
   useEffect(() => {
     updateClient(getNaviTopics(), context);
   }, []);
@@ -116,8 +127,7 @@ function NaviCardContainer(
         origin,
         intl,
         messages,
-        match.params,
-        router,
+        makeNewItinerarySearch,
       ),
     );
 

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -337,9 +337,7 @@ export const getTransitLegState = (leg, intl, messages, time) => {
 export function itinerarySearchPath(time, leg, nextLeg, position, to) {
   let from;
   if (leg?.transitLeg) {
-    from = leg.intermediatePlaces.find(
-      p => legTime(p.arrival) > time + TRANSFER_SLACK,
-    );
+    from = leg.intermediatePlaces.find(p => legTime(p.arrival) > time + 60000);
     if (!from) {
       from = leg.to;
     }

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -280,7 +280,10 @@ export const getTransitLegState = (leg, intl, messages, time) => {
     const departure = leg.trip.stoptimesForDate[0];
     const departed =
       1000 * (departure.serviceDay + departure.scheduledDeparture);
-    if (time - departed < DISPLAY_MESSAGE_THRESHOLD) {
+    if (
+      time - departed < DISPLAY_MESSAGE_THRESHOLD &&
+      time + DISPLAY_MESSAGE_THRESHOLD > legTime(leg.start)
+    ) {
       // vehicle just departed, maybe no realtime yet
       severity = 'INFO';
     } else {

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -365,6 +365,10 @@ function withNewSearchBtn(children, searchCallback) {
   );
 }
 
+function alertId(alert) {
+  return `${alert.effectiveStartDate}-${alert.alertDescriptionText}`;
+}
+
 export const getItineraryAlerts = (
   legs,
   time,
@@ -377,11 +381,11 @@ export const getItineraryAlerts = (
   const alerts = legs.flatMap(leg => {
     return leg.alerts
       .filter(alert => {
-        const { first } = getFirstLastLegs(legs);
-        const startTime = legTime(first.start) / 1000;
-        if (messages.get(alert.id)?.closed) {
+        if (messages.get(alertId(alert))?.closed) {
           return false;
         }
+        const { first } = getFirstLastLegs(legs);
+        const startTime = legTime(first.start) / 1000;
         // show only alerts that are active when
         // the journey starts
         if (startTime < alert.effectiveStartDate) {
@@ -402,7 +406,7 @@ export const getItineraryAlerts = (
             <span className="header"> {alert.alertHeaderText}</span>
           </div>
         ),
-        id: `${alert.effectiveStartDate}-${alert.alertDescriptionText}`,
+        id: alertId(alert),
       }));
   });
 

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -330,6 +330,22 @@ export const getTransitLegState = (leg, intl, messages, time) => {
   return [{ severity, content, id: legId, expiresOn: legTime(start) }];
 };
 
+function withNewSearchBtn(router, to, children) {
+  return (
+    <div className="navi-alert-content">
+      {children}
+      <FormattedMessage id="navigation-abort-trip" />
+      <button
+        className="new-itinerary-search"
+        type="button"
+        onClick={() => router.push(getItineraryPagePath('POS', to))}
+      >
+        <FormattedMessage id="settings-dropdown-open-label" />
+      </button>
+    </div>
+  );
+}
+
 export const getItineraryAlerts = (
   legs,
   time,
@@ -372,20 +388,6 @@ export const getItineraryAlerts = (
       }));
   });
 
-  const withNewSearchBtn = children => (
-    <div className="navi-alert-content">
-      {children}
-      <FormattedMessage id="navigation-abort-trip" />
-      <button
-        className="new-itinerary-search"
-        type="button"
-        onClick={() => router.push(getItineraryPagePath('POS', location.to))}
-      >
-        <FormattedMessage id="settings-dropdown-open-label" />
-      </button>
-    </div>
-  );
-
   const canceled = legs.filter(
     leg => leg.realtimeState === 'CANCELED' && legTime(leg.start) > time,
   );
@@ -406,7 +408,7 @@ export const getItineraryAlerts = (
       // we want to show the show routes button only for the first canceled leg.
       const content =
         i === 0 ? (
-          withNewSearchBtn({ m })
+          withNewSearchBtn(router, { m }, location.to)
         ) : (
           <div className="navi-alert-content">{m}</div>
         );
@@ -435,6 +437,7 @@ export const getItineraryAlerts = (
         alerts.push({
           severity: prob.severity,
           content: withNewSearchBtn(
+            router,
             <FormattedMessage
               id="navigation-transfer-problem"
               values={{
@@ -442,6 +445,7 @@ export const getItineraryAlerts = (
                 route2: prob.toLeg.route.shortName,
               }}
             />,
+            location.to,
           ),
           id: transferId,
           hideClose: prob.severity === 'ALERT',

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -331,9 +331,9 @@ export const getTransitLegState = (leg, intl, messages, time) => {
   return [{ severity, content, id: legId, expiresOn: legTime(start) }];
 };
 
-export function itinerarySearchPath(time, leg, position, to) {
+export function itinerarySearchPath(time, leg, nextLeg, position, to) {
   let from;
-  if (leg.transitLeg) {
+  if (leg?.transitLeg) {
     from = leg.intermediatePlaces.find(
       p => legTime(p.arrival) > time + TRANSFER_SLACK,
     );
@@ -341,7 +341,7 @@ export function itinerarySearchPath(time, leg, position, to) {
       from = leg.to;
     }
   } else {
-    from = position || leg.to;
+    from = position || leg?.to || nextLeg?.from;
   }
   const location = { ...from };
   if (from.stop) {

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -344,10 +344,7 @@ export function itinerarySearchPath(time, leg, nextLeg, position, to) {
   } else {
     from = position || leg?.to || nextLeg?.from;
   }
-  const location = { ...from };
-  if (from.stop) {
-    location.gtfsId = from.stop.gtfsId;
-  }
+  const location = { ...from, ...from.stop };
 
   return getItineraryPagePath(locationToUri(location), to);
 }

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -349,7 +349,7 @@ export const getItineraryAlerts = (
       .filter(alert => {
         const { first } = getFirstLastLegs(legs);
         const startTime = legTime(first.start) / 1000;
-        if (messages.get(alert.id)) {
+        if (messages.get(alert.id)?.closed) {
           return false;
         }
         // show only alerts that are active when

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -330,7 +330,7 @@ export const getTransitLegState = (leg, intl, messages, time) => {
   return [{ severity, content, id: legId, expiresOn: legTime(start) }];
 };
 
-function withNewSearchBtn(router, to, children) {
+function withNewSearchBtn(router, children, to) {
   return (
     <div className="navi-alert-content">
       {children}

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -9,7 +9,7 @@ import { ExtendedRouteTypes } from '../../../constants';
 import { getItineraryPagePath } from '../../../util/path';
 import { locationToUri } from '../../../util/otpStrings';
 
-const TRANSFER_SLACK = 60000;
+const TRANSFER_SLACK = 600000;
 const DISPLAY_MESSAGE_THRESHOLD = 120 * 1000; // 2 minutes
 
 export const DESTINATION_RADIUS = 20; // meters
@@ -343,7 +343,10 @@ export function itinerarySearchPath(time, leg, position, to) {
   } else {
     from = position || leg.to;
   }
-  const location = from.stop || from.stop; // prefer stops
+  const location = { ...from };
+  if (from.stop) {
+    location.gtfsId = from.stop.gtfsId;
+  }
 
   return getItineraryPagePath(locationToUri(location), to);
 }

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -9,7 +9,7 @@ import { ExtendedRouteTypes } from '../../../constants';
 import { getItineraryPagePath } from '../../../util/path';
 import { locationToUri } from '../../../util/otpStrings';
 
-const TRANSFER_SLACK = 600000;
+const TRANSFER_SLACK = 60000;
 const DISPLAY_MESSAGE_THRESHOLD = 120 * 1000; // 2 minutes
 
 export const DESTINATION_RADIUS = 20; // meters
@@ -337,7 +337,9 @@ export const getTransitLegState = (leg, intl, messages, time) => {
 export function itinerarySearchPath(time, leg, nextLeg, position, to) {
   let from;
   if (leg?.transitLeg) {
-    from = leg.intermediatePlaces.find(p => legTime(p.arrival) > time + 60000);
+    from = leg.intermediatePlaces.find(
+      p => legTime(p.arrival) > time + TRANSFER_SLACK,
+    );
     if (!from) {
       from = leg.to;
     }

--- a/app/component/itinerary/navigator/hooks/useRealtimeLegs.js
+++ b/app/component/itinerary/navigator/hooks/useRealtimeLegs.js
@@ -92,12 +92,12 @@ function matchLegEnds(legs) {
 }
 
 function getLegsOfInterest(
-  initialLegs,
+  realTimeLegs,
   time,
   previousFinishedLeg,
   itineraryStarted,
 ) {
-  if (!initialLegs?.length) {
+  if (!realTimeLegs?.length) {
     return {
       firstLeg: undefined,
       lastLeg: undefined,
@@ -105,7 +105,7 @@ function getLegsOfInterest(
       nextLeg: undefined,
     };
   }
-  const legs = initialLegs.reduce((acc, curr, i, arr) => {
+  const legs = realTimeLegs.reduce((acc, curr, i, arr) => {
     acc.push(curr);
     const next = arr[i + 1];
 
@@ -146,7 +146,7 @@ function getLegsOfInterest(
     lastLeg: legs[legs.length - 1],
     previousLeg,
     currentLeg,
-    nextLeg: initialLegs.find(({ start }) => legTime(start) >= nextStart),
+    nextLeg: realTimeLegs.find(({ start }) => legTime(start) >= nextStart),
   };
 }
 

--- a/app/component/itinerary/navigator/navigator.scss
+++ b/app/component/itinerary/navigator/navigator.scss
@@ -457,23 +457,16 @@ $fixed-width-padding: 16px;
       }
     }
 
-    .alt-btn {
-      display: flex;
-      flex-direction: column;
-      width: 100%;
+    .new-itinerary-search {
+      padding: var(--space-s, 16px) var(--space-xs, 8px) var(--space-s, 16px)
+        var(--space-s, 16px);
+      background: #0074bf;
+      color: #fff;
+      border-radius: 999px; // var(--radius-radius-medium, 8px);
+      margin-top: var(--space-xxs);
 
-      .show-options {
-        padding: var(--space-s, 16px) var(--space-xs, 8px) var(--space-s, 16px)
-          var(--space-s, 16px);
-        background: #0074bf;
-        color: #fff;
-        border-radius: 999px; // var(--radius-radius-medium, 8px);
-        margin-top: var(--space-xxs);
-
-        /* box-shadow-card-s-strong */
-        box-shadow: 0 2px 4px 0
-          var(--color-shadow-strong, rgba(51, 51, 51, 0.2));
-      }
+      /* box-shadow-card-s-strong */
+      box-shadow: 0 2px 4px 0 var(--color-shadow-strong, rgba(51, 51, 51, 0.2));
     }
 
     &.slide-out-right {

--- a/app/component/itinerary/queries/LegQuery.js
+++ b/app/component/itinerary/queries/LegQuery.js
@@ -30,6 +30,12 @@ const legQuery = graphql`
             time
           }
         }
+        stop {
+          gtfsId
+          lat
+          lon
+          name
+        }
       }
       to {
         vehicleRentalStation {

--- a/app/util/otpStrings.js
+++ b/app/util/otpStrings.js
@@ -52,7 +52,7 @@ export function locationToUri(location) {
   if (!location.lat) {
     return '-';
   }
-  let address = location.address || '';
+  let address = location.address || location.name || '';
   if (location.gtfsId) {
     address = `${address}**${location.gtfsId}`;
   }


### PR DESCRIPTION
New itinerary search works now as follows:
- During transit leg, search from next stop after a decent threshold 
- During walking, search from user location if available, otherwise from the leg end
- During waiting/before journey start, search from next leg start
- Use actual geolocation, not 'POS' path, which seems to be slow/unreliable when geolocation is already enabled  

Other fixes:
- Alert generation and rendering code refactored
- Alert content now updates by newer versions
- Alerts can be closed and they won't reappear
- Static schedule warning is not shown before 2 minutes to first departure
- Wait leg focusing works correctly
- Semantic fix: current leg is not set before itinerary starts 
