### PR TITLE
DT-6183 add taxi results to alternative search results

### DIFF
--- a/app/component/itinerary/ItineraryList.js
+++ b/app/component/itinerary/ItineraryList.js
@@ -36,7 +36,7 @@ function ItineraryList(
     bikeParkItineraryCount,
     carDirectItineraryCount,
     showRelaxedPlanNotifier,
-    showRentalVehicleNotifier,
+    rentalVehicleNotifierId,
     separatorPosition,
     loadingMore,
     routingFeedbackPosition,
@@ -182,7 +182,7 @@ function ItineraryList(
           </div>
         </div>
       )}
-      {showRentalVehicleNotifier && (
+      {rentalVehicleNotifierId?.length && (
         <div
           className={cx(
             'flex-horizontal',
@@ -197,9 +197,13 @@ function ItineraryList(
             </div>
             <div className="alternative-vehicle-info-content">
               <FormattedMessage
-                id="e-scooter-alternative"
+                id={`${rentalVehicleNotifierId}-alternative`}
                 values={{
-                  paymentInfo: <FormattedMessage id="payment-info-e-scooter" />,
+                  paymentInfo: (
+                    <FormattedMessage
+                      id={`payment-info-${rentalVehicleNotifierId}`}
+                    />
+                  ),
                 }}
               />
             </div>
@@ -242,7 +246,7 @@ ItineraryList.propTypes = {
   bikeParkItineraryCount: PropTypes.number,
   carDirectItineraryCount: PropTypes.number,
   showRelaxedPlanNotifier: PropTypes.bool,
-  showRentalVehicleNotifier: PropTypes.bool,
+  rentalVehicleNotifierId: PropTypes.string,
   separatorPosition: PropTypes.number,
   loadingMore: PropTypes.string,
   routingFeedbackPosition: PropTypes.number,
@@ -253,7 +257,7 @@ ItineraryList.defaultProps = {
   carDirectItineraryCount: 0,
   planEdges: [],
   showRelaxedPlanNotifier: false,
-  showRentalVehicleNotifier: false,
+  rentalVehicleNotifierId: undefined,
   separatorPosition: undefined,
   loadingMore: undefined,
   routingFeedbackPosition: undefined,

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -76,6 +76,8 @@ import {
   stopClient,
   updateClient,
   getSortedEdges,
+  filterItinerariesByRouteType,
+  sortAndMergeExternalPlans,
 } from './ItineraryPageUtils';
 import ItineraryTabs from './ItineraryTabs';
 import NaviGeolocationInfoModal from './navigator/navigatorgeolocation/NaviGeolocationInfoModal';
@@ -141,6 +143,8 @@ export default function ItineraryPage(props, context) {
   });
   const [relaxState, setRelaxState] = useState(emptyPlan);
   const [relaxScooterState, setRelaxScooterState] = useState(emptyPlan);
+  const [relaxFlexState, setRelaxFlexState] = useState(emptyPlan);
+  const [combinedRelaxState, setCombinedRelaxState] = useState(emptyPlan);
   const [scooterState, setScooterState] = useState(unset);
   const [combinedState, setCombinedState] = useState(emptyPlan);
   const [flexState, setFlexState] = useState(unset);
@@ -262,8 +266,8 @@ export default function ItineraryPage(props, context) {
           if (relaxState.plan?.edges?.length > 0) {
             return relaxState.plan;
           }
-          if (relaxScooterState.plan?.edges?.length > 0) {
-            return relaxScooterState.plan;
+          if (combinedRelaxState.plan?.edges?.length > 0) {
+            return combinedRelaxState.plan;
           }
         }
         return combinedState.plan;
@@ -496,6 +500,40 @@ export default function ItineraryPage(props, context) {
     } catch (error) {
       reportError(error);
       setFlexState(emptyPlan);
+    }
+  }
+
+  async function makeRelaxedFlexQuery() {
+    if (!planQueryNeeded(config, match, PLANTYPE.FLEXTRANSIT, true)) {
+      setRelaxFlexState(emptyPlan);
+      return;
+    }
+    setRelaxFlexState({ loading: LOADSTATE.LOADING });
+
+    const planParams = getPlanParams(
+      config,
+      match,
+      PLANTYPE.FLEXTRANSIT,
+      true, // force relaxed settings
+    );
+
+    const tunedParams = {
+      ...planParams,
+    };
+    try {
+      const plan = await iterateQuery(
+        tunedParams,
+        tunedParams.maxQueryIterations,
+      );
+      const flexPlan = {
+        edges: filterItinerariesByRouteType(
+          plan.edges,
+          config.allowedFlexRouteTypes,
+        ),
+      };
+      setRelaxFlexState({ plan: flexPlan, loading: LOADSTATE.DONE });
+    } catch (error) {
+      setRelaxFlexState(emptyPlan);
     }
   }
 
@@ -924,6 +962,7 @@ export default function ItineraryPage(props, context) {
     if (settingsLimitRouting(config) && !settingsState.settingsChanged) {
       makeRelaxedQuery();
       makeRelaxedScooterQuery();
+      makeRelaxedFlexQuery();
     }
   }, [
     settingsState.settingsChanged,
@@ -984,7 +1023,7 @@ export default function ItineraryPage(props, context) {
     carPublicState.plan,
     altStates[PLANTYPE.PARKANDRIDE][0].plan,
     location.state?.selectedItineraryIndex,
-    relaxScooterState.plan,
+    combinedRelaxState.plan,
     naviMode,
   ]);
 
@@ -1051,6 +1090,23 @@ export default function ItineraryPage(props, context) {
       resetItineraryPageSelection();
     }
   }, [scooterState.plan, state.plan, flexState.plan]);
+
+  // merge the relaxed scooter plan and the relaxed flex plan into one
+  useEffect(() => {
+    if (
+      relaxScooterState.loading === LOADSTATE.DONE &&
+      relaxFlexState.loading === LOADSTATE.DONE
+    ) {
+      const plan = sortAndMergeExternalPlans(
+        relaxScooterState.plan,
+        relaxFlexState.plan,
+        match.location.query.arriveBy === 'true',
+      );
+
+      setCombinedRelaxState({ plan, loading: LOADSTATE.DONE });
+      resetItineraryPageSelection();
+    }
+  }, [relaxScooterState.plan, relaxFlexState.plan]);
 
   const setMWTRef = ref => {
     mwtRef.current = ref;
@@ -1269,7 +1325,18 @@ export default function ItineraryPage(props, context) {
   const settings = getSettings(config);
 
   const showRelaxedPlanNotifier = plan === relaxState.plan;
-  const showRentalVehicleNotifier = plan === relaxScooterState.plan;
+  const showCombinedPlanNotifier = plan === combinedRelaxState.plan;
+  let rentalVehicleNotifierId = null;
+  if (showCombinedPlanNotifier) {
+    if (relaxFlexState.plan?.edges && relaxScooterState.plan?.edges) {
+      rentalVehicleNotifierId = 'e-scooter-or-taxi';
+    } else if (relaxFlexState.plan?.edges) {
+      rentalVehicleNotifierId = 'taxi';
+    } else if (relaxScooterState.plan?.edges) {
+      rentalVehicleNotifierId = 'e-scooter';
+    }
+  }
+
   /* NOTE: as a temporary solution, do filtering by feedId in UI */
   if (config.feedIdFiltering && plan) {
     plan = filterItinerariesByFeedId(plan, config);
@@ -1315,7 +1382,7 @@ export default function ItineraryPage(props, context) {
   const loading =
     combinedState.loading === LOADSTATE.LOADING ||
     (relaxState.loading === LOADSTATE.LOADING && hasNoTransitItineraries) ||
-    (relaxScooterState.loading === LOADSTATE.LOADING &&
+    (combinedRelaxState.loading === LOADSTATE.LOADING &&
       hasNoTransitItineraries) ||
     waitAlternatives ||
     (streetHashes.includes(hash) && loadingAlt); // viewing unfinished alt plan
@@ -1431,7 +1498,7 @@ export default function ItineraryPage(props, context) {
         bikeParkItineraryCount={bikePublicPlan.bikeParkItineraryCount}
         carDirectItineraryCount={carPublicPlan.carDirectItineraryCount}
         showRelaxedPlanNotifier={showRelaxedPlanNotifier}
-        showRentalVehicleNotifier={showRentalVehicleNotifier}
+        rentalVehicleNotifierId={rentalVehicleNotifierId}
         separatorPosition={hash ? undefined : state.separatorPosition}
         onLater={onLater}
         onEarlier={onEarlier}

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -594,6 +594,32 @@ export function mergeScooterTransitPlan(
   return sortAndMergePlans(scooterTransitEdges, transitPlan, arriveBy);
 }
 
+/**
+ * Combine two sets of external plans.
+ */
+export function sortAndMergeExternalPlans(
+  plan,
+  planToMerge,
+  arriveBy,
+  maxTotalEdges = 5,
+) {
+  const edges = plan.edges || [];
+  const edgesToMerge = planToMerge.edges || [];
+  return {
+    edges: getSortedEdges([...edges, ...edgesToMerge], arriveBy)
+      .slice(0, maxTotalEdges)
+      .map(edge => {
+        return {
+          ...edge,
+          node: {
+            ...edge.node,
+            legs: compressLegs(edge.node.legs),
+          },
+        };
+      }),
+  };
+}
+
 const ITERATION_CANCEL_TIME = 20000; // ms, stop looking for more if something was found
 
 export function quitIteration(plan, newPlan, planParams, startTime) {

--- a/app/translations.js
+++ b/app/translations.js
@@ -1461,10 +1461,10 @@ const translations = {
     'pay-attention': 'N.B.',
     'payment-info-e-scooter':
       'Please note that you need to use the app of the operator in question in order to use and pay for the scooters.',
-    'payment-info-e-scooter-taxi':
+    'payment-info-e-scooter-or-taxi':
       'Please note that you need to use the app of the operator in question in order to use and pay for the taxis or scooters.',
-    'payment-info-taxi-lifts':
-      'Huomaathan, että taksien ja kyytipalveluiden käyttö ja maksaminen tapahtuu toimijoiden omilla sovelluksilla.',
+    'payment-info-taxi':
+      'Please note that you need to use the app of the operator in question in order to use and pay for the taxis.',
     payment_at_gate: 'Payment at the gate ',
     'pick-icon': 'Select icon',
     'pick-mode': 'Transport modes',
@@ -1721,6 +1721,8 @@ const translations = {
     'swipe-summary-page': 'Itinerary swipe result tabs',
     'swipe-summary-page-header': 'Itinerary swipe result tabs.',
     taxi: 'Taxi',
+    'taxi-alternative':
+      'How about using a taxi for part of your journey? {paymentInfo}',
     'taxi-distance-duration': 'Travel for {duration} ({distance})',
     'taxi-distance-no-duration': 'Travel for {distance}',
     'taxi-external': 'Taxi',
@@ -2780,9 +2782,9 @@ const translations = {
     'pay-attention': 'Huom!',
     'payment-info-e-scooter':
       'Huomaathan, että potkulautojen käyttö ja maksaminen tapahtuu toimijoiden omilla sovelluksilla.',
-    'payment-info-e-scooter-taxi':
+    'payment-info-e-scooter-or-taxi':
       'Huomaathan, että potkulautojen ja taksin käyttö ja maksaminen tapahtuu toimijoiden omilla sovelluksilla.',
-    'payment-info-taxi-lifts':
+    'payment-info-taxi':
       'Huomaathan, että taksien ja kyytipalveluiden käyttö ja maksaminen tapahtuu toimijoiden omilla sovelluksilla.',
     payment_at_gate: 'Maksu portilla',
     'pick-icon': 'Valitse kuvake',
@@ -3039,6 +3041,8 @@ const translations = {
     'swipe-summary-page': 'Reittiehdotusvälilehtien',
     'swipe-summary-page-header': 'Reittiehdotusvälilehdet.',
     taxi: 'Taxi',
+    'taxi-alternative':
+      'Entä jos kulkisit osan matkasta taksilla? {paymentInfo}',
     'taxi-distance-duration': 'Matkusta {duration} ({distance})',
     'taxi-distance-no-duration': 'Matkusta {distance}',
     'taxi-external': 'Taksi',
@@ -5747,10 +5751,10 @@ const translations = {
     'pay-attention': 'Obs!',
     'payment-info-e-scooter':
       'Vänligen observera att användning och betalning av elsparkcyklar görs via operatörernas egna appar.',
-    'payment-info-e-scooter-taxi':
+    'payment-info-e-scooter-or-taxi':
       'Vänligen observera att användning och betalning av elsparkcyklar och taxi görs via operatörernas egna appar.',
-    'payment-info-taxi-lifts':
-      'Huomaathan, että taksien ja kyytipalveluiden käyttö ja maksaminen tapahtuu toimijoiden omilla sovelluksilla.',
+    'payment-info-taxi':
+      'Vänligen observera att användning och betalning av taxi görs via operatörernas egna appar.',
     payment_at_gate: 'Betalning vid porten',
     'pick-icon': 'Välj en ikon',
     'pick-mode': 'Trafikslag',
@@ -6011,6 +6015,8 @@ const translations = {
     'swipe-summary-page': 'Navigeringsknapp för att kunna bläddra ruttförslag.',
     'swipe-summary-page-header': 'Ruttförslag.',
     taxi: 'Taxi',
+    'taxi-alternative':
+      'Och om du skulle åka taxi en del av din resa? {paymentInfo}',
     'taxi-distance-duration': 'Matkusta {duration} ({distance})',
     'taxi-distance-no-duration': 'Matkusta {distance}',
     'taxi-external': 'Taxi',

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -258,13 +258,13 @@ export function planQueryNeeded(
         distance > config.suggestCarMinDistance &&
         settings.includeParkAndRideSuggestions
       );
-
+    /* special logic: relaxed flex query is made only if taxis are not allowed */
     case PLANTYPE.FLEXTRANSIT:
       return (
         config.experimental?.allowFlexJourneys &&
-        settings.includeTaxiSuggestions &&
         (transitModes.length > 0 ||
-          config.experimental?.allowDirectFlexJourneys)
+          config.experimental?.allowDirectFlexJourneys) &&
+        settings.includeTaxiSuggestions === !relaxSettings
       );
 
     case PLANTYPE.TRANSIT:

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -264,7 +264,7 @@ export function planQueryNeeded(
         config.experimental?.allowFlexJourneys &&
         (transitModes.length > 0 ||
           config.experimental?.allowDirectFlexJourneys) &&
-        settings.includeTaxiSuggestions === !relaxSettings
+        settings.includeTaxiSuggestions !== relaxSettings
       );
 
     case PLANTYPE.TRANSIT:


### PR DESCRIPTION
## Proposed Changes

  - Make flex query if no routes were found and taxi option is not selected.
  - Combine flex results with the existing alternative scooter results.
  - Fixed translations to include taxi only versions and fixed naming. 
  - Fixed notification logic to show correct version of notification (no suggestions for modes which are not available).

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
