### PR TITLE
DT-5921 - Add direct mode and other parameters to car transit requests to enable filtering

### DIFF
--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -64,7 +64,7 @@ import {
   isEqualItineraries,
   isStoredItineraryRelevant,
   mergeBikeTransitPlans,
-  mergeCarDirectAndTransitPlans,
+  parseCarTransitPlan,
   mergeScooterTransitPlan,
   quitIteration,
   reportError,
@@ -353,7 +353,11 @@ export default function ItineraryPage(props, context) {
     altState[1]({ loading: LOADSTATE.LOADING });
     const planParams = getPlanParams(config, match, planType);
     try {
-      const plan = await iterateQuery(planParams);
+      let reps;
+      if (planType === PLANTYPE.CARTRANSIT) {
+        reps = 1;
+      }
+      const plan = await iterateQuery(planParams, reps);
       altState[1]({ plan, loading: LOADSTATE.DONE });
     } catch (error) {
       altState[1]({ plan: {}, loading: LOADSTATE.DONE });
@@ -896,18 +900,14 @@ export default function ItineraryPage(props, context) {
   useEffect(() => {
     const settings = getSettings(config);
     if (
-      altStates[PLANTYPE.CAR][0].loading === LOADSTATE.DONE &&
       altStates[PLANTYPE.CARTRANSIT][0].loading === LOADSTATE.DONE &&
       settings.includeCarSuggestions &&
       config.carBoardingModes !== undefined
     ) {
-      const plan = mergeCarDirectAndTransitPlans(
-        altStates[PLANTYPE.CAR][0].plan,
-        altStates[PLANTYPE.CARTRANSIT][0].plan,
-      );
+      const plan = parseCarTransitPlan(altStates[PLANTYPE.CARTRANSIT][0].plan);
       setCarPublicState({ plan });
     }
-  }, [altStates[PLANTYPE.CAR][0].plan, altStates[PLANTYPE.CARTRANSIT][0].plan]);
+  }, [altStates[PLANTYPE.CARTRANSIT][0].plan]);
 
   // merge the main plan and the scooter plan into one
   useEffect(() => {

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -468,17 +468,30 @@ export function mergeBikeTransitPlans(bikeParkPlan, bikeTransitPlan) {
 }
 
 /**
- * Merge the direct car plan with the car transit plan.
+ * Parse the car transit plan which possibly includes a direct route.
  */
-export function mergeCarDirectAndTransitPlans(carDirectPlan, carTransitPlan) {
-  const carDirectPlanEdges = carDirectPlan?.edges || [];
-  const carPublicEdges = carTransitPlan?.edges || [];
+export function parseCarTransitPlan(carTransitPlan) {
+  let carEdges = carTransitPlan?.edges || [];
+  let carDirectItineraryCount = 0;
+  let carPublicItineraryCount = carEdges.length;
+  const maxCarPublicCount = 5;
+
+  if (carEdges.length > 0) {
+    // If the first route is a direct route.
+    if (carEdges?.[0]?.node.legs.every(leg => !leg.transitLeg)) {
+      carDirectItineraryCount = 1;
+      carPublicItineraryCount -= 1;
+    } else if (carEdges.length > maxCarPublicCount) {
+      carPublicItineraryCount = maxCarPublicCount;
+      carEdges = carEdges.slice(0, maxCarPublicCount);
+    }
+  }
 
   return {
     searchDateTime: carTransitPlan.searchDateTime,
-    edges: [...carDirectPlanEdges, ...carPublicEdges],
-    carDirectItineraryCount: carDirectPlanEdges.length,
-    carPublicItineraryCount: carPublicEdges.length,
+    edges: carEdges,
+    carDirectItineraryCount,
+    carPublicItineraryCount,
   };
 }
 

--- a/app/component/itinerary/PlanConnection.js
+++ b/app/component/itinerary/PlanConnection.js
@@ -8,6 +8,7 @@ const planConnection = graphql`
     $datetime: PlanDateTimeInput!
     $walkReluctance: Reluctance
     $walkBoardCost: Cost
+    $carReluctance: Reluctance
     $minTransferTime: Duration
     $walkSpeed: Speed
     $wheelchair: Boolean
@@ -42,6 +43,7 @@ const planConnection = graphql`
             reluctance: $walkReluctance
             boardCost: $walkBoardCost
           }
+          car: { reluctance: $carReluctance }
         }
         transit: {
           transfer: { cost: $transferPenalty, slack: $minTransferTime }

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -323,6 +323,8 @@ export function getPlanParams(
   let egress = access;
   let transfer = ['WALK'];
   let direct = null;
+  let numItineraries = directOnly ? 1 : 5;
+  let carReluctance = null;
 
   let noIterationsForShortTrips = false;
 
@@ -340,10 +342,14 @@ export function getPlanParams(
       noIterationsForShortTrips = shortTrip;
       break;
     case PLANTYPE.CARTRANSIT:
+      // For cars the direct mode is included to allow OTP to filter out unwanted routes.
+      direct = ['CAR'];
       access = ['CAR'];
       egress = ['CAR'];
       transfer = ['CAR'];
-      transitOnly = true;
+      transitOnly = false;
+      numItineraries = 6;
+      carReluctance = 1.75;
       // This is done to enable more cache hits. New cache entries are generated for different speeds otherwise.
       settings.walkSpeed = null;
       settings.bikeSpeed = null;
@@ -406,7 +412,6 @@ export function getPlanParams(
   const datetime = useLatestArrival
     ? { latestArrival: timeStr }
     : { earliestDeparture: timeStr };
-  const numItineraries = directOnly ? 1 : 5;
 
   return {
     ...settings,
@@ -428,5 +433,6 @@ export function getPlanParams(
     planType,
     noIterationsForShortTrips,
     via,
+    carReluctance,
   };
 }

--- a/docs/GraphQL.md
+++ b/docs/GraphQL.md
@@ -10,4 +10,4 @@
 
   When copying from a local OTP clone, usually something like this works:
 
-  `cd build; SCHEMA_SRC=~/OpenTripPlanner/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls node generate-schema.js`
+  `cd build; SCHEMA_SRC=~/OpenTripPlanner/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls node generate-schema.js`


### PR DESCRIPTION
Notes:
- There is a bug in OTP which makes direct-compared-to-transit filtering not work when iterating more than 1 time, therefore only 1 iteration is done
- Setting the car reluctance for car transit requests is needed to get good routing results
- I fixed some documentation