### PR TITLE
AB#114 Scale component height if stop description goes over one line

### DIFF
--- a/app/component/routepage/route.scss
+++ b/app/component/routepage/route.scss
@@ -239,7 +239,7 @@ $margin-left-right: 21.3px;
   align-items: center;
   height: 1.125em;
   min-width: calc(100% - 13% - 15px);
-  margin-bottom: 5px;
+  margin-bottom: 3px;
   flex-direction: row;
   font-family: $font-family;
 }
@@ -461,7 +461,9 @@ $margin-left-right: 21.3px;
       .route-details-bottom-row {
         display: flex;
         align-items: center;
-        height: 1em;
+        text-align: left;
+        min-height: 1em;
+        height: auto;
         justify-content: space-between;
 
         .route-address-container {


### PR DESCRIPTION
## Proposed Changes

  - Fixes css on route page so that long stop descriptions are shown properly

**BEFORE**
<img width="559" height="732" alt="image" src="https://github.com/user-attachments/assets/52438e7f-e6c0-416d-a398-17756f735035" />

**AFTER**
<img width="541" height="718" alt="image" src="https://github.com/user-attachments/assets/feb326a9-df4a-47d8-ae8f-a6e1e65f4f58" />


## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
