### PR TITLE
AB#229 Fix duplicate color definition

### DIFF
--- a/app/component/itinerary/customize-search.scss
+++ b/app/component/itinerary/customize-search.scss
@@ -38,7 +38,7 @@
   padding: 16px;
   gap: var(--space-xs, 8px);
   border-radius: var(--border-radius-bigger, 8px);
-  background: $success-color;
+  background: $success-bar-color;
   box-shadow: 0 4px 4px 0 var(--color-shadow-weak, rgba(0, 52, 86, 0.25));
   overflow: hidden;
   text-overflow: ellipsis;

--- a/sass/themes/default/_theme.scss
+++ b/sass/themes/default/_theme.scss
@@ -69,7 +69,7 @@ $disclaimer-background-color: rgba(254, 209, 0, 0.1);
 $disclaimer-border-color: #fed100;
 $navigation-background-color: $background-color-lighter;
 $route-title-margin: 2.7em;
-$success-color: #3b7f00;
+$success-bar-color: #3b7f00;
 $attention-color: #c53291;
 
 /* Vehicle palette */


### PR DESCRIPTION
## Proposed Changes

  - The variable success-color was already defined in the theme so the new definition unfortunately overrode the color where it shouldn't (travel companion start prompt). The success bar now has its own color variable.  

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
