### PR TITLE
AB#301 render short waiting on a stop

### DIFF
--- a/app/component/itinerary/Legs.js
+++ b/app/component/itinerary/Legs.js
@@ -145,6 +145,10 @@ export default class Legs extends React.Component {
         previousLeg?.mode === 'BICYCLE' && previousLeg.to.vehicleParking;
       const carPark =
         previousLeg?.mode === 'CAR' && previousLeg.to.vehicleParking;
+      const isSameStopTransfer =
+        leg.transitLeg &&
+        nextLeg?.transitLeg &&
+        leg.to.stop.gtfsId === nextLeg.from.stop.gtfsId;
       const legProps = {
         leg,
         index: j,
@@ -166,15 +170,15 @@ export default class Legs extends React.Component {
         const waitThresholdInMs = waitThreshold * 1000;
         const waitTime = legTime(nextLeg.start) - legTime(leg.end);
         if (
-          waitTime > waitThresholdInMs &&
-          (nextLeg != null ? nextLeg.mode : null) !== 'AIRPLANE' &&
+          (waitTime > waitThresholdInMs || isSameStopTransfer) &&
+          nextLeg.mode !== 'AIRPLANE' &&
           leg.mode !== 'AIRPLANE' &&
           !nextLeg.intermediatePlace &&
           !isNextLegInterlining &&
           leg.to.stop
         ) {
           const waitLegProps = { ...leg };
-          if (nextLeg && nextLeg.isViaPoint) {
+          if (nextLeg.isViaPoint) {
             waitLegProps.isViaPoint = true;
             nextLeg.isViaPoint = false;
           }


### PR DESCRIPTION
UI should render short wait leg when transfer happens in a single stop. Merging a short wait to a walk leg is OK but when there is no walking, itinerary becomes hard to understand.

An example: 
http://localhost:8080/reitti/Amuri%2C%20Tampere%3A%3A61.500276%2C23.74064/Loukonlahti%2C%20(asutuskohde)%2C%20Pirkkala%3A%3A61.471409%2C23.681408/0?setTime=true&time=1764153900
