### PR TITLE
DT-6960 Add explicit near you modes to waltti cities

### DIFF
--- a/app/configurations/config.kotka.js
+++ b/app/configurations/config.kotka.js
@@ -46,6 +46,8 @@ export default configMerger(walttiConfig, {
     },
   },
 
+  nearYouModes: ['bus', 'ferry', 'citybike'],
+
   vehicleRental: {
     networks: {
       donkey_kotka: {

--- a/app/configurations/config.kouvola.js
+++ b/app/configurations/config.kouvola.js
@@ -41,6 +41,8 @@ export default configMerger(walttiConfig, {
     },
   },
 
+  nearYouModes: ['bus', 'citybike'],
+
   vehicleRental: {
     networks: {
       donkey_kouvola: {

--- a/app/configurations/config.kuopio.js
+++ b/app/configurations/config.kuopio.js
@@ -106,6 +106,8 @@ export default configMerger(walttiConfig, {
     },
   },
 
+  nearYouModes: ['bus', 'rail', 'citybike'],
+
   menu: {
     copyright: { label: `© Kuopio ${walttiConfig.YEAR}` },
     content: [

--- a/app/configurations/config.lahti.js
+++ b/app/configurations/config.lahti.js
@@ -147,6 +147,8 @@ export default configMerger(walttiConfig, {
     },
   },
 
+  nearYouModes: ['bus', 'citybike'],
+
   vehicleRental: {
     networks: {
       freebike_lahti: {

--- a/app/configurations/config.lappeenranta.js
+++ b/app/configurations/config.lappeenranta.js
@@ -61,6 +61,8 @@ export default configMerger(walttiConfig, {
     },
   },
 
+  nearYouModes: ['bus', 'citybike'],
+
   feedIds: ['Lappeenranta'],
 
   useSearchPolygon: true,

--- a/app/configurations/config.tampere.js
+++ b/app/configurations/config.tampere.js
@@ -301,6 +301,8 @@ export default configMerger(walttiConfig, {
     },
   },
 
+  nearYouModes: ['bus', 'tram', 'rail', 'citybike'],
+
   bikeBoardingModes: {
     RAIL: { showNotification: true },
     TRAM: { showNotification: true },

--- a/app/configurations/config.varely.js
+++ b/app/configurations/config.varely.js
@@ -74,6 +74,8 @@ export default configMerger(walttiConfig, {
     },
   },
 
+  nearYouModes: ['bus', 'ferry'],
+
   searchParams: {
     'boundary.rect.min_lat': minLat,
     'boundary.rect.max_lat': maxLat,

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -144,6 +144,7 @@ export default {
     },
   },
 
+  nearYouModes: ['bus'],
   nearbyModeSet: 'waltti',
 
   maxNearbyStopDistance: {


### PR DESCRIPTION
## Proposed Changes

 Add nearby modes for waltti cities, since setting them without them them taxi gets included

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
