### PR TITLE
DT-6943 fix: navi starter rendering fixed

### DIFF
--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -104,7 +104,7 @@ function NaviContainer(
     }
   }, [firstLeg]);
 
-  if (loading) {
+  if (loading || !starterReady) {
     return null;
   }
 

--- a/app/component/itinerary/navigator/NaviContainer.js
+++ b/app/component/itinerary/navigator/NaviContainer.js
@@ -1,7 +1,7 @@
 import connectToStores from 'fluxible-addons-react/connectToStores';
 import { routerShape } from 'found';
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   startLocationWatch,
   stopLocationWatch,
@@ -39,6 +39,7 @@ function NaviContainer(
   const hasPosition = useRef(false);
   const prevPos = useRef(undefined);
   const posFrozen = useRef(0);
+  const [starterReady, setStarterReady] = useState(false);
 
   let position = getStore('PositionStore').getLocationState();
   if (!position.hasLocation) {
@@ -95,12 +96,15 @@ function NaviContainer(
   }, [time]);
 
   useEffect(() => {
-    if (firstLeg && time > legTime(firstLeg.start) - START_BUFFER) {
-      startItinerary(Date.now());
+    if (firstLeg && !starterReady) {
+      if (time > legTime(firstLeg.start) - START_BUFFER) {
+        startItinerary(Date.now() - 1);
+      }
+      setStarterReady(true);
     }
   }, [firstLeg]);
 
-  if (loading || !realTimeLegs?.length) {
+  if (loading) {
     return null;
   }
 
@@ -123,7 +127,7 @@ function NaviContainer(
   const containerTopPosition =
     mapLayerRef.current.getBoundingClientRect().top + TOPBAR_PADDING;
 
-  const isPastStart = time > legTime(firstLeg.start) || !!firstLeg.forceStart;
+  const isPastStart = time >= legTime(firstLeg.start) || !!firstLeg.forceStart;
 
   const handleNavigatorEndClick = () => {
     addAnalyticsEvent({


### PR DESCRIPTION
StartItinerary call to start navigation immediately did not trigger rendering. This had bad side effects:

- Start modal was rendered for 10 seconds although code already triggered navigation
- When user clicked 'Start now' , instructions appeared after a long delay (10 s in worst case)

Rendering is now triggered using local state variable. Also, itinerary start is set one seconds in the past to ensure that NaviCardContainer finds a leg to render.