### PR TITLE
Do not call onClick handler at every key event in stops near you buttons

### DIFF
--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -38,7 +38,6 @@ import scrollTop from '../util/scroll';
 import { LightenDarkenColor } from '../util/colorUtils';
 import { getRefPoint } from '../util/apiUtils';
 import { filterObject } from '../util/filterUtils';
-import { isKeyboardSelectionEvent } from '../util/browser';
 import {
   getTransportModes,
   getNearYouModes,
@@ -218,10 +217,7 @@ class IndexPage extends React.Component {
     }${this.context.config.trafficNowLink[lang]}`;
   };
 
-  clickStopNearIcon = (url, kbdEvent) => {
-    if (kbdEvent && !isKeyboardSelectionEvent(kbdEvent)) {
-      return;
-    }
+  clickStopNearIcon = url => {
     addAnalyticsEvent({
       event: 'sendMatomoEvent',
       category: 'nearbyStops',

--- a/digitransit-component/packages/digitransit-component-control-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-control-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-control-panel",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "digitransit-component control-panel module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-control-panel/src/index.js
+++ b/digitransit-component/packages/digitransit-component-control-panel/src/index.js
@@ -17,6 +17,18 @@ i18next.init({
   },
 });
 
+const isKeyboardSelectionEvent = event => {
+  const space = [13, ' ', 'Spacebar'];
+  const enter = [32, 'Enter'];
+  const key = (event && (event.key || event.which || event.keyCode)) || '';
+
+  if (!key || !space.concat(enter).includes(key)) {
+    return false;
+  }
+  event.preventDefault();
+  return true;
+};
+
 function SeparatorLine({ usePaddingBottom20 }) {
   const className = usePaddingBottom20
     ? styles['separator-div2']
@@ -216,7 +228,11 @@ function NearStopsAndRoutes({
             key={mode}
             role="link"
             tabIndex="0"
-            onKeyDown={e => onClick(url, e)}
+            onKeyDown={e => {
+              if (isKeyboardSelectionEvent(e)) {
+                onClick(url, e);
+              }
+            }}
             onClick={() => onClick(url)}
           >
             {modeButton}

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@digitransit-component/digitransit-component-autosuggest": "^4.3.0",
     "@digitransit-component/digitransit-component-autosuggest-panel": "^5.3.0",
-    "@digitransit-component/digitransit-component-control-panel": "^2.0.1",
+    "@digitransit-component/digitransit-component-control-panel": "^3.0.0",
     "@digitransit-component/digitransit-component-favourite-bar": "2.0.8",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^2.0.4",
     "@digitransit-component/digitransit-component-favourite-modal": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,7 +2042,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-control-panel@^2.0.1, @digitransit-component/digitransit-component-control-panel@workspace:digitransit-component/packages/digitransit-component-control-panel":
+"@digitransit-component/digitransit-component-control-panel@^3.0.0, @digitransit-component/digitransit-component-control-panel@workspace:digitransit-component/packages/digitransit-component-control-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-control-panel@workspace:digitransit-component/packages/digitransit-component-control-panel"
   peerDependencies:
@@ -2206,7 +2206,7 @@ __metadata:
   dependencies:
     "@digitransit-component/digitransit-component-autosuggest": ^4.3.0
     "@digitransit-component/digitransit-component-autosuggest-panel": ^5.3.0
-    "@digitransit-component/digitransit-component-control-panel": ^2.0.1
+    "@digitransit-component/digitransit-component-control-panel": ^3.0.0
     "@digitransit-component/digitransit-component-favourite-bar": 2.0.8
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^2.0.4
     "@digitransit-component/digitransit-component-favourite-modal": ^1.0.7


### PR DESCRIPTION
The buttons now filter selection events themselves. This will fix accessibility error in hsl.fi front page. 