### PR TITLE
DT-6929 Replacement notifications text update and new design

### DIFF
--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -220,19 +220,23 @@ function ItineraryDetails(
   }
 
   if (config.replacementBusNotification) {
-    itinerary.legs.forEach(leg => {
-      const { route, trip } = leg;
-      if (
-        (route && getRouteMode(route, config)?.includes('replacement')) ||
-        (trip &&
-          (trip.submode?.includes('replacement') ||
-            trip.submode?.includes(714)))
-      ) {
-        const notification = config.replacementBusNotification;
+    itinerary.legs.forEach(({ route, trip }) => {
+      const isReplacementRoute =
+        route?.desc?.length &&
+        getRouteMode(route, config)?.includes('replacement');
+      const isReplacementTrip =
+        trip?.submode?.includes('replacement') || trip?.submode?.includes(714);
+
+      if (isReplacementRoute || isReplacementTrip) {
+        const notification =
+          isReplacementRoute && config.showRouteDescNotification
+            ? { content: route.desc, link: route.url }
+            : config.replacementBusNotification;
+
         disclaimers.push(
           <RouteDisclaimer
             key="replacementBusNotification"
-            text={notification.content?.[currentLanguage].join(' ')}
+            text={notification.content?.[currentLanguage]?.join(' ')}
             href={notification.link?.[currentLanguage]}
             linkText={intl.formatMessage({ id: 'extra-info' })}
           />,

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -219,18 +219,21 @@ function ItineraryDetails(
     }
   }
 
-  if (config.showRouteDisclaimer) {
+  if (config.replacementBusNotification) {
     itinerary.legs.forEach(leg => {
-      const { route } = leg;
+      const { route, trip } = leg;
       if (
-        route?.desc?.length &&
-        getRouteMode(route, config)?.includes('replacement')
+        (route && getRouteMode(route, config)?.includes('replacement')) ||
+        (trip &&
+          (trip.submode?.includes('replacement') ||
+            trip.submode?.includes(714)))
       ) {
+        const notification = config.replacementBusNotification;
         disclaimers.push(
           <RouteDisclaimer
-            key={disclaimers.length}
-            text={route.desc}
-            href={route.url}
+            key="replacementBusNotification"
+            text={notification.content?.[currentLanguage].join(' ')}
+            href={notification.link?.[currentLanguage]}
             linkText={intl.formatMessage({ id: 'extra-info' })}
           />,
         );

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -217,25 +217,25 @@ function ItineraryDetails(
         />,
       );
     }
+  }
 
-    if (config.showRouteDisclaimer) {
-      itinerary.legs.forEach(leg => {
-        const { route } = leg;
-        if (
-          route?.desc?.length &&
-          getRouteMode(route, config)?.includes('replacement')
-        ) {
-          disclaimers.push(
-            <RouteDisclaimer
-              key={disclaimers.length}
-              text={route.desc}
-              href={route.url}
-              linkText={intl.formatMessage({ id: 'extra-info' })}
-            />,
-          );
-        }
-      });
-    }
+  if (config.showRouteDisclaimer) {
+    itinerary.legs.forEach(leg => {
+      const { route } = leg;
+      if (
+        route?.desc?.length &&
+        getRouteMode(route, config)?.includes('replacement')
+      ) {
+        disclaimers.push(
+          <RouteDisclaimer
+            key={disclaimers.length}
+            text={route.desc}
+            href={route.url}
+            linkText={intl.formatMessage({ id: 'extra-info' })}
+          />,
+        );
+      }
+    });
   }
 
   return (

--- a/app/component/itinerary/TransitLeg.js
+++ b/app/component/itinerary/TransitLeg.js
@@ -362,7 +362,7 @@ class TransitLeg extends React.Component {
     const createNotificationWithLink = notification => {
       return (
         <a
-          href={`https://www.${notification.link[lang]}`}
+          href={`https://www.${notification.link?.[lang]}`}
           className="disruption-link"
           target="_blank"
           rel="noreferrer"
@@ -397,6 +397,7 @@ class TransitLeg extends React.Component {
             <div
               className={cx('disruption', {
                 'no-header': !notification.header,
+                'no-link': !notification.link,
               })}
               key={`note-${index}`}
             >

--- a/app/component/itinerary/itinerary.scss
+++ b/app/component/itinerary/itinerary.scss
@@ -2164,6 +2164,14 @@ $itinerary-tab-switch-height: 48px;
       border: solid 1px #ddd;
       margin-bottom: 10px;
 
+      &.no-link {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 6px 15px 8px 12px;
+        text-decoration: none;
+      }
+
       .disruption-icon {
         width: 18px;
         height: 18px;

--- a/app/component/routepage/RouteControlPanel.js
+++ b/app/component/routepage/RouteControlPanel.js
@@ -373,9 +373,9 @@ class RouteControlPanel extends React.Component {
               key={notification.id}
               header={notification.header[language]}
               content={notification.content[language]}
-              link={notification.link[language]}
+              link={notification.link?.[language]}
               id={notification.id}
-              closeButtonLabel={notification.closeButtonLabel[language]}
+              closeButtonLabel={notification.closeButtonLabel?.[language]}
             />,
           );
         }

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -859,7 +859,6 @@ export default {
   navigation: false,
   sendAnalyticsCustomEventGoals: false,
   shortenLongTextThreshold: 10, // for route number in itinerary summary
-  showRouteDisclaimer: true,
   allowFlexJourneys: false,
   allowDirectFlexJourneys: false,
   allowedFlexRouteTypes: [1501],

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -862,4 +862,5 @@ export default {
   allowFlexJourneys: false,
   allowDirectFlexJourneys: false,
   allowedFlexRouteTypes: [1501],
+  showRouteDescNotification: false,
 };

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -751,8 +751,8 @@ export default {
       id: 'replacementBusNotification',
       header: {
         fi: 'Korvaava bussi',
-        en: 'Korvaava bussi',
-        sv: 'Korvaava bussi',
+        en: 'Replacement bus',
+        sv: 'Ersättande buss',
       },
       content: {
         fi: [
@@ -761,25 +761,18 @@ export default {
           'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
         ],
         en: [
-          'Voit nousta kyytiin myös bussin keskiovista.',
-          'Pysäkit on merkitty punaisilla tunnuksilla.',
-          'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
+          'You can also board the bus through the middle doors.',
+          'The stops are marked with red signs.',
+          'The bus stops only at designated stops and does not serve all stops.',
         ],
         sv: [
-          'Voit nousta kyytiin myös bussin keskiovista.',
-          'Pysäkit on merkitty punaisilla tunnuksilla.',
-          'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
+          'Du kan också stiga på bussen genom mittdörren.',
+          'Hållplatserna är markerade med röda punkter.',
+          'Linjen stannar endast vid vissa hållplatser, dvs. bussen stannar inte vid alla hållplatser.',
         ],
-      },
-      closeButtonLabel: {
-        fi: '',
-        en: '',
-        sv: '',
       },
       link: {
         fi: 'hsl.fi/korvaavabussi',
-        en: 'hsl.fi/korvaavabussi',
-        sv: 'hsl.fi/korvaavabussi',
       },
     },
   ],

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -746,36 +746,35 @@ export default {
         sv: 'hsl.fi/sv/kampanjer/snabbsparvag',
       },
     },
-    {
-      showForRoute: route => route.type === 714,
-      id: 'replacementBusNotification',
-      header: {
-        fi: 'Korvaava bussi',
-        en: 'Replacement bus',
-        sv: 'Ersättande buss',
-      },
-      content: {
-        fi: [
-          'Voit nousta kyytiin myös bussin keskiovista.',
-          'Pysäkit on merkitty punaisilla tunnuksilla.',
-          'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
-        ],
-        en: [
-          'You can also board the bus through the middle doors.',
-          'The stops are marked with red signs.',
-          'The bus stops only at designated stops and does not serve all stops.',
-        ],
-        sv: [
-          'Du kan också stiga på bussen genom mittdörren.',
-          'Hållplatserna är markerade med röda punkter.',
-          'Linjen stannar endast vid vissa hållplatser, dvs. bussen stannar inte vid alla hållplatser.',
-        ],
-      },
-      link: {
-        fi: 'hsl.fi/korvaavabussi',
-      },
-    },
   ],
+
+  replacementBusNotification: {
+    header: {
+      fi: 'Korvaava bussi',
+      en: 'Replacement bus',
+      sv: 'Ersättande buss',
+    },
+    content: {
+      fi: [
+        'Voit nousta kyytiin myös bussin keskiovista.',
+        'Pysäkit on merkitty punaisilla tunnuksilla.',
+        'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
+      ],
+      en: [
+        'You can also board the bus through the middle doors.',
+        'The stops are marked with red signs.',
+        'The bus stops only at designated stops and does not serve all stops.',
+      ],
+      sv: [
+        'Du kan också stiga på bussen genom mittdörren.',
+        'Hållplatserna är markerade med röda punkter.',
+        'Linjen stannar endast vid vissa hållplatser, dvs. bussen stannar inte vid alla hållplatser.',
+      ],
+    },
+    link: {
+      fi: 'hsl.fi/korvaavabussi',
+    },
+  },
 
   embeddedSearch: {
     title: {
@@ -811,7 +810,6 @@ export default {
   trafficLightGraphic: 'hsl/traffic-light.svg',
   naviGeolocationGraphic: 'hsl/geolocation.svg',
   navigation: true,
-  showRouteDisclaimer: true,
   crazyEgg: true,
   // features that should not be deployed to production
   experimental: {

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -772,7 +772,7 @@ export default {
       ],
     },
     link: {
-      fi: 'hsl.fi/korvaavabussi',
+      fi: 'https://hsl.fi/korvaavabussi',
     },
   },
 

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -318,8 +318,8 @@ export default {
       id: 'replacementBusNotification',
       header: {
         fi: 'Korvaava bussi',
-        en: 'Korvaava bussi',
-        sv: 'Korvaava bussi',
+        en: 'Replacement bus',
+        sv: 'Ersättande buss',
       },
       content: {
         fi: [
@@ -328,25 +328,15 @@ export default {
           'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
         ],
         en: [
-          'Voit nousta kyytiin myös bussin keskiovista.',
-          'Pysäkit on merkitty punaisilla tunnuksilla.',
-          'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
+          'You can also board the bus through the middle doors.',
+          'The stops are marked with red signs.',
+          'The bus stops only at designated stops and does not serve all stops.',
         ],
         sv: [
-          'Voit nousta kyytiin myös bussin keskiovista.',
-          'Pysäkit on merkitty punaisilla tunnuksilla.',
-          'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
+          'Du kan också stiga på bussen genom mittdörren.',
+          'Hållplatserna är markerade med röda punkter.',
+          'Linjen stannar endast vid vissa hållplatser, dvs. bussen stannar inte vid alla hållplatser.',
         ],
-      },
-      closeButtonLabel: {
-        fi: '',
-        en: '',
-        sv: '',
-      },
-      link: {
-        fi: '',
-        en: '',
-        sv: '',
       },
     },
   ],

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -312,34 +312,31 @@ export default {
   hideNaviTickets: true, // TODO: temporary force switch
   navigation: true,
 
-  routeNotifications: [
-    {
-      showForRoute: route => route.type === 714,
-      id: 'replacementBusNotification',
-      header: {
-        fi: 'Korvaava bussi',
-        en: 'Replacement bus',
-        sv: 'Ersättande buss',
-      },
-      content: {
-        fi: [
-          'Voit nousta kyytiin myös bussin keskiovista.',
-          'Pysäkit on merkitty punaisilla tunnuksilla.',
-          'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
-        ],
-        en: [
-          'You can also board the bus through the middle doors.',
-          'The stops are marked with red signs.',
-          'The bus stops only at designated stops and does not serve all stops.',
-        ],
-        sv: [
-          'Du kan också stiga på bussen genom mittdörren.',
-          'Hållplatserna är markerade med röda punkter.',
-          'Linjen stannar endast vid vissa hållplatser, dvs. bussen stannar inte vid alla hållplatser.',
-        ],
-      },
+  replacementBusNotification: {
+    header: {
+      fi: 'Korvaava bussi',
+      en: 'Replacement bus',
+      sv: 'Ersättande buss',
     },
-  ],
+    content: {
+      fi: [
+        'Voit nousta kyytiin myös bussin keskiovista.',
+        'Pysäkit on merkitty punaisilla tunnuksilla.',
+        'Linja käyttää valikoituja pysäkkejä, eli bussi ei pysähdy kaikilla pysäkeillä.',
+      ],
+      en: [
+        'You can also board the bus through the middle doors.',
+        'The stops are marked with red signs.',
+        'The bus stops only at designated stops and does not serve all stops.',
+      ],
+      sv: [
+        'Du kan också stiga på bussen genom mittdörren.',
+        'Hållplatserna är markerade med röda punkter.',
+        'Linjen stannar endast vid vissa hållplatser, dvs. bussen stannar inte vid alla hållplatser.',
+      ],
+    },
+  },
+
   externalFeedIds: ['02Taksi'],
 
   // features that should not be deployed to production


### PR DESCRIPTION
## Proposed Changes

  - Use new info box with configured replacement info
  - Support for showing replacement info when it comes from trip instead of route
  - Standard route notifications now allow configurations without link and button label fields.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
