### PR TITLE
ab#144 Fix schedule view font configurations

### DIFF
--- a/app/component/departure.scss
+++ b/app/component/departure.scss
@@ -362,6 +362,7 @@
     background-color: currentcolor;
     position: relative;
     border-radius: 3px;
+    font-family: $id-font-family;
 
     a {
       justify-content: center;

--- a/sass/themes/hsl/_theme.scss
+++ b/sass/themes/hsl/_theme.scss
@@ -56,6 +56,7 @@ $letter-spacing: -0.025em;
 $font-size-medium-large: 1rem;
 $font-family-narrow: 'Gotham XNarrow SSm A', 'Gotham XNarrow SSm B',
   'Gotham Rounded A', 'Gotham Rounded B', arial, georgia, serif;
+$id-font-family: $font-family-narrow;
 
 /* Spinner */
 $spinner-image: url('hsl-spinner.png');

--- a/sass/themes/matka/_theme.scss
+++ b/sass/themes/matka/_theme.scss
@@ -32,7 +32,7 @@ $car-color: #505064;
 $nav-logo-height: 2em;
 $nav-logo-min-height: 30px;
 $id-font-family: 'Roboto Mono', arial, georgia, sans-serif;
-$font-family-narrow: $id-font-family;
+$font-family-narrow: $font-family;
 $id-font-size: $font-size-xsmall;
 $id-font-weight: $font-weight-medium;
 $background-color-lighter: #f6f6f6;


### PR DESCRIPTION
## Proposed Changes

  - Removed id font from text fields in matka.
  - Specified route codes to use the id font.
  - Specified an id font for hsl where it was missing, so it won't fall back on fonts defined in the default theme. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
