### PR TITLE
DT-6772 fix itinerary sorting

### DIFF
--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -73,6 +73,7 @@ import {
   settingsLimitRouting,
   stopClient,
   updateClient,
+  getSortedEdges,
 } from './ItineraryPageUtils';
 import ItineraryTabs from './ItineraryTabs';
 import planConnection from './PlanConnection';
@@ -491,7 +492,7 @@ export default function ItineraryPage(props, context) {
       setState({ ...state, loadingMore: undefined });
       return;
     }
-    const { edges } = plan;
+    const edges = getSortedEdges(plan.edges, arriveBy);
     if (edges.length === 0) {
       const newState = arriveBy
         ? { topNote: 'no-more-route-msg' }
@@ -579,7 +580,7 @@ export default function ItineraryPage(props, context) {
       setState({ ...state, loadingMore: undefined });
       return;
     }
-    const { edges } = plan;
+    const edges = getSortedEdges(plan.edges, arriveBy);
     if (edges.length === 0) {
       const newState = arriveBy
         ? { bottomNote: 'no-more-route-msg' }
@@ -932,6 +933,7 @@ export default function ItineraryPage(props, context) {
         scooterState.plan,
         state.plan,
         config.vehicleRental.allowDirectScooterJourneys,
+        match.location.query.arriveBy,
       );
       setCombinedState({ plan, loading: LOADSTATE.DONE });
       resetItineraryPageSelection();

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -495,6 +495,20 @@ export function parseCarTransitPlan(carTransitPlan) {
   };
 }
 
+export function getSortedEdges(edges, arriveBy) {
+  const sortedEdges = [...edges];
+  sortedEdges.sort((a, b) => {
+    if (a.node.end === b.node.end) {
+      return 0;
+    }
+    if (arriveBy) {
+      return b.node.end > a.node.end ? 1 : -1;
+    }
+    return a.node.end > b.node.end ? 1 : -1;
+  });
+  return sortedEdges;
+}
+
 /**
  * Combine a scooter edge with the main transit edges.
  */
@@ -502,6 +516,7 @@ export function mergeScooterTransitPlan(
   scooterPlan,
   transitPlan,
   allowDirectScooterJourneys,
+  arriveBy,
 ) {
   const transitPlanEdges = transitPlan.edges || [];
   const scooterTransitEdges = scooterEdges(
@@ -521,22 +536,21 @@ export function mergeScooterTransitPlan(
   }
 
   return {
-    edges: [
-      ...scooterTransitEdges.slice(0, 1),
-      ...transitPlanEdges.slice(0, maxTransitEdges),
-    ]
-      .sort((a, b) => {
-        return a.node.end > b.node.end;
-      })
-      .map(edge => {
-        return {
-          ...edge,
-          node: {
-            ...edge.node,
-            legs: compressLegs(edge.node.legs),
-          },
-        };
-      }),
+    edges: getSortedEdges(
+      [
+        ...scooterTransitEdges.slice(0, 1),
+        ...transitPlanEdges.slice(0, maxTransitEdges),
+      ],
+      arriveBy,
+    ).map(edge => {
+      return {
+        ...edge,
+        node: {
+          ...edge.node,
+          legs: compressLegs(edge.node.legs),
+        },
+      };
+    }),
   };
 }
 


### PR DESCRIPTION
## Proposed Changes

  - Sort didn't take arriveBy into account when merging results.
  - Fixed the sorting function use (sort function must return 1, 0 or -1). Firefox works even when the function is incorrectly used but chrome does not. 
  - Added sorting to earlier and later itineraries to ensure correct order even if otp blips.
  - Order may still be incorrect between result groups as otp may return results that would belong in a previous result group.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
