### PR TITLE
Use new matka url everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We are currently moving our issue tracking into another platform.
 ## Demos
 
 - [https://reittiopas.hsl.fi - Helsinki city area demo](https://reittiopas.hsl.fi/)
-- [https://opas.matka.fi/ - National demo](https://opas.matka.fi/)
+- [https://matka.fintraffic.fi - National demo](https://matka.fintraffic.fi/)
 
 ## Testing
 

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -183,16 +183,16 @@ export default {
 
   nationalServiceLink: {
     fi: {
-      name: 'matka.fi',
-      href: 'https://opas.matka.fi/',
+      name: 'matka.fintraffic.fi',
+      href: 'https://matka.fintraffic.fi/',
     },
     sv: {
-      name: 'matka.fi',
-      href: 'https://opas.matka.fi/sv/',
+      name: 'matka.fintraffic.fi',
+      href: 'https://matka.fintraffic.fi/sv/',
     },
     en: {
-      name: 'matka.fi',
-      href: 'https://opas.matka.fi/en/',
+      name: 'matka.fintraffic.fi',
+      href: 'https://matka.fintraffic.fi/en/',
     },
   },
 

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -140,10 +140,10 @@ export default {
 
   meta: {
     description: APP_DESCRIPTION,
-    keywords: `reitti,reitit,opas,reittiopas,joukkoliikenne,joukkoliikenne, matkasuunnittelu, matkareitti, aikataulut, bussi, juna, metro, raitiovaunu, lautta, matka, suomen joukkoliikenne, reitti kartalla, matkareitti ovelta ovelle, opas.matka.fi, fintraffic matka, digitransit, reittiopas suomi, liikenneopas, julkinen liikenne, reittihaku, liityntäpysäköinti, pyöräily, autoilu, lennot, matkakumppani, matkaketju, reitti yhdellä haulla`,
+    keywords: `reitti,reitit,opas,reittiopas,joukkoliikenne,joukkoliikenne, matkasuunnittelu, matkareitti, aikataulut, bussi, juna, metro, raitiovaunu, lautta, matka, suomen joukkoliikenne, reitti kartalla, matkareitti ovelta ovelle, matka.fintraffic.fi, fintraffic matka, digitransit, reittiopas suomi, liikenneopas, julkinen liikenne, reittihaku, liityntäpysäköinti, pyöräily, autoilu, lennot, matkakumppani, matkaketju, reitti yhdellä haulla`,
   },
   menu: {
-    copyright: { label: `© Matka.fi ${YEAR}` },
+    copyright: { label: `© Matka.fintraffic.fi ${YEAR}` },
     content: [
       {
         name: 'Fintraffic',

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -160,16 +160,16 @@ export default {
 
   nationalServiceLink: {
     fi: {
-      name: 'matka.fi',
-      href: 'https://opas.matka.fi/',
+      name: 'matka.fintraffic.fi',
+      href: 'https://matka.fintraffic.fi/',
     },
     sv: {
-      name: 'matka.fi',
-      href: 'https://opas.matka.fi/sv/',
+      name: 'matka.fintraffic.fi',
+      href: 'https://matka.fintraffic.fi/',
     },
     en: {
-      name: 'matka.fi',
-      href: 'https://opas.matka.fi/en/',
+      name: 'matka.fintraffic.fi',
+      href: 'https://matka.fintraffic.fi/',
     },
   },
 

--- a/sass/themes/matka/_theme.scss
+++ b/sass/themes/matka/_theme.scss
@@ -1,4 +1,4 @@
-/* matka.fi theme */
+/* matka.fintraffic.fi theme */
 
 /* Base theme */
 @import '../default/theme';

--- a/test/unit/component/NoItinerariesNote.test.js
+++ b/test/unit/component/NoItinerariesNote.test.js
@@ -44,16 +44,16 @@ mockContext.config = {
   minDistanceBetweenFromAndTo: 100.0,
   nationalServiceLink: {
     fi: {
-      name: 'matka.fi',
-      href: 'https://opas.matka.fi/',
+      name: 'matka.fintraffic.fi',
+      href: 'https://matka.fintraffic.fi/',
     },
     sv: {
-      name: 'matka.fi',
-      href: 'https://opas.matka.fi/sv/',
+      name: 'matka.fintraffic.fi',
+      href: 'https://matka.fintraffic.fi/sv/',
     },
     en: {
-      name: 'matka.fi',
-      href: 'https://opas.matka.fi/en/',
+      name: 'matka.fintraffic.fi',
+      href: 'https://matka.fintraffic.fi/en/',
     },
   },
 };


### PR DESCRIPTION
## Proposed Changes

  - opas.matka.fi's new domain is matka.fintraffic.fi. We still had some references to the old URL.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
