### PR TITLE
Do not use city icon when a station/stop has a name 'city, city'

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^6.0.2",
+    "@digitransit-component/digitransit-component-autosuggest": "^6.0.3",
     "@digitransit-component/digitransit-component-icon": "^1.1.0",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^6.0.1",
+    "@digitransit-component/digitransit-component-autosuggest": "^6.0.2",
     "@digitransit-component/digitransit-component-icon": "^1.1.0",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [
@@ -29,7 +29,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": "^3.3.0",
+    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": "^3.3.1",
     "@digitransit-search-util/digitransit-search-util-get-label": "^1.0.1",
     "@digitransit-search-util/digitransit-search-util-uniq-by-label": "^2.1.0",
     "@hsl-fi/hooks": "^1.2.4"

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "@digitransit-component/digitransit-component-dialog-modal": "^2.0.0",
     "@digitransit-component/digitransit-component-icon": "^1.1.0",
-    "@digitransit-component/digitransit-component-suggestion-item": "^2.3.0",
+    "@digitransit-component/digitransit-component-suggestion-item": "^2.3.1",
     "@hsl-fi/sass": "^0.2.0",
     "classnames": "2.5.1",
     "i18next": "^22.5.1",

--- a/digitransit-component/packages/digitransit-component-favourite-bar/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-bar",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "digitransit-component favourite-bar module",
   "main": "index.js",
   "files": [
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@digitransit-component/digitransit-component-icon": "^1.1.0",
-    "@digitransit-component/digitransit-component-suggestion-item": "^2.3.0",
+    "@digitransit-component/digitransit-component-suggestion-item": "^2.3.1",
     "@hsl-fi/sass": "^0.2.0",
     "@hsl-fi/shimmer": "0.1.2",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-suggestion-item/package.json
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-suggestion-item",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "digitransit-component suggestion-item module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/src/index.js
@@ -103,6 +103,8 @@ function getAriaDescription(ariaContentArray) {
   return description?.toLowerCase();
 }
 
+const stopLayers = ['station', 'stop'];
+
 function getIconProperties(item, modeSet, stopCode, modes) {
   let iconId;
 
@@ -132,7 +134,11 @@ function getIconProperties(item, modeSet, stopCode, modes) {
     if (item.properties.layer === 'bikepark') {
       return [`bike-park`];
     }
-    if (item.properties.label?.split(',').length === 1 && !isFavourite(item)) {
+    if (
+      item.properties.label?.split(',').length === 1 &&
+      !isFavourite(item) &&
+      !stopLayers.includes(item.properties.layer)
+    ) {
       return ['city'];
     }
     iconId = item.properties.layer;

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-component",
   "module": "digitransit-component.mjs",
@@ -14,14 +14,14 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^6.0.2",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^7.0.2",
+    "@digitransit-component/digitransit-component-autosuggest": "^6.0.3",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^7.0.3",
     "@digitransit-component/digitransit-component-control-panel": "^6.0.1",
-    "@digitransit-component/digitransit-component-favourite-bar": "^4.0.1",
+    "@digitransit-component/digitransit-component-favourite-bar": "^4.0.2",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^4.0.0",
     "@digitransit-component/digitransit-component-favourite-modal": "^3.0.0",
     "@digitransit-component/digitransit-component-icon": "^1.1.0",
-    "@digitransit-component/digitransit-component-suggestion-item": "^2.3.0",
+    "@digitransit-component/digitransit-component-suggestion-item": "^2.3.1",
     "@digitransit-component/digitransit-component-with-breakpoint": "^1.0.0"
   },
   "peerDependencies": {

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -14,8 +14,8 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^6.0.1",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^7.0.1",
+    "@digitransit-component/digitransit-component-autosuggest": "^6.0.2",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^7.0.2",
     "@digitransit-component/digitransit-component-control-panel": "^6.0.1",
     "@digitransit-component/digitransit-component-favourite-bar": "^4.0.1",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^4.0.0",

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-execute-search-immidiate",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "digitransit-search-util execute-search-immidiate module",
   "main": "index.js",
   "publishConfig": {
@@ -24,7 +24,7 @@
     "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "0.0.3",
     "@digitransit-search-util/digitransit-search-util-get-geocoding-results": "0.0.8",
     "@digitransit-search-util/digitransit-search-util-get-json": "0.0.7",
-    "@digitransit-search-util/digitransit-search-util-helpers": "2.3.0",
+    "@digitransit-search-util/digitransit-search-util-helpers": "2.3.1",
     "lodash": "4.17.21"
   }
 }

--- a/digitransit-search-util/packages/digitransit-search-util-helpers/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-helpers/index.js
@@ -60,7 +60,9 @@ export const mapRoute = (item, pathOpts) => {
   const routesPrefix = opts.routesPrefix || DEFAULT_ROUTES_PREFIX;
   const stopsPrefix = opts.stopsPrefix || DEFAULT_STOPS_PREFIX;
 
-  const link = `/${routesPrefix}/${item.gtfsId}/${stopsPrefix}`;
+  const link = `/${routesPrefix}/${encodeURIComponent(
+    item.gtfsId,
+  )}/${stopsPrefix}`;
   return {
     type: 'Route',
     properties: {

--- a/digitransit-search-util/packages/digitransit-search-util-helpers/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-helpers",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "digitransit-search-util helpers module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-query-utils",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "digitransit-search-util query-utils module",
   "main": "lib/index.js",
   "publishConfig": {
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "0.0.3",
-    "@digitransit-search-util/digitransit-search-util-helpers": "2.3.0",
+    "@digitransit-search-util/digitransit-search-util-helpers": "2.3.1",
     "@digitransit-search-util/digitransit-search-util-route-name-compare": "0.0.2",
     "babel-plugin-relay": "16.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,11 +1996,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@^7.0.2, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@^7.0.3, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^6.0.2
+    "@digitransit-component/digitransit-component-autosuggest": ^6.0.3
     "@digitransit-component/digitransit-component-icon": ^1.1.0
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
@@ -2016,7 +2016,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@^6.0.2, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@^6.0.3, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
@@ -2027,7 +2027,7 @@ __metadata:
   peerDependencies:
     "@digitransit-component/digitransit-component-dialog-modal": ^2.0.0
     "@digitransit-component/digitransit-component-icon": ^1.1.0
-    "@digitransit-component/digitransit-component-suggestion-item": ^2.3.0
+    "@digitransit-component/digitransit-component-suggestion-item": ^2.3.1
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
     i18next: ^22.5.1
@@ -2090,14 +2090,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-favourite-bar@^4.0.1, @digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar":
+"@digitransit-component/digitransit-component-favourite-bar@^4.0.2, @digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar"
   dependencies:
     "@digitransit-search-util/digitransit-search-util-uniq-by-label": ^2.1.0
   peerDependencies:
     "@digitransit-component/digitransit-component-icon": ^1.1.0
-    "@digitransit-component/digitransit-component-suggestion-item": ^2.3.0
+    "@digitransit-component/digitransit-component-suggestion-item": ^2.3.1
     "@hsl-fi/sass": ^0.2.0
     "@hsl-fi/shimmer": 0.1.2
     classnames: 2.5.1
@@ -2155,7 +2155,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-suggestion-item@^2.3.0, @digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item":
+"@digitransit-component/digitransit-component-suggestion-item@^2.3.1, @digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item"
   peerDependencies:
@@ -2195,14 +2195,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^6.0.2
-    "@digitransit-component/digitransit-component-autosuggest-panel": ^7.0.2
+    "@digitransit-component/digitransit-component-autosuggest": ^6.0.3
+    "@digitransit-component/digitransit-component-autosuggest-panel": ^7.0.3
     "@digitransit-component/digitransit-component-control-panel": ^6.0.1
-    "@digitransit-component/digitransit-component-favourite-bar": ^4.0.1
+    "@digitransit-component/digitransit-component-favourite-bar": ^4.0.2
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^4.0.0
     "@digitransit-component/digitransit-component-favourite-modal": ^3.0.0
     "@digitransit-component/digitransit-component-icon": ^1.1.0
-    "@digitransit-component/digitransit-component-suggestion-item": ^2.3.0
+    "@digitransit-component/digitransit-component-suggestion-item": ^2.3.1
     "@digitransit-component/digitransit-component-with-breakpoint": ^1.0.0
   peerDependencies:
     "@digitransit-component/digitransit-component-dialog-modal": ^2.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,11 +1996,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@^7.0.1, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@^7.0.2, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^6.0.1
+    "@digitransit-component/digitransit-component-autosuggest": ^6.0.2
     "@digitransit-component/digitransit-component-icon": ^1.1.0
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
@@ -2016,11 +2016,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@^6.0.1, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@^6.0.2, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": ^3.3.0
+    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": ^3.3.1
     "@digitransit-search-util/digitransit-search-util-get-label": ^1.0.1
     "@digitransit-search-util/digitransit-search-util-uniq-by-label": ^2.1.0
     "@hsl-fi/hooks": ^1.2.4
@@ -2195,8 +2195,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^6.0.1
-    "@digitransit-component/digitransit-component-autosuggest-panel": ^7.0.1
+    "@digitransit-component/digitransit-component-autosuggest": ^6.0.2
+    "@digitransit-component/digitransit-component-autosuggest-panel": ^7.0.2
     "@digitransit-component/digitransit-component-control-panel": ^6.0.1
     "@digitransit-component/digitransit-component-favourite-bar": ^4.0.1
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^4.0.0
@@ -2231,14 +2231,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-execute-search-immidiate@^3.3.0, @digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate":
+"@digitransit-search-util/digitransit-search-util-execute-search-immidiate@^3.3.1, @digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate"
   dependencies:
     "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": 0.0.3
     "@digitransit-search-util/digitransit-search-util-get-geocoding-results": 0.0.8
     "@digitransit-search-util/digitransit-search-util-get-json": 0.0.7
-    "@digitransit-search-util/digitransit-search-util-helpers": 2.3.0
+    "@digitransit-search-util/digitransit-search-util-helpers": 2.3.1
     lodash: 4.17.21
   languageName: unknown
   linkType: soft
@@ -2276,7 +2276,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-helpers@2.3.0, @digitransit-search-util/digitransit-search-util-helpers@workspace:digitransit-search-util/packages/digitransit-search-util-helpers":
+"@digitransit-search-util/digitransit-search-util-helpers@2.3.1, @digitransit-search-util/digitransit-search-util-helpers@workspace:digitransit-search-util/packages/digitransit-search-util-helpers":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-helpers@workspace:digitransit-search-util/packages/digitransit-search-util-helpers"
   dependencies:
@@ -2298,7 +2298,7 @@ __metadata:
   resolution: "@digitransit-search-util/digitransit-search-util-query-utils@workspace:digitransit-search-util/packages/digitransit-search-util-query-utils"
   dependencies:
     "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": 0.0.3
-    "@digitransit-search-util/digitransit-search-util-helpers": 2.3.0
+    "@digitransit-search-util/digitransit-search-util-helpers": 2.3.1
     "@digitransit-search-util/digitransit-search-util-route-name-compare": 0.0.2
     babel-plugin-relay: 16.2.0
     relay-compiler: 16.2.0


### PR DESCRIPTION
Recent SuggestionItem refactoring removed a logic which reassigned stop or station icon to items which have a city like name such  as Järvenpää, Järvenpää.

This PR adds a condition to ensure that stops and stations get a proper icon.  

Another minor change is encoding GTFS route id embedded in links returned by search. 
