### PR TITLE
DT-6512 Hide all fare information on itineraries with legs from other operators

### DIFF
--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -313,7 +313,7 @@ function ItineraryDetails(
               config={config}
             />
           ),
-          shouldShowFareInfo(config, itinerary.legs) &&
+          shouldShowFareInfo(config, itinerary.legs, fares) &&
             (shouldShowFarePurchaseInfo(config, breakpoint, fares) ? (
               <MobileTicketPurchaseInformation
                 key="mobileticketpurchaseinformation"

--- a/app/component/itinerary/TransitLeg.js
+++ b/app/component/itinerary/TransitLeg.js
@@ -624,6 +624,7 @@ class TransitLeg extends React.Component {
             </div>
           )}
           {leg.fare?.isUnknown &&
+            !config.hideUnknownFare &&
             shouldShowFareInfo(config) &&
             (config.modeDisclaimers?.[mode]?.[lang] ? (
               <div className="disclaimer-container unknown-fare-disclaimer__leg">

--- a/app/component/itinerary/TransitLeg.js
+++ b/app/component/itinerary/TransitLeg.js
@@ -624,7 +624,7 @@ class TransitLeg extends React.Component {
             </div>
           )}
           {leg.fare?.isUnknown &&
-            !config.hideUnknownFare &&
+            !config.hideUnknownFares &&
             shouldShowFareInfo(config) &&
             (config.modeDisclaimers?.[mode]?.[lang] ? (
               <div className="disclaimer-container unknown-fare-disclaimer__leg">

--- a/app/configurations/config.tampere.js
+++ b/app/configurations/config.tampere.js
@@ -108,7 +108,7 @@ export default configMerger(walttiConfig, {
     RAIL: {
       fi: {
         disclaimer:
-          'Nyssen liput käyvät junaliikenteessä rajoitetusti vain Nysse-alueella. Lue lisää ',
+          'Nyssen liput käyvät Nysse-alueen junaliikenteessä rajoitetusti. Lue lisää ',
         link: 'https://www.nysse.fi/junat',
         text: 'nysse.fi/junat',
       },

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -261,7 +261,7 @@ export default {
 
   // if true we don't show fare information on top of the itinerary
   // when there are legs from unknown operators
-  hideUnknownFare: true,
+  hideUnknownFares: true,
 
   startSearchFromUserLocation: true,
 

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -259,6 +259,10 @@ export default {
       : '';
   },
 
+  // if true we don't show fare information on top of the itinerary
+  // when there are legs from unknown operators
+  hideUnknownFare: true,
+
   startSearchFromUserLocation: true,
 
   minTransferTimeSelection: [

--- a/app/util/fareUtils.js
+++ b/app/util/fareUtils.js
@@ -93,7 +93,7 @@ export const getAlternativeFares = (zones, currentFares, allFares) => {
  * @param {*} config configuration.
  */
 export const shouldShowFareInfo = (config, legs, fares) => {
-  if (fares && config.hideUnknownFare && fares.some(fare => fare.isUnknown)) {
+  if (fares && config.hideUnknownFares && fares.some(fare => fare.isUnknown)) {
     return false;
   }
   if (

--- a/app/util/fareUtils.js
+++ b/app/util/fareUtils.js
@@ -92,7 +92,10 @@ export const getAlternativeFares = (zones, currentFares, allFares) => {
  *
  * @param {*} config configuration.
  */
-export const shouldShowFareInfo = (config, legs) => {
+export const shouldShowFareInfo = (config, legs, fares) => {
+  if (fares && config.hideUnknownFare && fares.some(fare => fare.isUnknown)) {
+    return false;
+  }
   if (
     config.externalFareRouteIds &&
     legs?.some(


### PR DESCRIPTION
## Proposed Changes

  - Hide needed ticket info box and the transit leg fare disclaimer if the itinerary contains legs from external operators with unknown fares
  - Configurable, changes made to only affect waltti operators

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
