### PR TITLE
Ab#69 DT-6325 Near you page shows alerts related to the stops in view

### DIFF
--- a/app/component/DisruptionBanner.js
+++ b/app/component/DisruptionBanner.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
 import connectToStores from 'fluxible-addons-react/connectToStores';
 import isEmpty from 'lodash/isEmpty';
 import { configShape, alertShape } from '../util/shapes';
@@ -110,37 +109,13 @@ class DisruptionBanner extends React.Component {
 }
 const DisruptionBannerWithBreakpoint = withBreakpoint(DisruptionBanner);
 
-const containerComponent = createFragmentContainer(
-  connectToStores(
-    DisruptionBannerWithBreakpoint,
-    ['TimeStore', 'PreferencesStore'],
-    ({ getStore }) => ({
-      currentTime: getStore('TimeStore').getCurrentTime(),
-      language: getStore('PreferencesStore').getLanguage(),
-    }),
-  ),
-  {
-    alerts: graphql`
-      fragment DisruptionBanner_alerts on Alert @relay(plural: true) {
-        feed
-        id
-        alertSeverityLevel
-        alertHeaderText
-        alertEffect
-        alertCause
-        alertDescriptionText
-        effectiveStartDate
-        effectiveEndDate
-        entities {
-          __typename
-          ... on Route {
-            mode
-            shortName
-          }
-        }
-      }
-    `,
-  },
+const containerComponent = connectToStores(
+  DisruptionBannerWithBreakpoint,
+  ['TimeStore', 'PreferencesStore'],
+  ({ getStore }) => ({
+    currentTime: getStore('TimeStore').getCurrentTime(),
+    language: getStore('PreferencesStore').getLanguage(),
+  }),
 );
 
 export { containerComponent as default, DisruptionBanner as Component };

--- a/app/component/map/NearYouMap.js
+++ b/app/component/map/NearYouMap.js
@@ -117,7 +117,13 @@ const handleBounds = (location, edges) => {
 };
 
 const getLocationMarker = location => {
-  return <LocationMarker position={location} type="from" />;
+  return (
+    <LocationMarker
+      key={`from-${location.lat}:${location.lat}`}
+      position={location}
+      type="from"
+    />
+  );
 };
 
 function NearYouMap(

--- a/app/component/nearyou/NearYouPage.js
+++ b/app/component/nearyou/NearYouPage.js
@@ -246,7 +246,6 @@ class NearYouPage extends React.Component {
       filterByModes: modes,
       filterByPlaceTypes: placeTypes,
       omitNonPickups: this.context.config.omitNonPickups,
-      feedIds: this.context.config.feedIds,
       prioritizedStopIds: prioritizedStops,
       filterByNetwork: allowedNetworks,
     };
@@ -437,7 +436,6 @@ class NearYouPage extends React.Component {
                 $maxResults: Int!
                 $maxDistance: Int!
                 $omitNonPickups: Boolean!
-                $feedIds: [String!]
                 $filterByNetwork: [String!]
               ) {
                 stopPatterns: viewer {

--- a/app/component/nearyou/NearYouPage.js
+++ b/app/component/nearyou/NearYouPage.js
@@ -22,7 +22,6 @@ import {
   checkPositioningPermission,
   startLocationWatch,
 } from '../../action/PositionActions';
-import DisruptionBanner from '../DisruptionBanner';
 import StopsNearYouSearch from './StopsNearYouSearch';
 import {
   getGeolocationState,
@@ -455,9 +454,6 @@ class NearYouPage extends React.Component {
                       filterByNetwork: $filterByNetwork
                     )
                 }
-                alerts: alerts(feeds: $feedIds, severityLevel: [SEVERE]) {
-                  ...DisruptionBanner_alerts
-                }
               }
             `}
             variables={this.getQueryVariables(nearByStopMode)}
@@ -482,13 +478,6 @@ class NearYouPage extends React.Component {
                 config.prioritizedStopsNearYou[nearByStopMode.toLowerCase()];
               return (
                 <div className="stops-near-you-page">
-                  {renderDisruptionBanner && (
-                    <DisruptionBanner
-                      alerts={(props && props.alerts) || []}
-                      mode={nearByStopMode}
-                      trafficNowLink={config.trafficNowLink}
-                    />
-                  )}
                   {renderSearch && (
                     <StopsNearYouSearch
                       mode={nearByStopMode}
@@ -623,6 +612,8 @@ class NearYouPage extends React.Component {
                       stopPatterns={props.stopPatterns}
                       position={this.state.searchPosition}
                       withSeparator={!renderSearch}
+                      nearByStopMode={nearByStopMode}
+                      renderDisruptionBanner={renderDisruptionBanner}
                     />
                   )}
                 </div>

--- a/app/component/nearyou/StopsNearYouContainer.js
+++ b/app/component/nearyou/StopsNearYouContainer.js
@@ -15,6 +15,7 @@ import CityBikeStopNearYou from './VehicleRentalStationNearYou';
 import Loading from '../Loading';
 import Icon from '../Icon';
 import { getDefaultNetworks } from '../../util/vehicleRentalUtils';
+import DisruptionBanner from '../DisruptionBanner';
 
 class StopsNearYouContainer extends React.Component {
   static propTypes = {
@@ -33,12 +34,15 @@ class StopsNearYouContainer extends React.Component {
     }).isRequired,
     withSeparator: PropTypes.bool,
     prioritizedStops: PropTypes.arrayOf(PropTypes.string),
+    nearByStopMode: PropTypes.string.isRequired,
+    renderDisruptionBanner: PropTypes.bool,
   };
 
   static defaultProps = {
     stopPatterns: undefined,
     withSeparator: false,
     prioritizedStops: undefined,
+    renderDisruptionBanner: false,
   };
 
   static contextTypes = {
@@ -254,12 +258,23 @@ class StopsNearYouContainer extends React.Component {
       />
     );
     const stops = this.createNearbyStops().filter(e => e);
+    const alerts = stops
+      .flatMap(stop => stop.props.stop?.routes || [])
+      .flatMap(route => route?.alerts || [])
+      .filter(alert => alert.alertSeverityLevel === 'SEVERE');
     const noStopsFound =
       !stops.length &&
       this.state.refetches >= this.state.maxRefetches &&
       !this.state.isLoadingmoreStops;
     return (
       <>
+        {this.props.renderDisruptionBanner && (
+          <DisruptionBanner
+            alerts={alerts || []}
+            mode={this.props.nearByStopMode}
+            trafficNowLink={this.context.config.trafficNowLink}
+          />
+        )}
         {((!this.props.relay.hasMore() &&
           !stops.length &&
           !this.props.prioritizedStops?.length) ||
@@ -388,6 +403,28 @@ const refetchContainer = createPaginationContainer(
                     omitNonPickups: $omitNonPickups
                   ) {
                     scheduledArrival
+                  }
+                  routes {
+                    ... on Route {
+                      alerts {
+                        feed
+                        id
+                        alertSeverityLevel
+                        alertHeaderText
+                        alertEffect
+                        alertCause
+                        alertDescriptionText
+                        effectiveStartDate
+                        effectiveEndDate
+                        entities {
+                          __typename
+                          ... on Route {
+                            mode
+                            shortName
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Proposed Changes

  - Show only severe route disruptions that relate to the stops in view and nothing extra. This stops unwanted alerts that are irrelevant to the area, especially in planners that cover a large area. 
  - Alerts are now part of the StopsNearYouContainer for fetching and showing related alerts. The location of the banner moves down on the page, but is immediately above the nearby stop list. 
  - DisruptionBanner now only shows the alerts (no data fetching).
  - Also fixed an unrelated unique key warning related to the near you map. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
