### PR TITLE
Correct Tampere ticket configuration

### DIFF
--- a/app/component/FavouritesContainer.js
+++ b/app/component/FavouritesContainer.js
@@ -130,7 +130,7 @@ class FavouritesContainer extends React.Component {
           id: 'location-home',
           defaultMessage: 'Home',
         }),
-        selectedIconId: 'icon_home',
+        selectedIconId: 'icon-icon_home',
       },
     });
   };
@@ -147,7 +147,7 @@ class FavouritesContainer extends React.Component {
           id: 'location-work',
           defaultMessage: 'Work',
         }),
-        selectedIconId: 'icon_work',
+        selectedIconId: 'icon-icon_work',
       },
     });
   };

--- a/app/configurations/config.tampere.js
+++ b/app/configurations/config.tampere.js
@@ -104,7 +104,13 @@ export default configMerger(walttiConfig, {
 
   ticketLink: {
     fi: 'https://www.nysse.fi/liput-ja-hinnat.html',
+    sv: 'https://www.nysse.fi/en/tickets-and-fares.html',
+    en: 'https://www.nysse.fi/en/tickets-and-fares.html',
   },
+
+  showTicketLinkOnlyWhenTesting: true,
+  showTicketPrice: false,
+  ticketLinkOperatorCode: 50245,
 
   callAgencyInfo: {
     fi: {

--- a/digitransit-component/packages/digitransit-component-favourite-bar/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-bar",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "digitransit-component favourite-bar module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-favourite-bar/src/index.js
+++ b/digitransit-component/packages/digitransit-component-favourite-bar/src/index.js
@@ -168,6 +168,9 @@ class FavouriteBar extends React.Component {
     'icon-icon_sport': 'sport',
     'icon-icon_school': 'school',
     'icon-icon_shopping': 'shopping',
+    // Map two buggy ids temporarily. This code can be removed at some point.
+    icon_home: 'home',
+    icon_work: 'work',
   };
 
   constructor(props) {

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -17,7 +17,7 @@
     "@digitransit-component/digitransit-component-autosuggest": "^5.0.1",
     "@digitransit-component/digitransit-component-autosuggest-panel": "^6.0.1",
     "@digitransit-component/digitransit-component-control-panel": "^5.0.1",
-    "@digitransit-component/digitransit-component-favourite-bar": "3.0.1",
+    "@digitransit-component/digitransit-component-favourite-bar": "3.1.0",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^3.0.1",
     "@digitransit-component/digitransit-component-favourite-modal": "^2.0.1",
     "@digitransit-component/digitransit-component-icon": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,7 +2085,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-favourite-bar@3.0.1, @digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar":
+"@digitransit-component/digitransit-component-favourite-bar@3.1.0, @digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar"
   dependencies:
@@ -2189,7 +2189,7 @@ __metadata:
     "@digitransit-component/digitransit-component-autosuggest": ^5.0.1
     "@digitransit-component/digitransit-component-autosuggest-panel": ^6.0.1
     "@digitransit-component/digitransit-component-control-panel": ^5.0.1
-    "@digitransit-component/digitransit-component-favourite-bar": 3.0.1
+    "@digitransit-component/digitransit-component-favourite-bar": 3.1.0
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^3.0.1
     "@digitransit-component/digitransit-component-favourite-modal": ^2.0.1
     "@digitransit-component/digitransit-component-icon": ^1.1.0


### PR DESCRIPTION
- Part of confiiguration was dropped when changes were moved from next to dev, fixed now
- SVG cleanup accidentally renamed favourite identifiers. Correct ids are now used and id mapping extended for compatibility.
