### PR TITLE
DT-6920 vehicle positions for new Matka koontipalvelu realtime

### DIFF
--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -83,33 +83,19 @@ export function getTopics(legs, config) {
     legs.forEach(leg => {
       if (leg.transitLeg && leg.trip) {
         const feedId = leg.trip.gtfsId.split(':')[0];
-        let topic;
         if (realTime && feedIds.includes(feedId)) {
-          const routeProps = {
+          itineraryTopics.push({
             route: leg.route.gtfsId.split(':')[1],
             shortName: leg.route.shortName,
             type: leg.route.type,
-          };
-          if (realTime[feedId]?.useFuzzyTripMatching) {
-            topic = {
-              ...routeProps,
-              feedId,
-              mode: leg.mode.toLowerCase(),
-              direction: Number(leg.trip.directionId),
-              tripStartTime: getStartTimeWithColon(
-                leg.trip.stoptimesForDate[0].scheduledDeparture,
-              ),
-            };
-          } else if (realTime[feedId]) {
-            topic = {
-              ...routeProps,
-              feedId,
-              tripId: leg.trip.gtfsId.split(':')[1],
-            };
-          }
-        }
-        if (topic) {
-          itineraryTopics.push(topic);
+            feedId,
+            mode: leg.mode.toLowerCase(),
+            direction: Number(leg.trip.directionId),
+            tripStartTime: getStartTimeWithColon(
+              leg.trip.stoptimesForDate[0].scheduledDeparture,
+            ),
+            tripId: leg.trip.gtfsId.split(':')[1],
+          });
         }
       }
     });

--- a/app/component/map/VehicleMarkerContainer.js
+++ b/app/component/map/VehicleMarkerContainer.js
@@ -76,8 +76,9 @@ function VehicleMarkerContainer(props, { config }) {
   props.setVisibleVehicles(visibleVehicleIds);
 
   return visibleVehicles.map(([id, message]) => {
+    const r = message.route.split(':')[1];
     const type = props.topics?.find(
-      t => t.shortName === message.shortName,
+      t => t.shortName === message.shortName || t.route === r,
     )?.type;
     let mode;
     if (type === ExtendedRouteTypes.BusExpress) {
@@ -95,7 +96,7 @@ function VehicleMarkerContainer(props, { config }) {
     const feed = message.route?.split(':')[0];
     let vehicleNumber = message.shortName
       ? config.realTime[feed].vehicleNumberParser(message.shortName)
-      : message.route.split(':')[1];
+      : r;
     // Fallback to a question mark if the vehicle number is too long to fit in the icon
     vehicleNumber = vehicleNumber.length > 5 ? '?' : vehicleNumber;
     return (

--- a/app/component/map/VehicleMarkerContainer.js
+++ b/app/component/map/VehicleMarkerContainer.js
@@ -17,13 +17,7 @@ const MODES_WITH_ICONS = [
   'replacement-bus',
 ];
 
-function getVehicleIcon(
-  mode,
-  heading,
-  vehicleNumber,
-  color,
-  useLargeIcon = true,
-) {
+function getVehicleIcon(mode, heading, vehicleNumber, color, useLargeIcon) {
   const modeOrDefault = MODES_WITH_ICONS.indexOf(mode) !== -1 ? mode : 'bus';
 
   return {
@@ -139,11 +133,13 @@ VehicleMarkerContainer.propTypes = {
       long: PropTypes.number.isRequired,
     }).isRequired,
   ).isRequired,
+  useLargeIcon: PropTypes.bool,
 };
 
 VehicleMarkerContainer.defaultProps = {
   tripStart: undefined,
   direction: undefined,
+  useLargeIcon: true,
 };
 
 VehicleMarkerContainer.contextTypes = {

--- a/app/configurations/realtimeUtils.js
+++ b/app/configurations/realtimeUtils.js
@@ -138,6 +138,32 @@ function tripRouteTopicResolver(
   );
 }
 
+function routeTopicResolver(
+  route,
+  direction,
+  tripStartTime,
+  headsign,
+  feedId,
+  tripId,
+  geoHash,
+) {
+  return (
+    '/gtfsrt/vp/' +
+    feedId +
+    '/+/+/+/' +
+    route +
+    '/+/+/+/+/+/+/+/' +
+    geoHash[0] +
+    '/' +
+    geoHash[1] +
+    '/' +
+    geoHash[2] +
+    '/' +
+    geoHash[3] +
+    '/#'
+  );
+}
+
 function hslTopicResolver(
   route,
   hslDirection,
@@ -223,7 +249,7 @@ export default {
   FOLI: { ...walttiMqtt, mqttTopicResolver: noHeadsignTopicResolver },
   MATKA: {
     ...walttiMqtt,
-    mqttTopicResolver: tripRouteTopicResolver,
+    mqttTopicResolver: routeTopicResolver,
     vehicleNumberParser: vehicleNumberPartParser,
   },
   digitraffic: {

--- a/app/configurations/realtimeUtils.js
+++ b/app/configurations/realtimeUtils.js
@@ -220,7 +220,6 @@ export default {
     mqtt: 'wss://mqtt.hsl.fi',
     mqttTopicResolver: hslTopicResolver,
     gtfsrt: false,
-    useFuzzyTripMatching: true,
   },
   tampere: walttiMqtt,
   LINKKI: walttiMqtt,

--- a/app/store/RealTimeInformationStore.js
+++ b/app/store/RealTimeInformationStore.js
@@ -99,7 +99,6 @@ class RealTimeInformationStore extends Store {
       if (hasKey) {
         projectedVehicles.push(vehicle);
       }
-      this.vehicles[key] = vehicle;
     });
     events.emit('vehiclesChanged', projectedVehicles);
   }


### PR DESCRIPTION
Koontipalvelu realtime combines all vehiclePosition data into a single feed.  Because data content varies a lot, UI must subscribe to vehiclePositions MQTT with a minimal topic which only specifies the route. 

UI already has a confusing collection of filtering logic to show only part of incoming vehicle positions. Now itinerary page also uses such filtering to show only the relevant trips. 

Note: vehicle position related code badly needs refactoring. It seems sensible to filtert the data when it arrives into the store, instead of scattering complex filter props into map components. There is even a crazy feedback loop where map component updates the data store with some visibility rules whenever it recieives new positions. 