### PR TITLE
AB#135 Fix TerminalPage bugs related to multiple departures

### DIFF
--- a/app/component/DepartureListContainer.js
+++ b/app/component/DepartureListContainer.js
@@ -324,7 +324,7 @@ class DepartureListContainer extends Component {
         );
       }
 
-      const id = `${departure.pattern.code}:${departure.time}:${departure.trip.gtfsId}`;
+      const id = `${departure.pattern.code}:${departure.time}:${departure.trip.gtfsId}:${departure.stop.gtfsId}`;
       const dropoffMessage = getDropoffMessage(
         departure.hasOnlyDropoff,
         departure.hasNoStop,
@@ -436,6 +436,7 @@ const containerComponent = createFragmentContainer(DepartureListContainer, {
       dropoffType
       headsign
       stop {
+        gtfsId
         id
         code
         platformCode

--- a/app/component/stop/FilterTimeTableModal.js
+++ b/app/component/stop/FilterTimeTableModal.js
@@ -85,12 +85,10 @@ class FilterTimeTableModal extends React.Component {
       )
       .filter(o => o)
       .sort(routeCompare)
-      // deduplicate identical headsign + shortName combinations
+      // deduplicate patterns with same code
       .filter(
-        (li, index, self) =>
-          self
-            .map(route => `${route.headsign}:${route.shortName}`)
-            .indexOf(`${li.headsign}:${li.shortName}`) === index,
+        (pattern, index, self) =>
+          self.map(itm => itm.code).indexOf(pattern.code) === index,
       );
 
     routesWithStopTimes.forEach(o => {

--- a/app/component/stop/FilterTimeTableModal.js
+++ b/app/component/stop/FilterTimeTableModal.js
@@ -84,7 +84,14 @@ class FilterTimeTableModal extends React.Component {
           },
       )
       .filter(o => o)
-      .sort(routeCompare);
+      .sort(routeCompare)
+      // deduplicate identical headsign + shortName combinations
+      .filter(
+        (li, index, self) =>
+          self
+            .map(route => `${route.headsign}:${route.shortName}`)
+            .indexOf(`${li.headsign}:${li.shortName}`) === index,
+      );
 
     routesWithStopTimes.forEach(o => {
       const mode = getRouteMode(o);

--- a/app/component/stop/Timetable.js
+++ b/app/component/stop/Timetable.js
@@ -38,6 +38,7 @@ const mapStopTimes = stoptimesObject =>
           longName: stoptime.pattern.route.longName,
           isCanceled: st.realtimeState === RealtimeStateType.Canceled,
           mode: stoptime.pattern.route.mode,
+          gtfsId: st.stop.gtfsId,
         })),
     )
     .reduce((acc, val) => acc.concat(val), []);
@@ -460,6 +461,9 @@ Timetable.propTypes = {
             realtimeState: PropTypes.string.isRequired,
             scheduledDeparture: PropTypes.number.isRequired,
             serviceDay: PropTypes.number.isRequired,
+            stop: PropTypes.shape({
+              gtfsId: PropTypes.string.isRequired,
+            }).isRequired,
           }),
         ).isRequired,
       }),

--- a/app/component/stop/TimetableRow.js
+++ b/app/component/stop/TimetableRow.js
@@ -33,7 +33,7 @@ const TimetableRow = ({ title, stoptimes, showRoutes, timerows }, { intl }) => (
             className={cx('timetablerow-linetime', {
               canceled: time.isCanceled,
             })}
-            key={`${time.id}-${time.name}-${time.scheduledDeparture}`}
+            key={`${time.id}-${time.name}-${time.scheduledDeparture}-${time.gtfsId}`}
           >
             <div className="sr-only">
               {time.isCanceled ? intl.formatMessage({ id: 'canceled' }) : ''}
@@ -70,6 +70,7 @@ TimetableRow.propTypes = {
       name: PropTypes.string.isRequired,
       serviceDay: PropTypes.number.isRequired,
       scheduledDeparture: PropTypes.number.isRequired,
+      gtfsId: PropTypes.string,
     }),
   ).isRequired,
   showRoutes: PropTypes.arrayOf(PropTypes.string),

--- a/app/component/stop/queries/TimetableFragment.js
+++ b/app/component/stop/queries/TimetableFragment.js
@@ -29,6 +29,9 @@ export const TimetableFragment = graphql`
         serviceDay
         headsign
         pickupType
+        stop {
+          gtfsId
+        }
       }
     }
   }

--- a/app/util/shapes.js
+++ b/app/util/shapes.js
@@ -170,6 +170,10 @@ export const stopTimeShape = PropTypes.shape({
   trip: tripShape,
   dropoffType: PropTypes.string,
   pickupType: PropTypes.string,
+  stop: PropTypes.shape({
+    platformCode: PropTypes.string,
+    gtfsId: PropTypes.string,
+  }),
 });
 
 export const stopShape = PropTypes.shape({

--- a/test/unit/component/Timetable.test.js
+++ b/test/unit/component/Timetable.test.js
@@ -38,6 +38,9 @@ const props = {
             realtimeState: 'CANCELED',
             scheduledDeparture: 32460,
             serviceDay: 1547071200,
+            stop: {
+              gtfsId: `HSL:${stopIdNumber}`,
+            },
           },
         ],
       },


### PR DESCRIPTION
## Proposed Changes

  - Leverages stoptime.stop.gtfsId in addition to other fields to make keys unique in case the same pattern departs at the same time on different platforms
  - This was broken in both DepartureList and TimetablePage
  - In addition fixes a bug where the same pattern was displayed multiple times in the filter modal, which was related to the same issue

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
