### PR TITLE
DT-6822 Set allowedNetwork for scooter as well

### DIFF
--- a/app/component/itinerary/PlanConnection.js
+++ b/app/component/itinerary/PlanConnection.js
@@ -38,6 +38,7 @@ const planConnection = graphql`
             speed: $bikeSpeed
             rental: { allowedNetworks: $allowedRentalNetworks }
           }
+          scooter: { rental: { allowedNetworks: $allowedRentalNetworks } }
           walk: {
             speed: $walkSpeed
             reluctance: $walkReluctance


### PR DESCRIPTION
## Proposed Changes

Sets allowedNetwork for scooter rental preferences similarly as for bicycle preferences. There was a bug in OTP that the bicycle preferences were partly being used for scooter rental routing as well. I didn't notice that there would have been any effect after related OTP changes with or without this change but it probably still makes sense to include these as well.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
