### PR TITLE
DT-6586 Force start adjustments, bump arrival time buffer

### DIFF
--- a/app/component/itinerary/navigator/NaviCardContainer.js
+++ b/app/component/itinerary/navigator/NaviCardContainer.js
@@ -34,8 +34,12 @@ const getLegType = (
   interlineWithPreviousLeg,
 ) => {
   let legType;
-  if (!firstLeg.forceStart && time < legTime(firstLeg.start)) {
-    legType = LEGTYPE.PENDING;
+  if (time < legTime(firstLeg.start)) {
+    if (!firstLeg.forceStart) {
+      legType = LEGTYPE.PENDING;
+    } else {
+      legType = LEGTYPE.WAIT;
+    }
   } else if (leg) {
     if (!leg.transitLeg) {
       if (countAtLegEnd >= COUNT_AT_LEG_END) {

--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -19,6 +19,7 @@ import { addAnalyticsEvent } from '../../../util/analyticsUtils';
 const ADDITIONAL_ARRIVAL_TIME = 300000; // 5 min in ms
 const LEGLOG = true;
 const TOPBAR_PADDING = 8; // pixels
+const START_BUFFER = 120000; // 2 min in ms
 
 function NaviContainer(
   {
@@ -85,6 +86,10 @@ function NaviContainer(
       }
     }
     prevPos.current = position;
+
+    if (time > legTime(firstLeg.start) - START_BUFFER) {
+      startItinerary(Date.now());
+    }
   }, [time]);
 
   if (loading || !realTimeLegs?.length) {
@@ -101,7 +106,9 @@ function NaviContainer(
 
   if (LEGLOG) {
     // eslint-disable-next-line
-    console.log(...summaryString(realTimeLegs, time, previousLeg, currentLeg, nextLeg));
+    console.log(
+      ...summaryString(realTimeLegs, time, previousLeg, currentLeg, nextLeg),
+    );
   }
 
   const containerTopPosition =

--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -19,7 +19,6 @@ import { addAnalyticsEvent } from '../../../util/analyticsUtils';
 const ADDITIONAL_ARRIVAL_TIME = 300000; // 5 min in ms
 const LEGLOG = true;
 const TOPBAR_PADDING = 8; // pixels
-const START_BUFFER = 120000; // 2 min in ms
 
 function NaviContainer(
   {
@@ -86,10 +85,6 @@ function NaviContainer(
       }
     }
     prevPos.current = position;
-
-    if (time > legTime(firstLeg.start) - START_BUFFER) {
-      startItinerary(Date.now());
-    }
   }, [time]);
 
   if (loading || !realTimeLegs?.length) {
@@ -106,9 +101,7 @@ function NaviContainer(
 
   if (LEGLOG) {
     // eslint-disable-next-line
-    console.log(
-      ...summaryString(realTimeLegs, time, previousLeg, currentLeg, nextLeg),
-    );
+    console.log(...summaryString(realTimeLegs, time, previousLeg, currentLeg, nextLeg));
   }
 
   const containerTopPosition =

--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -16,7 +16,7 @@ import NaviStarter from './NaviStarter';
 import { DESTINATION_RADIUS, summaryString } from './NaviUtils';
 import { addAnalyticsEvent } from '../../../util/analyticsUtils';
 
-const ADDITIONAL_ARRIVAL_TIME = 60000; // 60 seconds in ms
+const ADDITIONAL_ARRIVAL_TIME = 300000; // 5 min in ms
 const LEGLOG = true;
 const TOPBAR_PADDING = 8; // pixels
 

--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -107,7 +107,7 @@ function NaviContainer(
   const containerTopPosition =
     mapLayerRef.current.getBoundingClientRect().top + TOPBAR_PADDING;
 
-  const isPastStart = time > legTime(firstLeg.start);
+  const isPastStart = time > legTime(firstLeg.start) || !!firstLeg.forceStart;
 
   const handleNavigatorEndClick = () => {
     addAnalyticsEvent({

--- a/app/component/itinerary/navigator/NaviInstructions.js
+++ b/app/component/itinerary/navigator/NaviInstructions.js
@@ -142,9 +142,11 @@ export default function NaviInstructions(
       duration: withRealTime(rt, remainingDuration),
       legTime: withRealTime(rt, legTimeStr(leg.end)),
     };
+
     const translationId = nextLeg?.interlineWithPreviousLeg
       ? 'navileg-in-transit-interline'
       : 'navileg-leave-at';
+
     return (
       <>
         <div className="notification-header">


### PR DESCRIPTION
## Proposed Changes
- Fixes issue where a wait card was not shown if a force started navigator journey starts with transit
- Increased the arrival time buffer from 1 minute to 5 minutes
- ~Every navigator journey is now force started 2 minutes before the actual itinerary is scheduled to start~

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
