### PR TITLE
AB#306 add error tolerance in ticket zone assembly

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -223,8 +223,8 @@ function setUpAvailableTickets() {
 
 function getZoneUrl(json) {
   const zoneLayer =
-    !json.noZoneSharing &&
-    json.layers.find(
+    !json?.noZoneSharing &&
+    json?.layers.find(
       layer => layer.name.fi === 'Vyöhykkeet' || layer.name.en === 'Zones',
     );
   if (zoneLayer && !allZones) {
@@ -235,8 +235,13 @@ function getZoneUrl(json) {
 }
 
 async function fetchGeoJsonConfig(url) {
-  const response = await getJson(url);
-  return response.geoJson || response.geojson;
+  try {
+    const response = await getJson(url);
+    return response.geoJson || response.geojson;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
 }
 
 function collectGeoJsonZones() {


### PR DESCRIPTION
Matka UI server got into crash loop when Turku geojson api was down.  Ticket zones on map are not vital information - UI server should simply start without some zone data.

This PR adds error catching in geojson configuration fetching. It can be tested by adding bad geojson config url into config.turku.js and starting UI server as:

`ASSEMBLE_GEOJSON=1 ui matka`



