### PR TITLE
DT-6464 Fix bug where stop name is not displayed when first leg is a scooter leg

### DIFF
--- a/app/component/itinerary/Itinerary.js
+++ b/app/component/itinerary/Itinerary.js
@@ -742,7 +742,8 @@ const Itinerary = (
               firstDepartureStopType: (
                 <FormattedMessage id={firstDepartureStopType} />
               ),
-              firstDepartureStop: stopNames[0],
+              // In case the first leg is a scooter leg, stopNames[0] is an empty string
+              firstDepartureStop: stopNames[0] || stopNames[1],
               firstDeparturePlatform,
             }}
           />


### PR DESCRIPTION
## Proposed Changes

  - Fixes a bug in Itinerary page where summary text doesn't display the stop name

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
