### PR TITLE
DT-6586 Improve force start UX

### DIFF
--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -1238,6 +1238,7 @@ export default function ItineraryPage(props, context) {
             mapLayerRef={mapLayerRef}
             isNavigatorIntroDismissed={isNavigatorIntroDismissed}
             updateLegs={updateStoredItinerary}
+            forceStartAt={storedItinerary?.params?.forceStartAt || undefined}
           />
         </>
       );

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -1238,7 +1238,7 @@ export default function ItineraryPage(props, context) {
             mapLayerRef={mapLayerRef}
             isNavigatorIntroDismissed={isNavigatorIntroDismissed}
             updateLegs={updateStoredItinerary}
-            forceStartAt={storedItinerary?.params?.forceStartAt || undefined}
+            forceStartAt={storedItinerary?.params?.forceStartAt}
           />
         </>
       );

--- a/app/component/itinerary/navigator/NaviCardContainer.js
+++ b/app/component/itinerary/navigator/NaviCardContainer.js
@@ -3,11 +3,7 @@ import { matchShape, routerShape } from 'found';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import { intlShape } from 'react-intl';
-import {
-  isAnyLegPropertyIdentical,
-  legTime,
-  legTimeStr,
-} from '../../../util/legUtils';
+import { isAnyLegPropertyIdentical, legTime } from '../../../util/legUtils';
 import { configShape, legShape } from '../../../util/shapes';
 import { getTopics, updateClient } from '../ItineraryPageUtils';
 import NaviCard from './NaviCard';
@@ -257,7 +253,6 @@ function NaviCardContainer(
         leg={l}
         nextLeg={nextLeg}
         legType={legType}
-        startTime={legTimeStr(firstLeg.start)}
         time={time}
         position={position}
         tailLength={tailLength}

--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -27,6 +27,7 @@ function NaviContainer(
     mapRef,
     mapLayerRef,
     updateLegs,
+    forceStartAt,
   },
   { executeAction, getStore, router },
 ) {
@@ -51,7 +52,13 @@ function NaviContainer(
     currentLeg,
     nextLeg,
     startItinerary,
-  } = useRealtimeLegs(relayEnvironment, legs, position, updateLegs);
+  } = useRealtimeLegs(
+    relayEnvironment,
+    legs,
+    position,
+    updateLegs,
+    forceStartAt,
+  );
 
   useEffect(() => {
     mapRef?.enableMapTracking(); // try always, shows annoying notifier
@@ -135,6 +142,7 @@ NaviContainer.propTypes = {
   mapLayerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
     .isRequired,
   updateLegs: PropTypes.func.isRequired,
+  forceStartAt: PropTypes.number,
 };
 
 NaviContainer.contextTypes = {
@@ -146,6 +154,7 @@ NaviContainer.contextTypes = {
 NaviContainer.defaultProps = {
   mapRef: undefined,
   isNavigatorIntroDismissed: false,
+  forceStartAt: undefined,
 };
 
 const connectedComponent = connectToStores(

--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -54,6 +54,7 @@ function NaviContainer(
     currentLeg,
     nextLeg,
     startItinerary,
+    loading,
   } = useRealtimeLegs(
     relayEnvironment,
     legs,
@@ -84,7 +85,7 @@ function NaviContainer(
     prevPos.current = position;
   }, [time]);
 
-  if (!realTimeLegs?.length) {
+  if (loading || !realTimeLegs?.length) {
     return null;
   }
 

--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -2,20 +2,22 @@ import connectToStores from 'fluxible-addons-react/connectToStores';
 import { routerShape } from 'found';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
-import { legTime } from '../../../util/legUtils';
-import { legShape, relayShape } from '../../../util/shapes';
 import {
   startLocationWatch,
   stopLocationWatch,
 } from '../../../action/PositionActions';
+import { legTime, legTimeStr } from '../../../util/legUtils';
+import { legShape, relayShape } from '../../../util/shapes';
+import { useRealtimeLegs } from './hooks/useRealtimeLegs';
 import NaviBottom from './NaviBottom';
 import NaviCardContainer from './NaviCardContainer';
-import { useRealtimeLegs } from './hooks/useRealtimeLegs';
 import NavigatorOutroModal from './navigatoroutro/NavigatorOutroModal';
+import NaviStarter from './NaviStarter';
 import { DESTINATION_RADIUS, summaryString } from './NaviUtils';
 
 const ADDITIONAL_ARRIVAL_TIME = 60000; // 60 seconds in ms
 const LEGLOG = true;
+const TOPBAR_PADDING = 8; // pixels
 
 function NaviContainer(
   {
@@ -99,23 +101,35 @@ function NaviContainer(
     console.log(...summaryString(realTimeLegs, time, previousLeg, currentLeg, nextLeg));
   }
 
+  const containerTopPosition =
+    mapLayerRef.current.getBoundingClientRect().top + TOPBAR_PADDING;
+
+  const isPastStart = time > legTime(firstLeg.start);
+
   return (
     <>
-      <NaviCardContainer
-        legs={realTimeLegs}
-        focusToLeg={position ? null : focusToLeg}
-        time={time}
-        position={position}
-        mapLayerRef={mapLayerRef}
-        tailLength={tailLength}
-        currentLeg={time > arrivalTime ? previousLeg : currentLeg}
-        nextLeg={nextLeg}
-        firstLeg={firstLeg}
-        lastLeg={lastLeg}
-        isJourneyCompleted={isJourneyCompleted}
-        previousLeg={previousLeg}
+      <NaviStarter
+        containerTopPosition={containerTopPosition}
+        time={legTimeStr(firstLeg.start)}
         startItinerary={startItinerary}
+        isPastStart={isPastStart}
       />
+      {isPastStart && (
+        <NaviCardContainer
+          legs={realTimeLegs}
+          focusToLeg={position ? null : focusToLeg}
+          time={time}
+          position={position}
+          tailLength={tailLength}
+          currentLeg={time > arrivalTime ? previousLeg : currentLeg}
+          nextLeg={nextLeg}
+          firstLeg={firstLeg}
+          lastLeg={lastLeg}
+          isJourneyCompleted={isJourneyCompleted}
+          previousLeg={previousLeg}
+          containerTopPosition={containerTopPosition}
+        />
+      )}
       {isJourneyCompleted && isNavigatorIntroDismissed && (
         <NavigatorOutroModal
           destination={lastLeg.to.name}

--- a/app/component/itinerary/navigator/NaviStarter.js
+++ b/app/component/itinerary/navigator/NaviStarter.js
@@ -1,18 +1,40 @@
 import Button from '@hsl-fi/button';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
 import { configShape } from '../../../util/shapes';
 import Icon from '../../Icon';
 import { useLogo } from './hooks/useLogo';
 
-const NaviStarter = ({ time, startItinerary }, { config, intl }) => {
+const NaviStarter = (
+  { time, startItinerary, containerTopPosition, isPastStart },
+  { config, intl },
+) => {
   const { logo } = useLogo(config.trafficLightGraphic);
+  const [isVisible, setIsVisible] = useState(!isPastStart);
+  const [isDismissed, setIsDismissed] = useState(false);
 
-  const handleClick = () => startItinerary(Date.now());
+  useEffect(() => {
+    setIsDismissed(isPastStart);
+  }, [isPastStart]);
+
+  const handleClick = () => setIsDismissed(true);
+
+  const handleAnimationEnd = () => {
+    setIsVisible(false);
+    startItinerary(Date.now());
+  };
+
+  if (!isVisible) {
+    return null;
+  }
 
   return (
-    <div className="navi-initializer-container">
+    <div
+      className={`navi-initializer-container ${isDismissed && 'slide-out'}`}
+      onAnimationEnd={handleAnimationEnd}
+      style={{ top: containerTopPosition }}
+    >
       <div className="navi-initializer-card">
         {logo ? (
           <img src={logo} alt="navigator logo" />
@@ -37,6 +59,13 @@ const NaviStarter = ({ time, startItinerary }, { config, intl }) => {
 NaviStarter.propTypes = {
   time: PropTypes.string.isRequired,
   startItinerary: PropTypes.func.isRequired,
+  containerTopPosition: PropTypes.number,
+  isPastStart: PropTypes.bool,
+};
+
+NaviStarter.defaultProps = {
+  containerTopPosition: 0,
+  isPastStart: true,
 };
 
 NaviStarter.contextTypes = {

--- a/app/component/itinerary/navigator/hooks/useRealtimeLegs.js
+++ b/app/component/itinerary/navigator/hooks/useRealtimeLegs.js
@@ -159,6 +159,7 @@ const useRealtimeLegs = (
   const [{ origin, time, realTimeLegs }, setTimeAndRealTimeLegs] = useState(
     () => getInitialState(initialLegs),
   );
+  const [loading, setLoading] = useState(true);
 
   const queryAndMapRealtimeLegs = useCallback(
     async (legs, now) => {
@@ -274,6 +275,8 @@ const useRealtimeLegs = (
       startItinerary(forceStartAt);
     }
 
+    setLoading(false);
+
     return () => clearInterval(interval);
   }, []);
 
@@ -295,6 +298,7 @@ const useRealtimeLegs = (
     currentLeg,
     nextLeg,
     startItinerary,
+    loading,
   };
 };
 

--- a/app/component/itinerary/navigator/hooks/useRealtimeLegs.js
+++ b/app/component/itinerary/navigator/hooks/useRealtimeLegs.js
@@ -3,6 +3,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import polyUtil from 'polyline-encoded';
 import { useCallback, useEffect, useState } from 'react';
 import { fetchQuery } from 'react-relay';
+import { updateLatestNavigatorItineraryParams } from '../../../../store/localStorage';
 import { GeodeticToEcef, GeodeticToEnu } from '../../../../util/geo-utils';
 import { legTime } from '../../../../util/legUtils';
 import { epochToIso } from '../../../../util/timeUtils';
@@ -153,6 +154,7 @@ const useRealtimeLegs = (
   initialLegs,
   position,
   updateLegs,
+  forceStartAt,
 ) => {
   const [{ origin, time, realTimeLegs }, setTimeAndRealTimeLegs] = useState(
     () => getInitialState(initialLegs),
@@ -257,6 +259,7 @@ const useRealtimeLegs = (
           realTimeLegs: prev.realTimeLegs,
         };
       });
+      updateLatestNavigatorItineraryParams({ forceStartAt: startTimeInMS });
     }
   };
 
@@ -266,6 +269,10 @@ const useRealtimeLegs = (
     const interval = setInterval(() => {
       fetchAndSetRealtimeLegs();
     }, 10000);
+
+    if (forceStartAt) {
+      startItinerary(forceStartAt);
+    }
 
     return () => clearInterval(interval);
   }, []);

--- a/app/component/itinerary/navigator/navigator.scss
+++ b/app/component/itinerary/navigator/navigator.scss
@@ -437,12 +437,19 @@
 }
 
 .navi-initializer-container {
+  position: fixed;
+  width: 100%;
+  padding: 0 var(--space-s);
   display: flex;
   flex-direction: column;
   gap: var(--space-xxs);
   font-weight: 325;
   font-size: 14px;
   line-height: 21px;
+
+  &.slide-out {
+    animation: slideUpToTop 1s ease-in-out forwards;
+  }
 
   .navi-initializer-card {
     display: flex;

--- a/app/store/localStorage.js
+++ b/app/store/localStorage.js
@@ -300,3 +300,11 @@ export const getLatestNavigatorItinerary = () => {
 export const clearLatestNavigatorItinerary = () => {
   setItem('latestNavigatorItinerary', {});
 };
+
+export const updateLatestNavigatorItineraryParams = valueObj => {
+  const itinerary = getItemAsJson('latestNavigatorItinerary', '{}');
+  setItem('latestNavigatorItinerary', {
+    itinerary: itinerary.itinerary,
+    params: { ...itinerary.params, ...valueObj },
+  });
+};


### PR DESCRIPTION
## Proposed Changes
- Refactored `NaviStarter` higher in hierarchy
  - It isn't a leg card so it shouldn't be under `NaviCardContainer`
  - Less prop drilling
  - Significant reduction in its render condition complexity
- Refactored `NaviStarter` to be self-responsible on its visibility
  - This was easier to achieve inside the component and clutters `NaviContainer` less
 - Store information when an itinerary was force started along the itinerary's local storage object
 - Added simple `loading` flag in `useRealTimeLegs` hook to let its consumer(s) know whether all relevant data is available after initialization
   - Without the flag a force started itinerary is initially rendered with no current leg causing incorrect animation sequence to be fired.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
