### PR TITLE
Use slightly faster default walk speed for HSL

### DIFF
--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -107,6 +107,19 @@ export default {
     bucketSize: 100,
   },
 
+  defaultSettings: {
+    walkSpeed: 1.28,
+  },
+
+  /**
+   * These are used for dropdown selection of values to override the default
+   * settings. This means that values ought to be relative to the current default.
+   * If not, the selection may not make any sense.
+   */
+  defaultOptions: {
+    walkSpeed: [0.69, 0.97, 1.28, 1.67, 2.22],
+  },
+
   omitNonPickups: true,
 
   parkAndRide: {


### PR DESCRIPTION
## Proposed Changes

  - Default speed has been changed from 1.2 to 1.28 m/s for HSL

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
