### PR TITLE
DT-5933 Restore only selected settings

### DIFF
--- a/app/component/itinerary/customizesearch/RestoreDefaultSettingSection.js
+++ b/app/component/itinerary/customizesearch/RestoreDefaultSettingSection.js
@@ -10,11 +10,22 @@ import {
   hasCustomizedSettings,
 } from '../../../util/planParamUtil';
 import { configShape } from '../../../util/shapes';
+import { getCustomizedSettings } from '../../../store/localStorage';
 
 const RestoreDefaultSettingSection = ({ config }, { executeAction, intl }) => {
   const restoreDefaultSettings = () => {
+    const customizedSettings = getCustomizedSettings(config);
+    const defaultSettings = getDefaultSettings(config);
+    const restoredSettings = Object.keys(customizedSettings).reduce(
+      (acc, setting) => ({
+        ...acc,
+        [setting]: defaultSettings[setting],
+      }),
+      {},
+    );
+
     executeAction(saveRoutingSettings, {
-      ...getDefaultSettings(config),
+      ...restoredSettings,
     });
   };
   const userHasCustomizedSettings = hasCustomizedSettings(config);


### PR DESCRIPTION
## Proposed Changes

  - Changed the logic to only restore settings which the user has actually changed, because restoring to configured default settings saved settings for user which are not selectable or visible to user. This could be a problem down the line when defaults might be changed but users could still have the old settings saved locally without their knowledge.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
