### PR TITLE
AB#107 Fix Autosuggest icons to use route.color if it is available

### DIFF
--- a/app/component/map/PositionMarker.js
+++ b/app/component/map/PositionMarker.js
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { memo } from 'react';
 import connectToStores from 'fluxible-addons-react/connectToStores';
-import pure from 'recompose/pure';
 import Marker from 'react-leaflet/es/Marker';
 import { default as L } from 'leaflet';
 
@@ -37,7 +36,7 @@ PositionMarker.defaultProps = {
 };
 
 export default connectToStores(
-  pure(PositionMarker),
+  memo(PositionMarker),
   ['PositionStore'],
   context => {
     const coordinates = context.getStore('PositionStore').getLocationState();

--- a/app/component/map/PositionMarker.js
+++ b/app/component/map/PositionMarker.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React from 'react';
 import connectToStores from 'fluxible-addons-react/connectToStores';
 import Marker from 'react-leaflet/es/Marker';
 import { default as L } from 'leaflet';
@@ -35,20 +35,16 @@ PositionMarker.defaultProps = {
   coordinates: null,
 };
 
-export default connectToStores(
-  memo(PositionMarker),
-  ['PositionStore'],
-  context => {
-    const coordinates = context.getStore('PositionStore').getLocationState();
+export default connectToStores(PositionMarker, ['PositionStore'], context => {
+  const coordinates = context.getStore('PositionStore').getLocationState();
 
-    return {
-      coordinates: coordinates.hasLocation
-        ? {
-            lat: coordinates.lat,
-            lon: coordinates.lon,
-            address: coordinates.address,
-          }
-        : null,
-    };
-  },
-);
+  return {
+    coordinates: coordinates.hasLocation
+      ? {
+          lat: coordinates.lat,
+          lon: coordinates.lon,
+          address: coordinates.address,
+        }
+      : null,
+  };
+});

--- a/app/component/routepage/TripStopsContainer.js
+++ b/app/component/routepage/TripStopsContainer.js
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, memo } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import cx from 'classnames';
-import pure from 'recompose/pure';
 import { matchShape } from 'found';
 import debounce from 'lodash/debounce';
 import RouteControlPanel from './RouteControlPanel';
@@ -79,7 +78,7 @@ TripStopsContainer.defaultProps = {
   route: undefined,
 };
 
-const pureComponent = pure(withBreakpoint(TripStopsContainer));
+const pureComponent = memo(withBreakpoint(TripStopsContainer));
 const containerComponent = createFragmentContainer(pureComponent, {
   trip: graphql`
     fragment TripStopsContainer_trip on Trip {

--- a/app/component/routepage/TripStopsContainer.js
+++ b/app/component/routepage/TripStopsContainer.js
@@ -11,7 +11,12 @@ import withBreakpoint from '../../util/withBreakpoint';
 import ScrollableWrapper from '../ScrollableWrapper';
 import { routeShape } from '../../util/shapes';
 
-function TripStopsContainer({ breakpoint, match, trip, route }) {
+const TripStopsContainer = memo(function TripStopsContainer({
+  breakpoint,
+  match,
+  trip,
+  route,
+}) {
   const [keepTracking, setTracking] = useState(true);
   const humanScrolling = useRef(true);
 
@@ -58,7 +63,7 @@ function TripStopsContainer({ breakpoint, match, trip, route }) {
       />
     </ScrollableWrapper>
   );
-}
+});
 
 TripStopsContainer.propTypes = {
   trip: PropTypes.shape({
@@ -78,8 +83,8 @@ TripStopsContainer.defaultProps = {
   route: undefined,
 };
 
-const pureComponent = memo(withBreakpoint(TripStopsContainer));
-const containerComponent = createFragmentContainer(pureComponent, {
+const componentWithBreakpoint = withBreakpoint(TripStopsContainer);
+const containerComponent = createFragmentContainer(componentWithBreakpoint, {
   trip: graphql`
     fragment TripStopsContainer_trip on Trip {
       stoptimesForDate {

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^4.1.0",
+    "@digitransit-component/digitransit-component-autosuggest": "^4.2.0",
     "@digitransit-component/digitransit-component-icon": "^1.0.2",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^4.2.0",
+    "@digitransit-component/digitransit-component-autosuggest": "^4.3.0",
     "@digitransit-component/digitransit-component-icon": "^1.0.2",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "@digitransit-component/digitransit-component-dialog-modal": "^0.3.7",
     "@digitransit-component/digitransit-component-icon": "^1.0.2",
-    "@digitransit-component/digitransit-component-suggestion-item": "^2.0.8",
+    "@digitransit-component/digitransit-component-suggestion-item": "^2.1.0",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.5.1",
     "i18next": "^22.5.1",

--- a/digitransit-component/packages/digitransit-component-suggestion-item/package.json
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-suggestion-item",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "digitransit-component suggestion-item module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-suggestion-item/package.json
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/package.json
@@ -28,9 +28,6 @@
   ],
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
-  "dependencies": {
-    "recompose": "0.30.0"
-  },
   "peerDependencies": {
     "@digitransit-component/digitransit-component-icon": "^1.0.2",
     "@hsl-fi/sass": " ^0.2.0",

--- a/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
@@ -299,7 +299,7 @@ const SuggestionItem = pure(
       >
         <Icon
           color={
-            item.properties.color
+            item?.properties?.color
               ? `#${item.properties.color}`
               : modeIconColor || iconColor
           }

--- a/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
@@ -1,8 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, memo } from 'react';
 import cx from 'classnames';
-import pure from 'recompose/pure';
 import Icon from '@digitransit-component/digitransit-component-icon';
 import styles from './helpers/styles.scss';
 
@@ -263,7 +262,7 @@ function hasVehicleStationCode(stationId) {
  *    loading={false}
  * />
  */
-const SuggestionItem = pure(
+const SuggestionItem = memo(
   ({
     item,
     content,
@@ -524,11 +523,32 @@ SuggestionItem.propTypes = {
     address: PropTypes.string,
     selectedIconId: PropTypes.string,
     iconColor: PropTypes.string,
+    translatedText: PropTypes.string,
+    properties: PropTypes.shape({
+      layer: PropTypes.string,
+      color: PropTypes.string,
+      localadmin: PropTypes.string,
+      mode: PropTypes.string,
+      id: PropTypes.string,
+      source: PropTypes.string,
+      arrowClicked: PropTypes.bool,
+      destination: PropTypes.shape({
+        name: PropTypes.string,
+        localadmin: PropTypes.string,
+      }),
+      origin: PropTypes.shape({
+        name: PropTypes.string,
+        localadmin: PropTypes.string,
+      }),
+    }),
   }),
   // eslint-disable-next-line
   content: PropTypes.array,
   className: PropTypes.string,
   isMobile: PropTypes.bool,
+  ariaFavouriteString: PropTypes.string,
+  loading: PropTypes.bool,
+  fillInput: PropTypes.func.isRequired,
   color: PropTypes.string,
   accessiblePrimaryColor: PropTypes.string,
   fontWeights: PropTypes.shape({
@@ -540,6 +560,8 @@ SuggestionItem.propTypes = {
 };
 
 SuggestionItem.defaultProps = {
+  item: undefined,
+  loading: false,
   className: undefined,
   isMobile: false,
   color: '#007ac9',

--- a/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
@@ -26,7 +26,7 @@ const getRouteMode = props => {
 };
 
 function isFavourite(item) {
-  return item?.type?.includes('Favourite');
+  return item.type?.includes('Favourite');
 }
 
 function getAriaDescription(ariaContentArray) {
@@ -46,7 +46,7 @@ function getIconProperties(
 ) {
   let iconId;
   let iconColor = '#888888';
-  if (item?.properties?.layer === 'bikestation' && getIcons) {
+  if (item.properties?.layer === 'bikestation' && getIcons) {
     return getIcons.citybikes(item);
   }
   // because of legacy favourites there might be selectedIconId for some stops or stations
@@ -58,22 +58,22 @@ function getIconProperties(
   } else if (item.type === 'Route') {
     const mode =
       modeSet === 'default'
-        ? getRouteMode(item?.properties)
-        : item?.properties?.mode?.toLowerCase() || 'bus';
+        ? getRouteMode(item.properties)
+        : item.properties?.mode?.toLowerCase() || 'bus';
     return modeSet === 'default'
       ? [`mode-${mode}`, `mode-${mode}`]
       : [`mode-${modeSet}-${mode}`, `mode-${mode}`];
-  } else if (item.type === 'OldSearch' && item?.properties?.mode) {
+  } else if (item.type === 'OldSearch' && item.properties?.mode) {
     const mode =
       modeSet === 'default'
-        ? getRouteMode(item?.properties)
-        : item?.properties?.mode?.toLowerCase() || 'bus';
+        ? getRouteMode(item.properties)
+        : item.properties?.mode?.toLowerCase() || 'bus';
     return modeSet === 'default'
       ? [`mode-${mode}`, `mode-${mode}`]
       : [`mode-${modeSet}-${mode}`, `mode-${mode}`];
-  } else if (item && item.selectedIconId) {
+  } else if (item.selectedIconId) {
     iconId = item.selectedIconId;
-  } else if (item && item.properties) {
+  } else if (item.properties) {
     if (item.properties.layer === 'bikestation') {
       return [`citybike-stop-${modeSet}`, 'mode-citybike'];
     }
@@ -294,11 +294,11 @@ const SuggestionItem = memo(
     const [arrowClicked, setArrowClicked] = useState(false);
     const icon = (
       <span
-        className={`${styles[iconId]} ${item?.properties?.mode?.toLowerCase()}`}
+        className={`${styles[iconId]} ${item.properties?.mode?.toLowerCase()}`}
       >
         <Icon
           color={
-            item?.properties?.color
+            item.properties?.color
               ? `#${item.properties.color}`
               : modeIconColor || iconColor
           }
@@ -454,7 +454,7 @@ const SuggestionItem = memo(
           )}
         </div>
         {iconId !== 'arrow' &&
-          (item?.properties?.layer !== 'street' ||
+          (item.properties?.layer !== 'street' ||
             !isMobile ||
             arrowClicked) && (
             <span
@@ -466,7 +466,7 @@ const SuggestionItem = memo(
             </span>
           )}
         {iconId !== 'arrow' &&
-          item?.properties?.layer === 'street' &&
+          item.properties?.layer === 'street' &&
           !arrowClicked &&
           isMobile && (
             // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
@@ -541,14 +541,14 @@ SuggestionItem.propTypes = {
         localadmin: PropTypes.string,
       }),
     }),
-  }),
+  }).isRequired,
   // eslint-disable-next-line
   content: PropTypes.array,
   className: PropTypes.string,
   isMobile: PropTypes.bool,
   ariaFavouriteString: PropTypes.string,
   loading: PropTypes.bool,
-  fillInput: PropTypes.func.isRequired,
+  fillInput: PropTypes.func,
   color: PropTypes.string,
   accessiblePrimaryColor: PropTypes.string,
   fontWeights: PropTypes.shape({
@@ -560,8 +560,9 @@ SuggestionItem.propTypes = {
 };
 
 SuggestionItem.defaultProps = {
-  item: undefined,
   loading: false,
+  ariaFavouriteString: '',
+  fillInput: () => {},
   className: undefined,
   isMobile: false,
   color: '#007ac9',

--- a/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
@@ -297,7 +297,14 @@ const SuggestionItem = pure(
       <span
         className={`${styles[iconId]} ${item?.properties?.mode?.toLowerCase()}`}
       >
-        <Icon color={modeIconColor || iconColor} img={iconId} />
+        <Icon
+          color={
+            item.properties.color
+              ? `#${item.properties.color}`
+              : modeIconColor || iconColor
+          }
+          img={iconId}
+        />
       </span>
     );
     let ariaParts;

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-component",
   "module": "digitransit-component.mjs",
@@ -14,14 +14,14 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^4.1.0",
+    "@digitransit-component/digitransit-component-autosuggest": "^4.2.0",
     "@digitransit-component/digitransit-component-autosuggest-panel": "^5.1.0",
     "@digitransit-component/digitransit-component-control-panel": "^2.0.1",
     "@digitransit-component/digitransit-component-favourite-bar": "2.0.8",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^2.0.4",
     "@digitransit-component/digitransit-component-favourite-modal": "^1.0.7",
     "@digitransit-component/digitransit-component-icon": "^1.0.2",
-    "@digitransit-component/digitransit-component-suggestion-item": "^2.0.8",
+    "@digitransit-component/digitransit-component-suggestion-item": "^2.1.0",
     "@digitransit-component/digitransit-component-with-breakpoint": "^0.0.5"
   },
   "peerDependencies": {

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -14,8 +14,8 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^4.2.0",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^5.1.0",
+    "@digitransit-component/digitransit-component-autosuggest": "^4.3.0",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^5.3.0",
     "@digitransit-component/digitransit-component-control-panel": "^2.0.1",
     "@digitransit-component/digitransit-component-favourite-bar": "2.0.8",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^2.0.4",

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-query-utils",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "description": "digitransit-search-util query-utils module",
   "main": "lib/index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/src/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/src/index.js
@@ -94,6 +94,7 @@ const searchRoutesQuery = graphql`
         type
         shortName
         mode
+        color
         longName
         patterns {
           code

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,11 +1996,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@^5.1.0, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@^5.3.0, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^4.2.0
+    "@digitransit-component/digitransit-component-autosuggest": ^4.3.0
     "@digitransit-component/digitransit-component-icon": ^1.0.2
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
@@ -2016,7 +2016,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@^4.2.0, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@^4.3.0, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
@@ -2204,8 +2204,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^4.2.0
-    "@digitransit-component/digitransit-component-autosuggest-panel": ^5.1.0
+    "@digitransit-component/digitransit-component-autosuggest": ^4.3.0
+    "@digitransit-component/digitransit-component-autosuggest-panel": ^5.3.0
     "@digitransit-component/digitransit-component-control-panel": ^2.0.1
     "@digitransit-component/digitransit-component-favourite-bar": 2.0.8
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^2.0.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,8 +2153,6 @@ __metadata:
 "@digitransit-component/digitransit-component-suggestion-item@^2.0.8, @digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item"
-  dependencies:
-    recompose: 0.30.0
   peerDependencies:
     "@digitransit-component/digitransit-component-icon": ^1.0.2
     "@hsl-fi/sass": " ^0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,7 +2000,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^4.1.0
+    "@digitransit-component/digitransit-component-autosuggest": ^4.2.0
     "@digitransit-component/digitransit-component-icon": ^1.0.2
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
@@ -2016,7 +2016,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@^4.1.0, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@^4.2.0, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
@@ -2027,7 +2027,7 @@ __metadata:
   peerDependencies:
     "@digitransit-component/digitransit-component-dialog-modal": ^0.3.7
     "@digitransit-component/digitransit-component-icon": ^1.0.2
-    "@digitransit-component/digitransit-component-suggestion-item": ^2.0.8
+    "@digitransit-component/digitransit-component-suggestion-item": ^2.1.0
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
     i18next: ^22.5.1
@@ -2150,7 +2150,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-suggestion-item@^2.0.8, @digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item":
+"@digitransit-component/digitransit-component-suggestion-item@^2.1.0, @digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item"
   peerDependencies:
@@ -2204,14 +2204,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^4.1.0
+    "@digitransit-component/digitransit-component-autosuggest": ^4.2.0
     "@digitransit-component/digitransit-component-autosuggest-panel": ^5.1.0
     "@digitransit-component/digitransit-component-control-panel": ^2.0.1
     "@digitransit-component/digitransit-component-favourite-bar": 2.0.8
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^2.0.4
     "@digitransit-component/digitransit-component-favourite-modal": ^1.0.7
     "@digitransit-component/digitransit-component-icon": ^1.0.2
-    "@digitransit-component/digitransit-component-suggestion-item": ^2.0.8
+    "@digitransit-component/digitransit-component-suggestion-item": ^2.1.0
     "@digitransit-component/digitransit-component-with-breakpoint": ^0.0.5
   peerDependencies:
     "@digitransit-component/digitransit-component-dialog-modal": ^0.3.6


### PR DESCRIPTION
## Proposed Changes

  - Changes suggestion icon to always use route_color from gtfs if it is specified
  - Route color overrides possible mode specific colors
  - Also replaces recompose/pure with React.memo since it is the modern equivalent
    - Decided to also remove usage of pure from app folder in this pr since there were only a few instances

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
