### PR TITLE
DT- 6737- Add screen reader instructions from metro entrances

### DIFF
--- a/app/component/itinerary/WalkLeg.js
+++ b/app/component/itinerary/WalkLeg.js
@@ -244,8 +244,23 @@ function WalkLeg(
 
         <div className="itinerary-leg-action">
           {previousLeg?.mode === 'SUBWAY' && (
-            <div className="subway-entrance-info-container">
-              <div className="subway-entrance-info-text">
+            <div
+              className="subway-entrance-info-container"
+              aria-labelledby="subway-entrance-label"
+            >
+              <span id="subway-entrance-label" className="sr-only">
+                <FormattedMessage
+                  id={
+                    entranceAccessible === 'POSSIBLE'
+                      ? 'subway-exit.sr-description.accessible'
+                      : 'subway-exit.sr-description'
+                  }
+                  defaultMessage="Exit {entranceName}"
+                  values={{ entranceName: entranceName || '' }}
+                />
+              </span>
+
+              <div className="subway-entrance-info-text" aria-hidden="true">
                 <FormattedMessage id="station-exit" defaultMessage="Exit" />
               </div>
               <Icon
@@ -286,8 +301,22 @@ function WalkLeg(
             />
           </div>
           {nextLeg?.mode === 'SUBWAY' && (
-            <div className="subway-entrance-info-container">
-              <div className="subway-entrance-info-text">
+            <div
+              className="subway-entrance-info-container"
+              aria-labelledby="subway-entrance-label"
+            >
+              <span id="subway-entrance-label" className="sr-only">
+                <FormattedMessage
+                  id={
+                    entranceAccessible === 'POSSIBLE'
+                      ? 'subway-entrance.sr-description.accessible'
+                      : 'subway-entrance.sr-description'
+                  }
+                  defaultMessage="Exit {entranceName}"
+                  values={{ entranceName: entranceName || '' }}
+                />
+              </span>
+              <div className="subway-entrance-info-text" aria-hidden="true">
                 <FormattedMessage
                   id="station-entrance"
                   defaultMessage="Entrance"

--- a/app/component/itinerary/itinerary.scss
+++ b/app/component/itinerary/itinerary.scss
@@ -2113,7 +2113,8 @@ $itinerary-tab-switch-height: 48px;
       border-top: 1px solid #ddd;
       padding: 1.2em 0;
       margin-bottom: 1em;
-      height: 60px;
+      min-height: 60px;
+      height: auto;
       font-size: 0.9375rem;
 
       @extend .itinerary-leg-text-gray;

--- a/app/translations.js
+++ b/app/translations.js
@@ -1685,6 +1685,12 @@ const translations = {
     // eslint-disable-next-line sort-keys
     street: 'Street',
     subway: 'Metro',
+    'subway-entrance.sr-description': 'Metro station entrance {entranceName}',
+    'subway-entrance.sr-description.accessible':
+      'Metro station entrance {entranceName}, accessible',
+    'subway-exit.sr-description': 'Metro station exit {entranceName}}',
+    'subway-exit.sr-description.accessible':
+      'Metro station exit {entranceName}, accessible',
     'subway-with-route-number': 'Metro {routeNumber} {headSign}',
     'summary-page.description': '{from} - {to}',
     'summary-page.row-label': 'Itinerary suggestion {number}',
@@ -2981,6 +2987,12 @@ const translations = {
     // eslint-disable-next-line sort-keys
     street: 'Katu',
     subway: 'Metro',
+    'subway-entrance.sr-description': 'Metroaseman sisäänkäynti {entranceName}',
+    'subway-entrance.sr-description.accessible':
+      'Metroaseman sisäänkäynti {entranceName}, esteetön',
+    'subway-exit.sr-description': 'Metroaseman uloskäynti {entranceName}',
+    'subway-exit.sr-description.accessible':
+      'Metroaseman uloskäynti {entranceName}, esteetön',
     'subway-with-route-number': 'Metro {routeNumber} {headSign}',
     'summary-page.description': '{from} - {to}',
     'summary-page.row-label': 'Reittiehdotus {number}',
@@ -5935,6 +5947,12 @@ const translations = {
     // eslint-disable-next-line sort-keys
     street: 'Gata',
     subway: 'Metro',
+    'subway-entrance.sr-description': 'Metro stationens ingång {entranceName}',
+    'subway-entrance.sr-description.accessible':
+      'Metro stationens ingång {entranceName}, tillgänglig',
+    'subway-exit.sr-description': 'Metro stationens utgång {entranceName}',
+    'subway-exit.sr-description.accessible':
+      'Metro stationens utgång {entranceName}, tillgänglig',
     'subway-with-route-number': 'Metro {routeNumber} {headSign}',
     'summary-page.description': '{from} - {to}',
     'summary-page.row-label': 'Ruttförslag {number}',


### PR DESCRIPTION
## Proposed Changes

  * Screen reader info for metro entrances
  * Fix over lapping text when zooming (firefox, zoom 200% with zoom text only option)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
