### PR TITLE
DT-6557 fix alternative routes showing incorrect alert icon

### DIFF
--- a/app/component/itinerary/queries/ItineraryDetailsFragment.js
+++ b/app/component/itinerary/queries/ItineraryDetailsFragment.js
@@ -51,6 +51,8 @@ export const ItineraryDetailsFragment = graphql`
         route {
           alerts {
             alertSeverityLevel
+            effectiveStartDate
+            effectiveEndDate
           }
           shortName
           mode
@@ -63,6 +65,8 @@ export const ItineraryDetailsFragment = graphql`
             platformCode
             alerts {
               alertSeverityLevel
+              effectiveStartDate
+              effectiveEndDate
             }
           }
         }
@@ -70,6 +74,8 @@ export const ItineraryDetailsFragment = graphql`
           stop {
             alerts {
               alertSeverityLevel
+              effectiveStartDate
+              effectiveEndDate
             }
           }
         }

--- a/app/util/alertUtils.js
+++ b/app/util/alertUtils.js
@@ -519,7 +519,6 @@ export const getActiveLegAlerts = (leg, legStartTime) => {
         ),
       };
     }),
-  ].filter(alert => isAlertActive(legStartTime, alert));
-
+  ].filter(alert => isAlertValid(alert, legStartTime));
   return serviceAlerts;
 };


### PR DESCRIPTION
## Proposed Changes

  - Added start and end dates to alternative route search. The validity of alerts can't be properly checked without the dates. If startDate is missing alert is automatically assumed to be valid.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
