### PR TITLE
DT-6714 fix missing geolocation address 

### DIFF
--- a/app/action/PositionActions.js
+++ b/app/action/PositionActions.js
@@ -47,6 +47,7 @@ const debouncedReverseGeocoding = debounce(reverseGeocodeAddress, 10000, {
 });
 
 function geoCallback(actionContext, pos) {
+  actionContext.dispatch('StartReverseGeocoding');
   actionContext.dispatch('GeolocationFound', {
     lat: pos.coords.latitude,
     lon: pos.coords.longitude,


### PR DESCRIPTION
StartReverseGeocoding status for PositionStore should be dispatched early, otherwise some components render before the address has been found.