### PR TITLE
DT-6268 MobileTimePicker and MobilePickerModal accessibility improvements

### DIFF
--- a/app/translations.js
+++ b/app/translations.js
@@ -736,7 +736,6 @@ const translations = {
     'swap-order-button-label': 'Start und Ziel tauschen',
     'swipe-result-tab-left': 'Show the previous tab.',
     'swipe-result-tab-right': 'Show the next tab.',
-    'swipe-result-tabs': 'Switch tabs using arrow keys.',
     'terminal-page.description': 'Terminal - {name}',
     'terminal-page.title': 'Terminal',
     'terminal-page.title-short': 'Terminal - {name}',
@@ -857,8 +856,6 @@ const translations = {
     back: 'Back',
     'buy-in-app': 'Buy in App',
     'search-autosuggest-label': 'Venue, place and stopsearch.',
-    'search-autosuggest-label-instructions':
-      'Navigate list with arrow keys and select with enter key.',
     'search-autosuggest-label-move-to-destination':
       'After selecting the starting location you are automatically moved to the destination field.',
     'search-autosuggest-len':
@@ -1705,7 +1702,6 @@ const translations = {
     'swipe-message-bar-tab': 'Message swipe result tabs',
     'swipe-result-tab-left': 'Show the previous tab.',
     'swipe-result-tab-right': 'Show the next tab.',
-    'swipe-result-tabs': 'Switch tabs using arrow keys.',
     'swipe-sr-new-tab-opened': 'Tab {number} opened.',
     'swipe-stops-near-you-tab': 'Stops near you swipe result tabs.',
     'swipe-summary-page-tab': 'Itinerary swipe result tabs',
@@ -2172,8 +2168,6 @@ const translations = {
     'as-viapoint': 'Välipisteeksi',
     'buy-in-app': 'Osta sovelluksessa',
     'search-autosuggest-label': 'Paikka, linja ja pysäkkihaku.',
-    'search-autosuggest-label-instructions':
-      'Navigoi listassa nuolinäppäimillä ja valitse enterillä.',
     'search-autosuggest-label-move-to-destination':
       'Valittuasi lähtöpaikan siirrytään suoraan määränpää-kenttään.',
     'search-autosuggest-len':
@@ -3017,7 +3011,6 @@ const translations = {
     'swipe-message-bar-tab': 'Viestivälilehti {number}',
     'swipe-result-tab-left': 'Näytä edellinen välilehti.',
     'swipe-result-tab-right': 'Näytä seuraava välilehti.',
-    'swipe-result-tabs': 'Selaa välilehtiä nuolinäppäimillä.',
     'swipe-sr-new-tab-opened': 'Välilehti {number} avattu.',
     'swipe-stops-near-you-tab': 'Lähipysäkkivälilehti {number}',
     'swipe-summary-page-tab': 'Reittiehdotus {number}',
@@ -3777,8 +3770,6 @@ const translations = {
     'as-origin': 'Początek',
     'as-viapoint': 'Punkt pośredni',
     'search-autosuggest-label': 'Miejsce, lokalizacja i przystanek.',
-    'search-autosuggest-label-instructions':
-      'Nawiguj po liście używając strzałek i wybieraj klawiszem Enter.',
     'search-autosuggest-label-move-to-destination':
       'Po wybraniu lokalizacji początkowej, automatycznie przejdziesz do pola miejsca docelowego.',
     'search-autosuggest-len':
@@ -4493,7 +4484,6 @@ const translations = {
     'swipe-message-bar-tab': 'Message swipe result tabs',
     'swipe-result-tab-left': 'Aby wyświetlić poprzednią kartę.',
     'swipe-result-tab-right': 'Aby wyświetlić następną kartę.',
-    'swipe-result-tabs': 'Przełącz karty klawiszami strzałek.',
     'swipe-sr-new-tab-opened': 'Otwarto kartę {number}.',
     'swipe-stops-near-you-tab': 'Stops near you swipe result tabs.',
     'swipe-summary-page-tab': 'Itinerary swipe result tabs',
@@ -5024,7 +5014,6 @@ const translations = {
     'swap-order-button-label': 'Schimbați originea cu destinația',
     'swipe-result-tab-left': 'Show the previous tab.',
     'swipe-result-tab-right': 'Show the next tab.',
-    'swipe-result-tabs': 'Switch tabs using arrow keys.',
     'terminal-page.description': 'Terminalul {name}',
     'terminal-page.title': 'Terminalul {name}',
     'terminal-page.title-short': 'Terminal',
@@ -5133,8 +5122,6 @@ const translations = {
       'Tilaa kyyti sovelluksella ja jää odottamaan sen saapumista:',
     'buy-in-app': 'Köp i appen',
     'search-autosuggest-label': 'Plats, linje och hållplatssökning.',
-    'search-autosuggest-label-instructions':
-      'Navigera listan med piltangenterna och välj med Enter-tangeten.',
     'search-autosuggest-label-move-to-destination':
       'Efter att du valt avgångsplatsen tas du direkt till Destination-fältet.',
     'search-autosuggest-len': 'Hittade {len} förslag',
@@ -5969,7 +5956,6 @@ const translations = {
       'Navigeringsknapp för att kunna bläddra stäng banner',
     'swipe-result-tab-left': 'Gå till föregående blad.',
     'swipe-result-tab-right': 'Gå till följande blad.',
-    'swipe-result-tabs': 'Bläddra mellan blad med pilknapparna.',
     'swipe-sr-new-tab-opened': 'Blad {number} öppnad.',
     'swipe-stops-near-you-tab':
       'Navigeringsknapp för att kunna bläddra hållplatser nära mig.',

--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
@@ -260,6 +260,11 @@ function Datetimepicker({
                 onClose();
               }
             }}
+            onAfterClose={() =>
+              requestAnimationFrame(() => {
+                openPickerRef.current?.focus();
+              })
+            }
             getTimeDisplay={getTimeDisplay}
             timeZone={timeZone}
             timestamp={displayTimestamp}

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
@@ -139,11 +139,6 @@ function Datetimepicker({
     return () => clearInterval(newId);
   }, [displayTimestamp]);
 
-  const prevIsOpenRef = useRef();
-  useEffect(() => {
-    prevIsOpenRef.current = isOpen;
-  });
-
   /**
    * @param {number} date Date in milliseconds since unix epoch
    * @returns {string} formatted date
@@ -235,17 +230,26 @@ function Datetimepicker({
     }
   }
 
+  const handleClose = () => {
+    changeOpen(false);
+    showScreenreaderCloseAlert();
+    if (onClose) {
+      onClose();
+    }
+  };
+
+  const handleNowClick = () => {
+    handleClose();
+    onNowClick();
+  };
+
   function renderOpen() {
     if (useMobileInputs) {
       return (
         isOpen && (
           <MobilePickerModal
             departureOrArrival={departureOrArrival}
-            onNowClick={() => {
-              changeOpen(false);
-              showScreenreaderCloseAlert();
-              onNowClick();
-            }}
+            onNowClick={handleNowClick}
             lang={lang}
             color={color}
             onSubmit={(newTimestamp, newDepartureOrArrival) => {
@@ -253,13 +257,7 @@ function Datetimepicker({
               changeOpen(false);
               showScreenreaderCloseAlert();
             }}
-            onCancel={() => {
-              changeOpen(false);
-              showScreenreaderCloseAlert();
-              if (onClose) {
-                onClose();
-              }
-            }}
+            onCancel={handleClose}
             onAfterClose={() =>
               requestAnimationFrame(() => {
                 openPickerRef.current?.focus();
@@ -345,14 +343,7 @@ function Datetimepicker({
               id={`${htmlId}-now`}
               type="button"
               className={styles['departure-now-button']}
-              onClick={() => {
-                changeOpen(false);
-                showScreenreaderCloseAlert();
-                if (onClose) {
-                  onClose();
-                }
-                onNowClick();
-              }}
+              onClick={handleNowClick}
               ref={inputRef}
             >
               {i18next.t('departure-now', translationSettings)}
@@ -363,13 +354,7 @@ function Datetimepicker({
                 className={styles['close-button']}
                 aria-controls={`${htmlId}-root`}
                 aria-expanded="true"
-                onClick={() => {
-                  changeOpen(false);
-                  showScreenreaderCloseAlert();
-                  if (onClose) {
-                    onClose();
-                  }
-                }}
+                onClick={handleClose}
               >
                 <span className={styles['close-icon']}>
                   <Icon img="close" color={color} />
@@ -438,6 +423,7 @@ function Datetimepicker({
       </>
     );
   }
+
   const formatToprowSummary = () => {
     if (nowSelected && departureOrArrival === 'departure') {
       return <span>{i18next.t('departure-now', translationSettings)}</span>;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobilePickerModal.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobilePickerModal.js
@@ -45,6 +45,7 @@ function MobilePickerModal({
   dateSelectItemCount,
   getDateDisplay,
   fontWeights,
+  onAfterClose,
 }) {
   Settings.defaultZone = timeZone;
   const translationSettings = { lng: lang };
@@ -78,6 +79,7 @@ function MobilePickerModal({
       isOpen
       className={styles['mobile-modal-content']}
       overlayClassName={styles['mobile-modal-overlay']}
+      onAfterClose={onAfterClose}
     >
       <div
         style={{
@@ -212,6 +214,7 @@ MobilePickerModal.propTypes = {
   color: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
+  onAfterClose: PropTypes.func.isRequired,
   timestamp: PropTypes.number.isRequired,
   getTimeDisplay: PropTypes.func.isRequired,
   dateSelectItemCount: PropTypes.number.isRequired,

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileTimepicker.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useRef, useLayoutEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Settings } from 'luxon';
 import cx from 'classnames';
 import styles from './styles.scss';
@@ -22,12 +22,6 @@ function MobileTimepicker({
   Settings.defaultZone = timeZone;
   const inputId = `${id}-input`;
   const labelId = `${id}-label`;
-  const timeInputRef = useRef(null);
-  useLayoutEffect(() => {
-    if (timeInputRef.current) {
-      timeInputRef.current.focus();
-    }
-  }, []);
   const showError = !isValidInput;
   return (
     <label className={styles['input-container']} htmlFor={inputId}>
@@ -70,7 +64,6 @@ function MobileTimepicker({
             onChange(timestamp);
           }
         }}
-        ref={timeInputRef}
       />
     </label>
   );


### PR DESCRIPTION
## Proposed Changes
- Focus is no longer skipping directly to time input field as required by [WCAG 2.4.3](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html)
- Focus is returned to modal launching button instead of document start on modal close

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
