### PR TITLE
DT-4133 Replace all moment dependencies in shared components

### DIFF
--- a/app/component/DatetimepickerContainer.js
+++ b/app/component/DatetimepickerContainer.js
@@ -103,7 +103,7 @@ function DatetimepickerContainer(
       embedWhenOpen={embedWhenOpen}
       lang={lang}
       color={color}
-      timeZone={config.timezoneData.split('|')[0]}
+      timeZone={config.timeZone}
       serviceTimeRange={context.config.itinerary.serviceTimeRange}
       fontWeights={config.fontWeights}
       onOpen={onOpen}

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -234,9 +234,6 @@ export default {
     'pl',
   ],
   defaultLanguage: 'en',
-  // This timezone data will expire in 2037
-  timezoneData:
-    'Europe/Helsinki|EET EEST|-20 -30|0101010101010101010101010101010101010|22k10 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00|12e5',
   timeZone: 'Europe/Helsinki',
   allowLogin: false,
   allowFavouritesFromLocalstorage: true,
@@ -478,16 +475,6 @@ export default {
     taxi: {
       availableForSelection: false,
       defaultValue: false, // always false
-    },
-  },
-
-  moment: {
-    relativeTimeThreshold: {
-      seconds: 55,
-      minutes: 59,
-      hours: 23,
-      days: 26,
-      months: 11,
     },
   },
 

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -18,7 +18,6 @@ const globals = {
   classnames: 'cx',
   'prop-types': 'PropTypes',
   i18next: 'i18next',
-  'moment-timezone': 'moment',
   'react-autosuggest': 'Autosuggest',
   'react-sortablejs': 'reactSortablejs',
   'react-modal': 'ReactModal',
@@ -48,7 +47,6 @@ const globals = {
   'lodash/get': 'get',
   'lodash/uniq': 'uniq',
   'lodash/compact': 'compact',
-  moment: 'moment',
   'react-relay': 'reactRelay',
 };
 

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^3.0.6",
+    "@digitransit-component/digitransit-component-autosuggest": "^4.0.0",
     "@digitransit-component/digitransit-component-icon": "^1.0.2",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "4.0.7",
+  "version": "5.0.0",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "3.0.6",
+  "version": "4.0.0",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [
@@ -43,6 +43,7 @@
     "i18next": "^22.5.1",
     "lodash": "4.17.21",
     "lodash-es": "4.17.21",
+    "luxon": "^3.6.1",
     "prop-types": "^15.8.1",
     "react": "^16.13.0",
     "react-autosuggest": "^10.0.0",

--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "1.1.9",
+  "version": "2.0.0",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [
@@ -34,8 +34,7 @@
     "i18next": "^22.5.1",
     "lodash": "4.17.21",
     "lodash-es": "4.17.21",
-    "moment": "2.30.1",
-    "moment-timezone": "0.5.45",
+    "luxon": "^3.6.1",
     "prop-types": "^15.8.1",
     "react": "^16.13.0",
     "react-autosuggest": "^10.0.0",

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/DesktopDatetimepicker.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
-import moment from 'moment-timezone';
+import { DateTime, Settings } from 'luxon';
 import Select from 'react-select';
 import i18next from 'i18next';
 import cx from 'classnames';
@@ -45,7 +45,7 @@ function DesktopDatetimepicker({
   datePicker,
   translationSettings,
 }) {
-  moment.tz.setDefault(timeZone);
+  Settings.defaultZone = timeZone;
   const [displayValue, changeDisplayValue] = useState(getDisplay(value));
   const [typing, setTyping] = useState(false);
   const [showAllOptions, setShowAllOptions] = useState(true);
@@ -60,12 +60,10 @@ function DesktopDatetimepicker({
   // newValue is string
   const handleTimestamp = newValue => {
     const asNumber = Number(newValue);
-    if (
-      Number.isNaN(asNumber) ||
-      !moment(asNumber).isValid() ||
-      moment(asNumber).valueOf() !== asNumber
-    ) {
-      // TODO handle error?
+    try {
+      DateTime.fromMillis(asNumber);
+    } catch (e) {
+      // If the value is not a valid timestamp, we don't change it
       return;
     }
     onChange(asNumber);
@@ -159,7 +157,7 @@ function DesktopDatetimepicker({
         options={options}
         inputId={inputId}
         onChange={time => {
-          const currentTime = moment(value).format('HH:mm');
+          const currentTime = DateTime.fromMillis(value).toFormat('HH:mm');
           const ts = getTs(displayValue, value);
           if (typing) {
             if (ts !== null) {

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState, useRef, useLayoutEffect } from 'react';
-import moment from 'moment-timezone';
+import { DateTime, Settings } from 'luxon';
 import Autosuggest from 'react-autosuggest';
 import styles from './styles.scss';
 import { isAndroid } from './mobileDetection';
@@ -19,13 +19,12 @@ function MobileDatepicker({
   icon,
   timeZone,
 }) {
-  moment.tz.setDefault(timeZone);
-
+  Settings.defaultZone = timeZone;
   const [open, changeOpen] = useState(false);
   const scrollRef = useRef(null);
   const dateChoices = Array(itemCount)
     .fill()
-    .map((_, i) => moment(startTime).add(i, 'day').valueOf());
+    .map((_, i) => DateTime.fromMillis(startTime).plus({ days: i }).toMillis());
   const minute = 1000 * 60;
   const diffs = dateChoices.map(t => value - t);
   const scrollIndex = diffs.findIndex(t => t < minute); // when time is now, the times might differ by less than one minute

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useRef, useLayoutEffect, useState } from 'react';
-import moment from 'moment-timezone';
+import { Settings } from 'luxon';
 import cx from 'classnames';
 import styles from './styles.scss';
 import { parseTypedTime, getTs, validateInput } from './utils';
@@ -19,7 +19,7 @@ function MobileTimepicker({
 }) {
   const [inputValue, changeInputValue] = useState(getDisplay(value));
   const [isValidInput, setValidInput] = useState(true);
-  moment.tz.setDefault(timeZone);
+  Settings.defaultZone = timeZone;
   const inputId = `${id}-input`;
   const labelId = `${id}-label`;
   const timeInputRef = useRef(null);

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/utils.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/utils.js
@@ -1,4 +1,4 @@
-import moment from 'moment-timezone';
+import { DateTime } from 'luxon';
 
 /**
  * Handle typing time and adding necessary :
@@ -104,9 +104,13 @@ export const getTs = (inputValue, currentTimestamp) => {
     if (!minutesValid || !hoursValid) {
       return null;
     }
-    const newStamp = moment(currentTimestamp)
-      .hours(hours)
-      .minutes(minutes)
+    const newStamp = DateTime.fromMillis(currentTimestamp)
+      .set({
+        hour: hours,
+        minute: minutes,
+        second: 0,
+        millisecond: 0,
+      })
       .valueOf();
     return newStamp;
   }

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/index.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
-import moment from 'moment-timezone';
+import { Settings, DateTime } from 'luxon';
 import debounce from 'lodash/debounce';
 import Datetimepicker from './helpers/Datetimepicker';
 
@@ -61,9 +61,9 @@ function DatetimepickerStateContainer({
   onClose,
   openPicker,
 }) {
-  moment.locale(lang);
-  moment.tz.setDefault(timeZone);
-  const initialNow = realtime ? null : moment().valueOf();
+  Settings.defaultLocale = lang;
+  Settings.defaultZone = timeZone;
+  const initialNow = realtime ? null : DateTime.now().toMillis();
   const [timestamp, changeTimestampState] = useState(
     initialTimestamp ? initialTimestamp * 1000 : initialNow,
   );
@@ -93,9 +93,9 @@ function DatetimepickerStateContainer({
 
   const timeChanged = debounce(newTime => {
     if (newTime === null) {
-      changeTimestampState(moment().valueOf());
+      changeTimestampState(DateTime.now().toMillis());
       onTimeChange(
-        Math.round(moment().valueOf() / 1000),
+        DateTime.now().toUnixInteger(),
         departureOrArrival === 'arrival',
       );
       return;
@@ -106,9 +106,9 @@ function DatetimepickerStateContainer({
 
   const dateChanged = debounce(newDate => {
     if (newDate === null) {
-      changeTimestampState(moment().valueOf());
+      changeTimestampState(DateTime.now().toMillis());
       onDateChange(
-        Math.round(moment().valueOf() / 1000),
+        DateTime.now().toUnixInteger(),
         departureOrArrival === 'arrival',
       );
       return;
@@ -119,7 +119,7 @@ function DatetimepickerStateContainer({
 
   const nowClicked = () => {
     changeDepartureOrArrival('departure');
-    const newTimestamp = realtime ? null : moment().valueOf();
+    const newTimestamp = realtime ? null : DateTime.now().toMillis();
     changeTimestampState(newTimestamp);
     onNowClick(Math.round(newTimestamp / 1000));
   };
@@ -128,7 +128,7 @@ function DatetimepickerStateContainer({
     let changed = false;
     let newTime = timestamp;
     if (timestamp === null) {
-      const now = moment().valueOf();
+      const now = DateTime.now().toMillis();
       changeTimestampState(now);
       newTime = now;
       changed = true;
@@ -146,7 +146,7 @@ function DatetimepickerStateContainer({
     let changed = false;
     let newTime = timestamp;
     if (timestamp === null) {
-      const now = moment().valueOf();
+      const now = DateTime.now().toMillis();
       changeTimestampState(now);
       newTime = now;
       changed = true;

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@digitransit-component/digitransit-component-autosuggest": "^4.0.0",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^4.0.7",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^5.0.0",
     "@digitransit-component/digitransit-component-control-panel": "^2.0.1",
     "@digitransit-component/digitransit-component-favourite-bar": "2.0.8",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^2.0.4",

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component",
-  "version": "1.2.17",
+  "version": "2.0.0",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-component",
   "module": "digitransit-component.mjs",
@@ -14,7 +14,7 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^3.0.6",
+    "@digitransit-component/digitransit-component-autosuggest": "^4.0.0",
     "@digitransit-component/digitransit-component-autosuggest-panel": "^4.0.7",
     "@digitransit-component/digitransit-component-control-panel": "^2.0.1",
     "@digitransit-component/digitransit-component-favourite-bar": "2.0.8",
@@ -35,6 +35,7 @@
     "i18next": "^22.5.1",
     "lodash": "4.17.21",
     "lodash-es": "4.17.21",
+    "luxon": "^3.6.1",
     "prop-types": "^15.8.1",
     "react": "^16.13.0",
     "react-autosuggest": "^10.0.0",

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-query-utils",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "digitransit-search-util query-utils module",
   "main": "lib/index.js",
   "publishConfig": {
@@ -30,7 +30,6 @@
   "peerDependencies": {
     "graphql": "16.8.1",
     "lodash": "4.17.21",
-    "moment": "2.30.1",
     "react-relay": "16.2.0"
   },
   "devDependencies": {

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/src/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/src/index.js
@@ -3,7 +3,6 @@ import take from 'lodash/take';
 import flatten from 'lodash/flatten';
 import uniq from 'lodash/uniq';
 import compact from 'lodash/compact';
-import moment from 'moment';
 import { fetchQuery, graphql } from 'react-relay';
 import routeNameCompare from '@digitransit-search-util/digitransit-search-util-route-name-compare';
 import {
@@ -508,7 +507,7 @@ export function withCurrentTime(location) {
     ...location,
     query: {
       ...query,
-      time: query.time ? query.time : moment().unix(),
+      time: query.time ? query.time : Math.floor(new Date().getTime() / 1000),
     },
   };
 }

--- a/digitransit-util/packages/digitransit-util-enrich-patterns/package.json
+++ b/digitransit-util/packages/digitransit-util-enrich-patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-util/digitransit-util-enrich-patterns",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "digitransit-util enrich-patterns module",
   "main": "index.js",
   "scripts": {
@@ -23,6 +23,7 @@
   },
   "peerDependencies": {
     "lodash": "4.17.21",
-    "lodash-es": "4.17.21"
+    "lodash-es": "4.17.21",
+    "luxon": "^3.6.1"
   }
 }

--- a/digitransit-util/packages/digitransit-util-enrich-patterns/test.js
+++ b/digitransit-util/packages/digitransit-util-enrich-patterns/test.js
@@ -1,43 +1,53 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import enrichPatterns from '.';
+
+const DATE_FORMAT = 'yyyyLLdd';
 
 describe('Testing @digitransit-util/digitransit-util-enrich-patterns module', () => {
   const nextFridaysAndSaturdays = [];
   nextFridaysAndSaturdays.push(
-    JSON.parse(`{ "day": ["${moment(moment()).day(5).format('YYYYMMDD')}"] }`),
-  );
-  nextFridaysAndSaturdays.push(
-    JSON.parse(`{ "day": ["${moment(moment()).day(6).format('YYYYMMDD')}"] }`),
-  );
-  nextFridaysAndSaturdays.push(
     JSON.parse(
-      `{ "day": ["${moment(moment())
-        .day(5 + 7)
-        .format('YYYYMMDD')}"] }`,
+      `{ "day": ["${DateTime.now()
+        .set({ weekday: 5 })
+        .toFormat(DATE_FORMAT)}"] }`,
     ),
   );
   nextFridaysAndSaturdays.push(
     JSON.parse(
-      `{ "day": ["${moment(moment())
-        .day(6 + 7)
-        .format('YYYYMMDD')}"] }`,
+      `{ "day": ["${DateTime.now()
+        .set({ weekday: 6 })
+        .toFormat(DATE_FORMAT)}"] }`,
     ),
   );
   nextFridaysAndSaturdays.push(
     JSON.parse(
-      `{ "day": ["${moment(moment())
-        .day(5 + 14)
-        .format('YYYYMMDD')}"] }`,
+      `{ "day": ["${DateTime.now()
+        .set({ weekday: 5 + 7 })
+        .toFormat(DATE_FORMAT)}"] }`,
     ),
   );
   nextFridaysAndSaturdays.push(
     JSON.parse(
-      `{ "day": ["${moment(moment())
-        .day(6 + 14)
-        .format('YYYYMMDD')}"] }`,
+      `{ "day": ["${DateTime.now()
+        .set({ weekday: 6 + 7 })
+        .toFormat(DATE_FORMAT)}"] }`,
+    ),
+  );
+  nextFridaysAndSaturdays.push(
+    JSON.parse(
+      `{ "day": ["${DateTime.now()
+        .set({ weekday: 5 + 14 })
+        .toFormat(DATE_FORMAT)}"] }`,
+    ),
+  );
+  nextFridaysAndSaturdays.push(
+    JSON.parse(
+      `{ "day": ["${DateTime.now()
+        .set({ weekday: 6 + 14 })
+        .toFormat(DATE_FORMAT)}"] }`,
     ),
   );
 

--- a/digitransit-util/packages/digitransit-util-route-pattern-option-text/index.js
+++ b/digitransit-util/packages/digitransit-util-route-pattern-option-text/index.js
@@ -2,13 +2,13 @@
 /* eslint-disable no-nested-ternary */
 /* eslint no-bitwise: ["error", { "allow": [">>"] }] */
 
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import i18next from 'i18next';
 import translations from './helpers/translations';
 
-const DATE_FORMAT = 'YYYYMMDD';
-const DATE_FORMAT2 = 'D.M.';
-const DATE_FORMAT3 = 'D.';
+const DATE_FORMAT = 'yyyyLLdd';
+const DATE_FORMAT2 = 'd.L.';
+const DATE_FORMAT3 = 'd.';
 
 i18next.init({ lng: 'en', resources: {} });
 
@@ -70,15 +70,11 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
     pattern.rangeFollowingDays !== undefined &&
     pattern.rangeFollowingDays.length === 1 &&
     pattern.fromDate !== '-' &&
-    pattern.fromDate !== 'Invalid date' &&
+    pattern.fromDate !== 'Invalid DateTime' &&
     pattern.untilDate !== '-' &&
-    pattern.untilDate !== 'Invalid date' &&
-    ((moment(pattern.lastRangeDate).isAfter(
-      moment(pattern.rangeFollowingDays[0][1]),
-    ) &&
-      moment(pattern.currentDate).isBefore(
-        moment(pattern.rangeFollowingDays[0][1]),
-      )) ||
+    pattern.untilDate !== 'Invalid DateTime' &&
+    ((pattern.lastRangeDate > pattern.rangeFollowingDays[0][1] &&
+      pattern.currentDate < pattern.rangeFollowingDays[0][1]) ||
       pattern.fromDate === pattern.untilDate)
   ) {
     retValue += ' (';
@@ -91,7 +87,10 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
       });
     }
 
-    retValue += moment(pattern.rangeFollowingDays[0][0], DATE_FORMAT).format(
+    retValue += DateTime.fromFormat(
+      pattern.rangeFollowingDays[0][0],
+      DATE_FORMAT,
+    ).toFormat(
       pattern.rangeFollowingDays[0][1] === 0
         ? DATE_FORMAT2
         : (pattern.rangeFollowingDays[0][0] / 100) >> 0 ===
@@ -105,9 +104,10 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
       pattern.rangeFollowingDays[0][1] !== 0
     ) {
       retValue += '-';
-      retValue += moment(pattern.rangeFollowingDays[0][1], DATE_FORMAT).format(
-        DATE_FORMAT2,
-      );
+      retValue += DateTime.fromFormat(
+        pattern.rangeFollowingDays[0][1],
+        DATE_FORMAT,
+      ).toFormat(DATE_FORMAT2);
     }
     retValue += ')';
     return retValue;
@@ -122,7 +122,10 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
     pattern.dayString === '-'
   ) {
     retValue += ' (';
-    retValue += moment(pattern.rangeFollowingDays[0][0], DATE_FORMAT).format(
+    retValue += DateTime.fromFormat(
+      pattern.rangeFollowingDays[0][0],
+      DATE_FORMAT,
+    ).toFormat(
       pattern.rangeFollowingDays[0][0] !== pattern.rangeFollowingDays[0][1] &&
         (pattern.rangeFollowingDays[0][0] / 100) >> 0 ===
           (pattern.rangeFollowingDays[0][1] / 100) >> 0
@@ -131,11 +134,15 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
     );
     if (pattern.rangeFollowingDays[0][1] !== pattern.rangeFollowingDays[0][0]) {
       retValue += '-';
-      retValue += moment(pattern.rangeFollowingDays[0][1], DATE_FORMAT).format(
-        DATE_FORMAT2,
-      );
+      retValue += DateTime.fromFormat(
+        pattern.rangeFollowingDays[0][1],
+        DATE_FORMAT,
+      ).toFormat(DATE_FORMAT2);
       retValue += ', ';
-      retValue += moment(pattern.rangeFollowingDays[1][0], DATE_FORMAT).format(
+      retValue += DateTime.fromFormat(
+        pattern.rangeFollowingDays[1][0],
+        DATE_FORMAT,
+      ).toFormat(
         pattern.rangeFollowingDays[1][0] !== pattern.rangeFollowingDays[1][1] &&
           (pattern.rangeFollowingDays[1][0] / 100) >> 0 ===
             (pattern.rangeFollowingDays[1][1] / 100) >> 0
@@ -146,19 +153,21 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
 
     if (pattern.rangeFollowingDays[1][1] !== pattern.rangeFollowingDays[1][0]) {
       retValue += '-';
-      retValue += moment(pattern.rangeFollowingDays[1][1], DATE_FORMAT).format(
-        DATE_FORMAT2,
-      );
+      retValue += DateTime.fromFormat(
+        pattern.rangeFollowingDays[1][1],
+        DATE_FORMAT,
+      ).toFormat(DATE_FORMAT2);
     }
     if (pattern.rangeFollowingDays.length > 2) {
       retValue += ', ';
-      retValue += moment(pattern.rangeFollowingDays[2][0], DATE_FORMAT).format(
+      retValue += DateTime.fromFormat(
+        pattern.rangeFollowingDays[2][0],
+        DATE_FORMAT,
+      ).toFormat(
         pattern.rangeFollowingDays[2][0] !== pattern.rangeFollowingDays[2][1] &&
           (pattern.rangeFollowingDays[2][0] / 100) >> 0 ===
             (pattern.rangeFollowingDays[2][1] / 100) >> 0 &&
-          moment(pattern.lastRangeDate).isAfter(
-            moment(pattern.rangeFollowingDays[2][1], DATE_FORMAT),
-          )
+          pattern.lastRangeDate > pattern.rangeFollowingDays[2][1]
           ? DATE_FORMAT3
           : DATE_FORMAT2,
       );
@@ -168,12 +177,12 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
       ) {
         retValue += '-';
         retValue +=
-          moment(pattern.lastRangeDate).isAfter(
-            moment(pattern.rangeFollowingDays[2][1], DATE_FORMAT),
-          ) || pattern.rangeFollowingDays.length > 3
-            ? moment(pattern.rangeFollowingDays[2][1], DATE_FORMAT).format(
-                DATE_FORMAT2,
-              )
+          pattern.lastRangeDate > pattern.rangeFollowingDays[2][1] ||
+          pattern.rangeFollowingDays.length > 3
+            ? DateTime.fromFormat(
+                pattern.rangeFollowingDays[2][1],
+                DATE_FORMAT,
+              ).toFormat(DATE_FORMAT2)
             : '';
       }
       if (pattern.rangeFollowingDays.length > 3) {
@@ -214,15 +223,16 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
     pattern.untilDate !== '-' &&
     pattern.dayString === 'ma-su' &&
     pattern.untilDate !== 'Invalid date' &&
-    moment(pattern.untilDate, DATE_FORMAT).format(DATE_FORMAT2) !==
-      'Invalid date'
+    DateTime.fromFormat(pattern.untilDate, DATE_FORMAT).isValid
   ) {
     retValue += translateText({
       id: 'route-pattern-select-until',
       range: translateText({
         id: `route-pattern-select-range-${pattern.dayString}`,
       }).replace(/\(|\)| /gi, ''),
-      day: moment(pattern.untilDate, DATE_FORMAT).format(DATE_FORMAT2),
+      day: DateTime.fromFormat(pattern.untilDate, DATE_FORMAT).toFormat(
+        DATE_FORMAT2,
+      ),
     }).replace(/\( {2}|\( |\(/gi, '(');
     return retValue;
   }
@@ -232,15 +242,16 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
     pattern.untilDate !== '-' &&
     pattern.dayString !== 'ma-su' &&
     pattern.untilDate !== 'Invalid date' &&
-    moment(pattern.untilDate, DATE_FORMAT).format(DATE_FORMAT2) !==
-      'Invalid date'
+    DateTime.fromFormat(pattern.untilDate, DATE_FORMAT).isValid
   ) {
     retValue += translateText({
       id: 'route-pattern-select-until',
       range: translateText({
         id: `route-pattern-select-range-${pattern.dayString}`,
       }).replace(/\(|\)/gi, ''),
-      day: moment(pattern.untilDate, DATE_FORMAT).format(DATE_FORMAT2),
+      day: DateTime.fromFormat(pattern.untilDate, DATE_FORMAT).toFormat(
+        DATE_FORMAT2,
+      ),
     }).replace(/\( {2}|\( |\(/gi, '(');
     return retValue;
   }
@@ -249,15 +260,16 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
   if (
     pattern.fromDate !== '-' &&
     pattern.dayString === 'ma-su' &&
-    moment(pattern.fromDate, DATE_FORMAT).format(DATE_FORMAT2) !==
-      'Invalid date'
+    DateTime.fromFormat(pattern.fromDate, DATE_FORMAT).isValid
   ) {
     retValue += translateText({
       id: 'route-pattern-select-from',
       range: translateText({
         id: `route-pattern-select-range-${pattern.dayString}`,
       }).replace(/\(|\)| /gi, ''),
-      day: moment(pattern.fromDate, DATE_FORMAT).format(DATE_FORMAT2),
+      day: DateTime.fromFormat(pattern.fromDate, DATE_FORMAT).toFormat(
+        DATE_FORMAT2,
+      ),
     }).replace(/\( {2}|\( |\(/gi, '(');
     return retValue;
   }
@@ -266,15 +278,16 @@ export default function routePatternOptionText(language, pattern, isTogglable) {
   if (
     pattern.fromDate !== '-' &&
     pattern.dayString !== 'ma-su' &&
-    moment(pattern.fromDate, DATE_FORMAT).format(DATE_FORMAT2) !==
-      'Invalid date'
+    DateTime.fromFormat(pattern.fromDate, DATE_FORMAT).isValid
   ) {
     retValue += translateText({
       id: 'route-pattern-select-from',
       range: translateText({
         id: `route-pattern-select-range-${pattern.dayString}`,
       }).replace(/\(|\)/gi, ''),
-      day: moment(pattern.fromDate, DATE_FORMAT).format(DATE_FORMAT2),
+      day: DateTime.fromFormat(pattern.fromDate, DATE_FORMAT).toFormat(
+        DATE_FORMAT2,
+      ),
     }).replace(/\( {2}|\( |\(/gi, '(');
     return retValue;
   }

--- a/digitransit-util/packages/digitransit-util-route-pattern-option-text/package.json
+++ b/digitransit-util/packages/digitransit-util-route-pattern-option-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-util/digitransit-util-route-pattern-option-text",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "digitransit-util route-pattern-option-text module",
   "main": "index.js",
   "scripts": {
@@ -21,6 +21,7 @@
     "i18next": "^19.2.0",
     "i18next-xhr-backend": "^3.2.2",
     "lodash": "4.17.21",
-    "lodash-es": "4.17.21"
+    "lodash-es": "4.17.21",
+    "luxon": "^3.6.1"
   }
 }

--- a/digitransit-util/packages/digitransit-util-route-pattern-option-text/test.js
+++ b/digitransit-util/packages/digitransit-util-route-pattern-option-text/test.js
@@ -2,7 +2,7 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import cloneDeep from 'lodash/cloneDeep';
 import routePatternOptionText from '.';
 
@@ -25,9 +25,9 @@ const fd1 = [];
 const fd2 = [];
 const fd3 = [];
 ad.forEach(function (d) {
-  fd1.push(moment(d.day[0], 'YYYYMMDD').format('D.'));
-  fd2.push(moment(d.day[0], 'YYYYMMDD').format('D.M.'));
-  fd3.push(moment(d.day[0], 'YYYYMMDD').format('YYYYMMDD'));
+  fd1.push(DateTime.fromFormat(d.day[0], 'yyyyLLdd').toFormat('d.'));
+  fd2.push(DateTime.fromFormat(d.day[0], 'yyyyLLdd').toFormat('d.L.'));
+  fd3.push(DateTime.fromFormat(d.day[0], 'yyyyLLdd').toFormat('yyyyLLdd'));
 });
 
 const tests = [
@@ -215,8 +215,8 @@ const defPattern = {
   headsign: 'Kirkkonummi',
   stops: [{ name: 'Helsinki' }, { name: 'Kirkkonummi' }],
   tripsForDate: [],
-  lastRangeDate: moment('20200330').format('YYYYMMDD'),
-  currentDate: moment('20200220').format('YYYYMMDD'),
+  lastRangeDate: '20200330',
+  currentDate: '20200220',
 };
 
 describe('Testing @digitransit-util/digitransit-util-route-pattern-option-text module', () => {

--- a/digitransit-util/packages/digitransit-util/package.json
+++ b/digitransit-util/packages/digitransit-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-util/digitransit-util",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-util",
   "module": "digitransit-util.mjs",
@@ -16,7 +16,7 @@
   "dependencies": {
     "@digitransit-util/digitransit-util-day-range-allowed-diff": "^1.0.4",
     "@digitransit-util/digitransit-util-day-range-pattern": "^1.1.0",
-    "@digitransit-util/digitransit-util-enrich-patterns": "^1.1.3",
-    "@digitransit-util/digitransit-util-route-pattern-option-text": "^1.1.3"
+    "@digitransit-util/digitransit-util-enrich-patterns": "^2.0.0",
+    "@digitransit-util/digitransit-util-route-pattern-option-text": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -169,8 +169,6 @@
     "lodash": "4.17.21",
     "lru-cache": "6.0.0",
     "luxon": "^3.6.1",
-    "moment": "2.30.1",
-    "moment-timezone": "0.5.48",
     "morgan": "1.10.0",
     "mqtt": "4.3.8",
     "node-fetch": "2.6.7",

--- a/server/passport-openid-connect/Strategy.js
+++ b/server/passport-openid-connect/Strategy.js
@@ -3,7 +3,6 @@
 'use strict';
 
 const { Issuer, Strategy, custom } = require('openid-client');
-const moment = require('moment');
 const util = require('util');
 const process = require('process');
 const User = require('./User').User;
@@ -62,7 +61,7 @@ OICStrategy.prototype.authenticate = function auth(req, opts) {
   const cookieLang = req.cookies.lang || 'fi';
   const { ssoValidTo, ssoToken } = req.session;
   const authurl =
-    ssoValidTo && ssoValidTo > moment().unix()
+    ssoValidTo && ssoValidTo > Math.floor(new Date().getTime() / 1000)
       ? this.createAuthUrl(redirectUri, cookieLang, ssoToken)
       : this.createAuthUrl(redirectUri, cookieLang);
   if (debugLogging) {

--- a/server/passport-openid-connect/openidConnect.js
+++ b/server/passport-openid-connect/openidConnect.js
@@ -3,7 +3,6 @@ const passport = require('passport');
 const session = require('express-session');
 const redis = require('redis');
 const axios = require('axios');
-const moment = require('moment');
 const RedisStore = require('connect-redis')(session);
 const LoginStrategy = require('./Strategy').Strategy;
 
@@ -88,7 +87,7 @@ export default function setUpOIDC(app, port, indexPath, hostnames) {
       !req.isAuthenticated() &&
       ssoToken &&
       ssoValidTo &&
-      ssoValidTo > moment().unix()
+      ssoValidTo > Math.floor(new Date().getTime() / 1000)
     ) {
       const params = Object.keys(req.query)
         .map(k => `${k}=${req.query[k]}`)
@@ -109,7 +108,7 @@ export default function setUpOIDC(app, port, indexPath, hostnames) {
     if (
       req.isAuthenticated() &&
       req.user.token.refresh_token &&
-      moment().unix() >= req.user.token.expires_at
+      Math.floor(new Date().getTime() / 1000) >= req.user.token.expires_at
     ) {
       return passport.authenticate('passport-openid-connect', {
         refresh: true,
@@ -237,7 +236,8 @@ export default function setUpOIDC(app, port, indexPath, hostnames) {
       }
       req.session.ssoToken = req.query['sso-token'];
       req.session.ssoValidTo =
-        Number(req.query['sso-validity']) * 60 * 1000 + moment().unix();
+        Number(req.query['sso-validity']) * 60 * 1000 +
+        Math.floor(new Date().getTime() / 1000);
       res.send();
     }
   });

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -25,7 +25,6 @@ const isProduction = mode === 'production';
 const isDevelopment = !isProduction;
 
 const languageExp = new RegExp(`^./(${languages.join('|')})$`);
-const momentExpression = /moment[/\\]locale$/;
 const reactIntlExpression = /react-intl[/\\]locale-data$/;
 const intlExpression = /intl[/\\]locale-data[/\\]jsonp$/;
 const themeExpression = /sass[/\\]themes$/;
@@ -236,7 +235,6 @@ module.exports = {
       ? false
       : process.env.WEBPACK_DEVTOOL || (isProduction ? 'source-map' : 'eval'),
   plugins: [
-    new webpack.ContextReplacementPlugin(momentExpression, languageExp),
     new webpack.ContextReplacementPlugin(reactIntlExpression, languageExp),
     new webpack.ContextReplacementPlugin(intlExpression, languageExp),
     ...(isDevelopment
@@ -282,7 +280,6 @@ module.exports = {
     alias: {
       lodash: 'lodash-es',
       'lodash.merge': 'lodash-es/merge',
-      moment$: 'moment/moment.js',
       'babel-runtime/helpers/slicedToArray': path.join(
         __dirname,
         'app/util/slicedToArray',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,7 +2000,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^3.0.6
+    "@digitransit-component/digitransit-component-autosuggest": ^4.0.0
     "@digitransit-component/digitransit-component-icon": ^1.0.2
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
@@ -2016,7 +2016,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@^3.0.6, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@^4.0.0, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
@@ -2033,6 +2033,7 @@ __metadata:
     i18next: ^22.5.1
     lodash: 4.17.21
     lodash-es: 4.17.21
+    luxon: ^3.6.1
     prop-types: ^15.8.1
     react: ^16.13.0
     react-autosuggest: ^10.0.0
@@ -2063,8 +2064,7 @@ __metadata:
     i18next: ^22.5.1
     lodash: 4.17.21
     lodash-es: 4.17.21
-    moment: 2.30.1
-    moment-timezone: 0.5.45
+    luxon: ^3.6.1
     prop-types: ^15.8.1
     react: ^16.13.0
     react-autosuggest: ^10.0.0
@@ -2206,7 +2206,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^3.0.6
+    "@digitransit-component/digitransit-component-autosuggest": ^4.0.0
     "@digitransit-component/digitransit-component-autosuggest-panel": ^4.0.7
     "@digitransit-component/digitransit-component-control-panel": ^2.0.1
     "@digitransit-component/digitransit-component-favourite-bar": 2.0.8
@@ -2226,6 +2226,7 @@ __metadata:
     i18next: ^22.5.1
     lodash: 4.17.21
     lodash-es: 4.17.21
+    luxon: ^3.6.1
     prop-types: ^15.8.1
     react: ^16.13.0
     react-autosuggest: ^10.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2316,7 +2316,6 @@ __metadata:
   peerDependencies:
     graphql: 16.8.1
     lodash: 4.17.21
-    moment: 2.30.1
     react-relay: 16.2.0
   languageName: unknown
   linkType: soft
@@ -2383,7 +2382,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-util/digitransit-util-enrich-patterns@^1.1.3, @digitransit-util/digitransit-util-enrich-patterns@workspace:digitransit-util/packages/digitransit-util-enrich-patterns":
+"@digitransit-util/digitransit-util-enrich-patterns@^2.0.0, @digitransit-util/digitransit-util-enrich-patterns@workspace:digitransit-util/packages/digitransit-util-enrich-patterns":
   version: 0.0.0-use.local
   resolution: "@digitransit-util/digitransit-util-enrich-patterns@workspace:digitransit-util/packages/digitransit-util-enrich-patterns"
   dependencies:
@@ -2392,10 +2391,11 @@ __metadata:
   peerDependencies:
     lodash: 4.17.21
     lodash-es: 4.17.21
+    luxon: ^3.6.1
   languageName: unknown
   linkType: soft
 
-"@digitransit-util/digitransit-util-route-pattern-option-text@^1.1.3, @digitransit-util/digitransit-util-route-pattern-option-text@workspace:digitransit-util/packages/digitransit-util-route-pattern-option-text":
+"@digitransit-util/digitransit-util-route-pattern-option-text@^2.0.0, @digitransit-util/digitransit-util-route-pattern-option-text@workspace:digitransit-util/packages/digitransit-util-route-pattern-option-text":
   version: 0.0.0-use.local
   resolution: "@digitransit-util/digitransit-util-route-pattern-option-text@workspace:digitransit-util/packages/digitransit-util-route-pattern-option-text"
   peerDependencies:
@@ -2403,6 +2403,7 @@ __metadata:
     i18next-xhr-backend: ^3.2.2
     lodash: 4.17.21
     lodash-es: 4.17.21
+    luxon: ^3.6.1
   languageName: unknown
   linkType: soft
 
@@ -2412,8 +2413,8 @@ __metadata:
   dependencies:
     "@digitransit-util/digitransit-util-day-range-allowed-diff": ^1.0.4
     "@digitransit-util/digitransit-util-day-range-pattern": ^1.1.0
-    "@digitransit-util/digitransit-util-enrich-patterns": ^1.1.3
-    "@digitransit-util/digitransit-util-route-pattern-option-text": ^1.1.3
+    "@digitransit-util/digitransit-util-enrich-patterns": ^2.0.0
+    "@digitransit-util/digitransit-util-route-pattern-option-text": ^2.0.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11117,8 +11117,6 @@ __metadata:
     mocha: 11.2.2
     mock-local-storage: 1.1.24
     mockdate: 3.0.5
-    moment: 2.30.1
-    moment-timezone: 0.5.48
     morgan: 1.10.0
     mqtt: 4.3.8
     node-fetch: 2.6.7
@@ -19469,22 +19467,6 @@ __metadata:
   bin:
     module-deps: bin/cmd.js
   checksum: fead1d0bb6bda4618abe6e8befb848a145868322fc67ddba6d25a725e1e944602d1d5558ada9ed0e4a6942237a4d0a4c230747ffe740f7856a9663e92aca25db
-  languageName: node
-  linkType: hard
-
-"moment-timezone@npm:0.5.48":
-  version: 0.5.48
-  resolution: "moment-timezone@npm:0.5.48"
-  dependencies:
-    moment: ^2.29.4
-  checksum: 8a350b30205cc06aa9c029643316f4c0d538e76a3f7a92d74a3214d602377db2a1f8b7719debd4eb3e1fa1bac3de1912c1b94182af4e12810513670b578c84ab
-  languageName: node
-  linkType: hard
-
-"moment@npm:2.30.1, moment@npm:^2.29.4":
-  version: 2.30.1
-  resolution: "moment@npm:2.30.1"
-  checksum: 859236bab1e88c3e5802afcf797fc801acdbd0ee509d34ea3df6eea21eb6bcc2abd4ae4e4e64aa7c986aa6cba563c6e62806218e6412a765010712e5fa121ba6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,7 +1996,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@^4.0.7, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@^5.0.0, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
@@ -2207,7 +2207,7 @@ __metadata:
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
     "@digitransit-component/digitransit-component-autosuggest": ^4.0.0
-    "@digitransit-component/digitransit-component-autosuggest-panel": ^4.0.7
+    "@digitransit-component/digitransit-component-autosuggest-panel": ^5.0.0
     "@digitransit-component/digitransit-component-control-panel": ^2.0.1
     "@digitransit-component/digitransit-component-favourite-bar": 2.0.8
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^2.0.4


### PR DESCRIPTION
## Proposed Changes

  - Replaces Moment.js in digitransit-util, digitransit-component and digitransit-store
  - Cleanup and remove last moment dependencies in app and server
  - Removes moment and moment-timezone from package.json
  - Removes config.timezoneData as its no longer needed
  - In some instances where we just need a simple unix timestamp, use native date instead of importing luxon or moment
  - **I believe unit-tests for the packages are not included in the CI build**
      - fixing one package would require to fix all of the packages as lerna runs the test commands recursively
### New versions of the packages haven't yet been published to npm as I'd rather wait for a review first
  

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
