### PR TITLE
DT-6529 Hide Navigator start button for unsupported itineraries

### DIFF
--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -154,15 +154,22 @@ class ItineraryDetails extends React.Component {
     // this could then be used to set the waiting icon legs that need it.
     const usingOwnCarWholeTrip =
       walking.distance === 0 && biking.distance === 0 && driving.distance > 0;
-    const legsWithRentalBike = compressLegs(itinerary.legs).filter(leg =>
+    const compressedLegs = compressLegs(itinerary.legs);
+    const legsWithRentalBike = compressedLegs.filter(leg =>
       legContainsRentalBike(leg),
     );
-    const legswithBikePark = compressLegs(itinerary.legs).filter(leg =>
+    const legswithBikePark = compressedLegs.filter(leg =>
       legContainsBikePark(leg),
     );
-    const legsWithScooter = compressLegs(itinerary.legs).some(
-      leg => leg.mode === 'SCOOTER',
-    );
+    const legsWithScooter = compressedLegs.some(leg => leg.mode === 'SCOOTER');
+    const onlyWalking = compressedLegs.every(leg => leg.mode === 'WALK');
+    const onlyBiking = compressedLegs.every(leg => leg.mode === 'BICYCLE');
+    const showStartNavi =
+      this.props.startNavigation &&
+      !onlyWalking &&
+      !onlyBiking &&
+      !legsWithScooter &&
+      legsWithRentalBike.length === 0;
     const containsBiking = biking.duration > 0 && biking.distance > 0;
     const showBikeBoardingInformation =
       containsBiking &&
@@ -320,7 +327,7 @@ class ItineraryDetails extends React.Component {
                 />
               )),
 
-            this.props.startNavigation && (
+            showStartNavi && (
               <StartNavi
                 key="navigation"
                 startNavigation={this.props.startNavigation}

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -169,7 +169,8 @@ class ItineraryDetails extends React.Component {
       !onlyWalking &&
       !onlyBiking &&
       !legsWithScooter &&
-      legsWithRentalBike.length === 0;
+      legsWithRentalBike.length === 0 &&
+      driving.distance === 0;
     const containsBiking = biking.duration > 0 && biking.distance > 0;
     const showBikeBoardingInformation =
       containsBiking &&


### PR DESCRIPTION
## Proposed Changes
Prevents rendering Navigator initiating StartNavi component if itinerary:
- consists entirely of walking
- consists entirely of biking
- contains city bike legs
- contains e-scooter legs

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
