### PR TITLE
Utility to generate stop page links

### DIFF
--- a/app/component/AlertRow.js
+++ b/app/component/AlertRow.js
@@ -10,7 +10,7 @@ import ExternalLink from './ExternalLink';
 import Icon from './Icon';
 import RouteNumber from './RouteNumber';
 import ServiceAlertIcon from './ServiceAlertIcon';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../util/path';
+import { routePagePath, PREFIX_STOPS } from '../util/path';
 import {
   entityCompare,
   getEntitiesOfType,
@@ -139,7 +139,7 @@ export default function AlertRow(
               onClickLink?.();
             }}
             key={`${gtfsIdList[i]}-${index}`}
-            to={`/${PREFIX_ROUTES}/${gtfsIdList[i]}/${PREFIX_STOPS}`}
+            to={routePagePath(gtfsIdList[i], PREFIX_STOPS)}
             className={cx('alert-row-link', routeMode)}
             style={{ color: routeColor }}
             aria-label={`${intl.formatMessage({

--- a/app/component/AlertRow.js
+++ b/app/component/AlertRow.js
@@ -10,7 +10,7 @@ import ExternalLink from './ExternalLink';
 import Icon from './Icon';
 import RouteNumber from './RouteNumber';
 import ServiceAlertIcon from './ServiceAlertIcon';
-import { routePagePath, PREFIX_STOPS } from '../util/path';
+import { routePagePath, stopPagePath, PREFIX_STOPS } from '../util/path';
 import {
   entityCompare,
   getEntitiesOfType,
@@ -160,7 +160,7 @@ export default function AlertRow(
               onClickLink?.();
             }}
             key={`${gtfsIdList[i]}-${index}`}
-            to={`/${PREFIX_STOPS}/${gtfsIdList[i]}`}
+            to={stopPagePath(false, gtfsIdList[i])}
             className={cx('alert-row-link', routeMode)}
             aria-label={`${intl.formatMessage({
               id: 'stop',

--- a/app/component/DepartureRow.js
+++ b/app/component/DepartureRow.js
@@ -13,7 +13,7 @@ import { addAnalyticsEvent } from '../util/analyticsUtils';
 import { getHeadsignFromRouteLongName } from '../util/legUtils';
 import { getRouteMode } from '../util/modeUtils';
 import { getCapacity } from '../util/occupancyUtil';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../util/path';
+import { routePagePath, PREFIX_STOPS } from '../util/path';
 import { configShape, departureShape } from '../util/shapes';
 import { epochToTime } from '../util/timeUtils';
 import Icon from './Icon';
@@ -68,7 +68,7 @@ export default function DepartureRow(
   }
   const headsign =
     departure.headsign ||
-    departure.trip.tripHeadsign ||
+    trip.tripHeadsign ||
     getHeadsignFromRouteLongName(trip.route);
   let shownTime;
   if (timeDiffInMinutes <= 0) {
@@ -87,7 +87,7 @@ export default function DepartureRow(
       { minutes: timeDiffInMinutes },
     );
   }
-  const { shortName } = departure.trip.route;
+  const { shortName } = trip.route;
   const lowerCaseShortName = shortName?.toLowerCase();
   const nameOrIcon =
     shortName?.length > 6 || !shortName?.length ? (
@@ -98,7 +98,7 @@ export default function DepartureRow(
 
   const capacity = getCapacity(
     config,
-    trip?.occupancy?.occupancyStatus,
+    trip.occupancy?.occupancyStatus,
     departureTimeMs,
   );
 
@@ -133,11 +133,12 @@ export default function DepartureRow(
     <Link
       as="tr"
       tabIndex={isParentTabActive ? '0' : '-1'}
-      to={`/${PREFIX_ROUTES}/${encodeURIComponent(
-        departure.trip.pattern.route.gtfsId,
-      )}/${PREFIX_STOPS}/${encodeURIComponent(
-        departure.trip.pattern.code,
-      )}/${encodeURIComponent(departure.trip.gtfsId)}`}
+      to={routePagePath(
+        trip.pattern.route.gtfsId,
+        PREFIX_STOPS,
+        trip.pattern.code,
+        trip.gtfsId,
+      )}
       onClick={() => {
         addAnalyticsEvent({
           category: 'Stop',
@@ -153,13 +154,13 @@ export default function DepartureRow(
         departure.bottomRow ? 'bottom' : '',
         props.className,
       )}
-      key={departure.trip.gtfsId}
+      key={trip.gtfsId}
     >
       <td
         className={cx('route-number-container', {
           long: shortName && shortName.length <= 6 && shortName.length >= 5,
         })}
-        style={{ backgroundColor: `#${departure.trip.route.color}` }}
+        style={{ backgroundColor: `#${trip.route.color}` }}
       >
         <div aria-hidden="true" className="route-number">
           {nameOrIcon}

--- a/app/component/itinerary/AirportCheckInLeg.js
+++ b/app/component/itinerary/AirportCheckInLeg.js
@@ -7,7 +7,7 @@ import { legTimeStr } from '../../util/legUtils';
 import ItineraryCircleLine from './ItineraryCircleLine';
 import Icon from '../Icon';
 import ItineraryMapAction from './ItineraryMapAction';
-import { PREFIX_STOPS } from '../../util/path';
+import { stopPagePath } from '../../util/path';
 
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 export default function AirportCheckInLeg(props, { config }) {
@@ -32,7 +32,7 @@ export default function AirportCheckInLeg(props, { config }) {
               onClick={e => {
                 e.stopPropagation();
               }}
-              to={`/${PREFIX_STOPS}/${props.leg.from.stop.gtfsId}`}
+              to={stopPagePath(false, props.leg.from.stop.gtfsId)}
             >
               {name}
               <Icon

--- a/app/component/itinerary/AirportCollectLuggageLeg.js
+++ b/app/component/itinerary/AirportCollectLuggageLeg.js
@@ -7,7 +7,7 @@ import { legTimeStr } from '../../util/legUtils';
 import Icon from '../Icon';
 import ItineraryCircleLine from './ItineraryCircleLine';
 import ItineraryMapAction from './ItineraryMapAction';
-import { PREFIX_STOPS } from '../../util/path';
+import { stopPagePath } from '../../util/path';
 
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 function AirportCollectLuggageLeg(props, { config }) {
@@ -32,7 +32,7 @@ function AirportCollectLuggageLeg(props, { config }) {
               onClick={e => {
                 e.stopPropagation();
               }}
-              to={`/${PREFIX_STOPS}/${props.leg.to.stop.gtfsId}`}
+              to={stopPagePath(false, props.leg.to.stop.gtfsId)}
             >
               {name}
               <Icon

--- a/app/component/itinerary/BicycleLeg.js
+++ b/app/component/itinerary/BicycleLeg.js
@@ -12,7 +12,7 @@ import { displayDistance } from '../../util/geo-utils';
 import { durationToString } from '../../util/timeUtils';
 import ItineraryCircleLine from './ItineraryCircleLine';
 import ItineraryCircleLineLong from './ItineraryCircleLineLong';
-import { PREFIX_STOPS } from '../../util/path';
+import { stopPagePath } from '../../util/path';
 import {
   getRentalNetworkConfig,
   RentalNetworkType,
@@ -273,7 +273,7 @@ export default function BicycleLeg(
                     onClick={e => {
                       e.stopPropagation();
                     }}
-                    to={`/${PREFIX_STOPS}/${fromStop.gtfsId}`}
+                    to={stopPagePath(false, fromStop.gtfsId)}
                   >
                     {origin}
                     {leg.isViaPoint && (

--- a/app/component/itinerary/IntermediateLeg.js
+++ b/app/component/itinerary/IntermediateLeg.js
@@ -5,7 +5,7 @@ import Link from 'found/Link';
 import { configShape, legTimeShape } from '../../util/shapes';
 import { legTimeStr } from '../../util/legUtils';
 import ZoneIcon from '../ZoneIcon';
-import { PREFIX_STOPS } from '../../util/path';
+import { stopPagePath } from '../../util/path';
 import Icon from '../Icon';
 
 function IntermediateLeg(
@@ -138,7 +138,7 @@ function IntermediateLeg(
           onClick={e => {
             e.stopPropagation();
           }}
-          to={`/${PREFIX_STOPS}/${gtfsId}`}
+          to={stopPagePath(false, gtfsId)}
         >
           <div
             className="itinerary-leg-row-intermediate"

--- a/app/component/itinerary/LegInfo.js
+++ b/app/component/itinerary/LegInfo.js
@@ -8,7 +8,7 @@ import { legShape, configShape } from '../../util/shapes';
 import { legTimeStr } from '../../util/legUtils';
 import { getRouteMode } from '../../util/modeUtils';
 import RouteNumber from '../RouteNumber';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../../util/path';
+import { routePagePath, PREFIX_STOPS } from '../../util/path';
 import { getCapacityForLeg } from '../../util/occupancyUtil';
 import Icon from '../Icon';
 import CapacityModal from '../CapacityModal';
@@ -35,7 +35,7 @@ export default function LegInfo(
   const mode = isCallAgency
     ? 'call'
     : getRouteMode(
-        { mode: leg.mode, type: leg.route.type, gtfsId: leg.route?.gtfsId },
+        { mode: leg.mode, type: leg.route.type, gtfsId: leg.route.gtfsId },
         config,
       );
   const capacity = getCapacityForLeg(config, leg);
@@ -56,12 +56,12 @@ export default function LegInfo(
         onClick={e => {
           e.stopPropagation();
         }}
-        to={
-          `/${PREFIX_ROUTES}/${leg.route.gtfsId}/${PREFIX_STOPS}/${
-            leg.trip.pattern.code
-          }${shouldLinkToTrip ? `/${leg.trip.gtfsId}` : ''}`
-          // TODO: Create a helper function for generating links
-        }
+        to={routePagePath(
+          leg.route.gtfsId,
+          PREFIX_STOPS,
+          leg.trip.pattern.code,
+          shouldLinkToTrip && leg.trip.gtfsId,
+        )}
         aria-label={`${intl.formatMessage({
           id: mode,
           defaultMessage: 'Vehicle',

--- a/app/component/itinerary/TransitLeg.js
+++ b/app/component/itinerary/TransitLeg.js
@@ -24,7 +24,7 @@ import {
 } from '../../util/alertUtils';
 import {
   PREFIX_DISRUPTION,
-  PREFIX_ROUTES,
+  routePagePath,
   PREFIX_STOPS,
 } from '../../util/path';
 import { durationToString } from '../../util/timeUtils';
@@ -564,7 +564,11 @@ class TransitLeg extends React.Component {
                 <Link
                   to={
                     (hasEntitiesOfType(alert, AlertEntityType.Route) &&
-                      `/${PREFIX_ROUTES}/${leg.route.gtfsId}/${PREFIX_DISRUPTION}/${leg.trip.pattern.code}`) ||
+                      routePagePath(
+                        leg.route.gtfsId,
+                        PREFIX_DISRUPTION,
+                        leg.trip.pattern.code,
+                      )) ||
                     (hasEntitiesOfType(alert, AlertEntityType.Stop) &&
                       `/${PREFIX_STOPS}/${alert.entities[0].gtfsId}/${PREFIX_DISRUPTION}/`)
                   }

--- a/app/component/itinerary/TransitLeg.js
+++ b/app/component/itinerary/TransitLeg.js
@@ -25,7 +25,7 @@ import {
 import {
   PREFIX_DISRUPTION,
   routePagePath,
-  PREFIX_STOPS,
+  stopPagePath,
 } from '../../util/path';
 import { durationToString } from '../../util/timeUtils';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
@@ -477,7 +477,7 @@ class TransitLeg extends React.Component {
                     name: mode,
                   });
                 }}
-                to={`/${PREFIX_STOPS}/${leg.from.stop.gtfsId}`}
+                to={stopPagePath(false, leg.from.stop.gtfsId)}
               >
                 {leg.from.name}
                 {leg.isViaPoint && (
@@ -570,7 +570,11 @@ class TransitLeg extends React.Component {
                         leg.trip.pattern.code,
                       )) ||
                     (hasEntitiesOfType(alert, AlertEntityType.Stop) &&
-                      `/${PREFIX_STOPS}/${alert.entities[0].gtfsId}/${PREFIX_DISRUPTION}/`)
+                      stopPagePath(
+                        false,
+                        alert.entities[0].gtfsId,
+                        PREFIX_DISRUPTION,
+                      ))
                   }
                   className="disruption-link"
                 >

--- a/app/component/map/route/PopupHeader.js
+++ b/app/component/map/route/PopupHeader.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Link from 'found/Link';
 import cx from 'classnames';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../../../util/path';
+import { routePagePath, PREFIX_STOPS } from '../../../util/path';
 import { convertTo24HourFormat } from '../../../util/timeUtils';
 import RouteNumber from '../../RouteNumber';
 import { getRouteMode } from '../../../util/modeUtils';
@@ -29,9 +29,7 @@ export default function PopupHeader({
 
   const routeLine =
     startTime && pattern ? (
-      <Link
-        to={`/${PREFIX_ROUTES}/${route.gtfsId}/${PREFIX_STOPS}/${pattern.code}`}
-      >
+      <Link to={routePagePath(route.gtfsId, PREFIX_STOPS, pattern.code)}>
         {routeLineText}
       </Link>
     ) : (

--- a/app/component/map/route/TripMarkerPopup.js
+++ b/app/component/map/route/TripMarkerPopup.js
@@ -4,26 +4,32 @@ import { createFragmentContainer, graphql } from 'react-relay';
 
 import Link from 'found/Link';
 import { FormattedMessage } from 'react-intl';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../../../util/path';
+import { routePagePath, PREFIX_STOPS } from '../../../util/path';
 
 import PopupHeader from './PopupHeader';
 
 import { addAnalyticsEvent } from '../../../util/analyticsUtils';
 
-function TripMarkerPopup(props) {
-  let patternPath = `/${PREFIX_ROUTES}/${props.trip.route.gtfsId}/${PREFIX_STOPS}`;
-  let tripPath = patternPath;
-
-  patternPath += `/${props.trip.pattern.code}`;
-  tripPath = `${patternPath}/${props.trip.gtfsId}`;
+function TripMarkerPopup({ trip, message }) {
+  const patternPath = routePagePath(
+    trip.route.gtfsId,
+    PREFIX_STOPS,
+    trip.pattern.code,
+  );
+  const tripPath = routePagePath(
+    trip.route.gtfsId,
+    PREFIX_STOPS,
+    trip.pattern.code,
+    trip.gtfsId,
+  );
 
   return (
     <div className="card">
       <PopupHeader
         card
-        route={props.trip.route}
-        pattern={props.trip.pattern}
-        startTime={props.message.tripStartTime}
+        route={trip.route}
+        pattern={trip.pattern}
+        startTime={message.tripStartTime}
       />
       <div className="bottom location">
         <Link
@@ -32,7 +38,7 @@ function TripMarkerPopup(props) {
             addAnalyticsEvent({
               category: 'Map',
               action: 'OpenTripInformation',
-              name: props.trip.route.mode,
+              name: trip.route.mode,
             });
           }}
         >

--- a/app/component/map/tile-layer/SelectStopRow.js
+++ b/app/component/map/tile-layer/SelectStopRow.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Link from 'found/Link';
 import { FormattedMessage } from 'react-intl';
 import Icon from '../../Icon';
-import { PREFIX_TERMINALS, PREFIX_STOPS } from '../../../util/path';
+import { stopPagePath } from '../../../util/path';
 import { configShape } from '../../../util/shapes';
 import { getStopMode, transitIconName } from '../../../util/modeUtils';
 import { getModeIconColor } from '../../../util/colorUtils';
@@ -28,12 +28,8 @@ function SelectStopRow(
   const showDesc = desc && desc !== 'null';
   const showCode = code && code !== 'null';
 
-  const prefix = terminal ? PREFIX_TERMINALS : PREFIX_STOPS;
   return (
-    <Link
-      className="stop-popup-choose-row"
-      to={`/${prefix}/${encodeURIComponent(gtfsId)}`}
-    >
+    <Link className="stop-popup-choose-row" to={stopPagePath(terminal, gtfsId)}>
       <span className="choose-row-left-column" aria-hidden="true">
         <Icon
           className={iconOptions.className}

--- a/app/component/map/tile-layer/SelectVehicleRow.js
+++ b/app/component/map/tile-layer/SelectVehicleRow.js
@@ -3,34 +3,33 @@ import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 
 import Link from 'found/Link';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../../../util/path';
+import { routePagePath, PREFIX_STOPS } from '../../../util/path';
 import { getRouteMode } from '../../../util/modeUtils';
 import Icon from '../../Icon';
 
-function SelectVehicleRow(props) {
-  const mode = getRouteMode(props.trip.route);
+function SelectVehicleRow({ trip }) {
+  const mode = getRouteMode(trip.route);
   const iconId = `icon_${mode || 'bus'}`;
 
-  let patternPath = `/${PREFIX_ROUTES}/${props.trip.route.gtfsId}/${PREFIX_STOPS}`;
+  const patternPath = routePagePath(
+    trip.route.gtfsId,
+    PREFIX_STOPS,
+    trip.pattern.code,
+    trip.gtfsId,
+  );
 
-  patternPath += `/${props.trip.pattern.code}/${props.trip.gtfsId}`;
-
-  const name = props.trip.pattern.headsign || props.trip.route.longName;
+  const name = trip.pattern.headsign || trip.route.longName;
   return (
     <Link className="stop-popup-choose-row" to={patternPath}>
       <span className="choose-row-left-column" aria-hidden="true">
         <Icon
           className={mode}
           img={iconId}
-          color={
-            props.trip.route.color
-              ? `#${props.trip.route.color}`
-              : 'currentColor'
-          }
+          color={trip.route.color ? `#${trip.route.color}` : 'currentColor'}
         />
       </span>
       <span className="choose-row-center-column">
-        <h5 className="choose-row-header">{props.trip.route.shortName}</h5>
+        <h5 className="choose-row-header">{trip.route.shortName}</h5>
         <span className="choose-row-text">
           <span className="choose-row-address">{name}</span>
         </span>

--- a/app/component/map/tile-layer/TileLayerContainer.js
+++ b/app/component/map/tile-layer/TileLayerContainer.js
@@ -21,9 +21,8 @@ import PreferencesStore from '../../../store/PreferencesStore';
 import { addAnalyticsEvent } from '../../../util/analyticsUtils';
 import { getClientBreakpoint } from '../../../util/withBreakpoint';
 import {
+  stopPagePath,
   PREFIX_BIKESTATIONS,
-  PREFIX_STOPS,
-  PREFIX_TERMINALS,
   PREFIX_CARPARK,
   PREFIX_BIKEPARK,
   PREFIX_RENTALVEHICLES,
@@ -240,13 +239,11 @@ class TileLayerContainer extends GridLayer {
         selectableTargets.length === 1 &&
         selectableTargets[0].layer === 'stop'
       ) {
-        const prefix = selectableTargets[0].feature.properties.stops
-          ? PREFIX_TERMINALS
-          : PREFIX_STOPS;
         this.context.router.push(
-          `/${prefix}/${encodeURIComponent(
+          stopPagePath(
+            selectableTargets[0].feature.properties.stops,
             selectableTargets[0].feature.properties.gtfsId,
-          )}`,
+          ),
         );
         return;
       }

--- a/app/component/nearyou/StopNearYou.js
+++ b/app/component/nearyou/StopNearYou.js
@@ -6,7 +6,7 @@ import connectToStores from 'fluxible-addons-react/connectToStores';
 import Modal from '@hsl-fi/modal';
 import { stopShape, configShape, relayShape } from '../../util/shapes';
 import { hasEntitiesOfType } from '../../util/alertUtils';
-import { PREFIX_STOPS, PREFIX_TERMINALS } from '../../util/path';
+import { stopPagePath, PREFIX_DISRUPTION } from '../../util/path';
 import { AlertEntityType } from '../../constants';
 import StopNearYouHeader from './StopNearYouHeader';
 import AlertBanner from '../AlertBanner';
@@ -22,8 +22,10 @@ const StopNearYou = (
   }
   const [capacityModalOpen, setCapacityModalOpen] = useState(false);
   const stopMode = stop.stoptimesWithoutPatterns[0]?.trip.route.mode;
+  const { gtfsId } = stop;
+
   useEffect(() => {
-    let id = stop.gtfsId;
+    let id = gtfsId;
     if (stopId) {
       id = stopId;
     }
@@ -33,17 +35,14 @@ const StopNearYou = (
       }, null);
     }
   }, [currentTime, currentMode]);
+
   const description = desc || stop.desc;
   const isStation = stop.locationType === 'STATION';
-  const { gtfsId } = stop;
-  const urlEncodedGtfsId = gtfsId.replace('/', '%2F');
-  const linkAddress = isStation
-    ? `/${PREFIX_TERMINALS}/${urlEncodedGtfsId}`
-    : `/${PREFIX_STOPS}/${urlEncodedGtfsId}`;
+  const linkAddress = stopPagePath(isStation, gtfsId, PREFIX_DISRUPTION);
 
   const { constantOperationStops } = config;
   const { locale } = intl;
-  const isConstantOperation = constantOperationStops[stop.gtfsId];
+  const isConstantOperation = constantOperationStops[gtfsId];
   const filteredAlerts = stop.alerts.filter(alert =>
     hasEntitiesOfType(alert, AlertEntityType.Stop),
   );
@@ -63,22 +62,19 @@ const StopNearYou = (
           />
         </span>
         {filteredAlerts.length > 0 && (
-          <AlertBanner
-            alerts={filteredAlerts}
-            linkAddress={`${linkAddress}/hairiot`}
-          />
+          <AlertBanner alerts={filteredAlerts} linkAddress={linkAddress} />
         )}
         {isConstantOperation ? (
           <div className="stop-constant-operation-container bottom-margin">
             <div style={{ width: '85%' }}>
-              <span>{constantOperationStops[stop.gtfsId][locale].text}</span>
+              <span>{constantOperationStops[gtfsId][locale].text}</span>
               <span style={{ display: 'inline-block' }}>
                 <a
-                  href={constantOperationStops[stop.gtfsId][locale].link}
+                  href={constantOperationStops[gtfsId][locale].link}
                   target="_blank"
                   rel="noreferrer"
                 >
-                  {constantOperationStops[stop.gtfsId][locale].link}
+                  {constantOperationStops[gtfsId][locale].link}
                 </a>
               </span>
             </div>

--- a/app/component/routepage/FuzzyTripLink.js
+++ b/app/component/routepage/FuzzyTripLink.js
@@ -7,7 +7,7 @@ import ReactRelayContext from 'react-relay/lib/ReactRelayContext';
 import { intlShape } from 'react-intl';
 import VehicleIcon from '../VehicleIcon';
 import TripLinkWithScroll from './TripLinkWithScroll';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../../util/path';
+import { routePagePath, PREFIX_STOPS } from '../../util/path';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 import { vehicleShape, tripShape } from '../../util/shapes';
 
@@ -110,7 +110,7 @@ function FuzzyTripLink({ vehicle, stopName, nextStopName, ...rest }, context) {
 
         return (
           <Link
-            to={`/${PREFIX_ROUTES}/${route}/${PREFIX_STOPS}/${pattern}/${trip}`}
+            to={routePagePath(route, PREFIX_STOPS, pattern, trip)}
             className="route-now-content"
             onClick={() => {
               addAnalyticsEvent({

--- a/app/component/routepage/PatternRedirector.js
+++ b/app/component/routepage/PatternRedirector.js
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import sortBy from 'lodash/sortBy';
 import { matchShape, routerShape } from 'found';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../../util/path';
+import { routePagePath, PREFIX_STOPS } from '../../util/path';
 import Error404 from '../404';
 import { saveSearchItems } from '../../action/SearchActions';
 import { getOldSearchItems } from '../../util/storeUtils';
@@ -54,9 +54,11 @@ const PatternRedirector = ({ router, match, route }, context) => {
         : undefined;
   }
 
-  const path = `/${PREFIX_ROUTES}/${match.params.routeId}/${
-    match.params.type || PREFIX_STOPS
-  }/${pattern ? pattern.code : `${match.params.routeId}:0:01`}`;
+  const path = routePagePath(
+    match.params.routeId,
+    match.params.type || PREFIX_STOPS,
+    pattern.code || `${match.params.routeId}:0:01`,
+  );
 
   useEffect(() => {
     router.replace(path);

--- a/app/component/routepage/PatternRedirector.js
+++ b/app/component/routepage/PatternRedirector.js
@@ -54,10 +54,11 @@ const PatternRedirector = ({ router, match, route }, context) => {
         : undefined;
   }
 
+  const { routeId, type } = match.params;
   const path = routePagePath(
-    match.params.routeId,
-    match.params.type || PREFIX_STOPS,
-    pattern.code || `${match.params.routeId}:0:01`,
+    routeId,
+    type || PREFIX_STOPS,
+    pattern.code || `${routeId}:0:01`,
   );
 
   useEffect(() => {

--- a/app/component/routepage/PatternStopsContainer.js
+++ b/app/component/routepage/PatternStopsContainer.js
@@ -29,16 +29,16 @@ class PatternStopsContainer extends React.PureComponent {
   };
 
   render() {
+    const routeId = this.props.route.gtfsId;
     if (!this.props.pattern) {
-      if (this.props.route.gtfsId) {
+      if (routeId) {
         // Redirect back to routes default pattern
-        this.props.router.replace(routePagePath(this.props.route.gtfsId));
+        this.props.router.replace(routePagePath(routeId));
       } else {
         return <Error404 />;
       }
       return false;
     }
-    const routeId = this.props.route.gtfsId;
     const { locale } = this.context.intl;
     const { constantOperationRoutes } = this.context.config;
 

--- a/app/component/routepage/PatternStopsContainer.js
+++ b/app/component/routepage/PatternStopsContainer.js
@@ -8,7 +8,7 @@ import { routeShape, configShape } from '../../util/shapes';
 import RouteStopListContainer from './RouteStopListContainer';
 import withBreakpoint from '../../util/withBreakpoint';
 import RouteControlPanel from './RouteControlPanel';
-import { PREFIX_ROUTES } from '../../util/path';
+import { routePagePath } from '../../util/path';
 import Error404 from '../404';
 import ScrollableWrapper from '../ScrollableWrapper';
 
@@ -32,9 +32,7 @@ class PatternStopsContainer extends React.PureComponent {
     if (!this.props.pattern) {
       if (this.props.route.gtfsId) {
         // Redirect back to routes default pattern
-        this.props.router.replace(
-          `/${PREFIX_ROUTES}/${this.props.route.gtfsId}`,
-        );
+        this.props.router.replace(routePagePath(this.props.route.gtfsId));
       } else {
         return <Error404 />;
       }

--- a/app/component/routepage/RouteControlPanel.js
+++ b/app/component/routepage/RouteControlPanel.js
@@ -27,7 +27,7 @@ import {
 import { isActiveDate } from '../../util/patternUtils';
 import {
   PREFIX_DISRUPTION,
-  PREFIX_ROUTES,
+  routePagePath,
   PREFIX_STOPS,
   PREFIX_TIMETABLE,
 } from '../../util/path';
@@ -326,9 +326,11 @@ class RouteControlPanel extends React.Component {
   }
 
   changeTab = tab => {
-    const path = `/${PREFIX_ROUTES}/${this.props.route.gtfsId}/${tab}/${
-      this.props.match.params.patternId || ''
-    }`;
+    const path = routePagePath(
+      this.props.route.gtfsId,
+      tab,
+      this.props.match.params.patternId,
+    );
     this.context.router.replace(path);
     let action;
     switch (tab) {

--- a/app/component/routepage/RouteControlPanel.js
+++ b/app/component/routepage/RouteControlPanel.js
@@ -26,8 +26,8 @@ import {
 } from '../../util/alertUtils';
 import { isActiveDate } from '../../util/patternUtils';
 import {
-  PREFIX_DISRUPTION,
   routePagePath,
+  PREFIX_DISRUPTION,
   PREFIX_STOPS,
   PREFIX_TIMETABLE,
 } from '../../util/path';
@@ -268,20 +268,21 @@ class RouteControlPanel extends React.Component {
       this.startClient(pattern[0]);
     }
 
-    let newPathname = decodeURIComponent(match.location.pathname).replace(
-      new RegExp(`${match.params.patternId}(.*)`),
+    let newPath = routePagePath(
+      this.props.route.gtfsId,
+      type || PREFIX_STOPS,
       newPattern,
     );
     if (type === PREFIX_TIMETABLE) {
       const today = unixToYYYYMMDD(unixTime(), config);
       if (pattern[0].minAndMaxDate && today < pattern[0].minAndMaxDate[0]) {
-        newPathname += `?serviceDay=${pattern[0].minAndMaxDate[0]}`;
+        newPath += `?serviceDay=${pattern[0].minAndMaxDate[0]}`;
       }
       if (match.query && match.query.serviceDay) {
-        newPathname += `?serviceDay=${match.query.serviceDay}`;
+        newPath += `?serviceDay=${match.query.serviceDay}`;
       }
     }
-    router.replace(newPathname);
+    router.replace(newPath);
   };
 
   startClient(pattern) {

--- a/app/component/routepage/RoutePage.js
+++ b/app/component/routepage/RoutePage.js
@@ -60,8 +60,7 @@ class RoutePage extends React.Component {
   render() {
     const { breakpoint, router, route, error, currentTime } = this.props;
     const { config } = this.context;
-    const tripId = this.props.match.params?.tripId;
-    const patternId = this.props.match.params?.patternId;
+    const { tripId, patternId, routeId } = this.props.match.params;
 
     if (route == null && !error) {
       /* In this case there is little we can do
@@ -140,9 +139,9 @@ class RoutePage extends React.Component {
               <AlertBanner
                 alerts={filteredAlerts}
                 linkAddress={routePagePath(
-                  this.props.match.params.routeId,
+                  routeId,
                   PREFIX_DISRUPTION,
-                  this.props.match.params.patternId,
+                  patternId,
                 )}
               />
             </div>

--- a/app/component/routepage/RoutePage.js
+++ b/app/component/routepage/RoutePage.js
@@ -10,7 +10,11 @@ import Icon from '../Icon';
 import RouteAgencyInfo from './RouteAgencyInfo';
 import RouteNumber from '../RouteNumber';
 import RouteControlPanel from './RouteControlPanel';
-import { PREFIX_DISRUPTION, PREFIX_ROUTES } from '../../util/path';
+import {
+  PREFIX_ROUTES,
+  PREFIX_DISRUPTION,
+  routePagePath,
+} from '../../util/path';
 import withBreakpoint from '../../util/withBreakpoint';
 import BackButton from '../BackButton';
 import { getRouteMode } from '../../util/modeUtils';
@@ -63,7 +67,7 @@ class RoutePage extends React.Component {
       /* In this case there is little we can do
        * There is no point continuing rendering as it can only
        * confuse user. Therefore redirect to Routes page */
-      router.replace(`/${PREFIX_ROUTES}`);
+      router.replace(PREFIX_ROUTES);
       return null;
     }
     const mode = getRouteMode(route, config);
@@ -135,7 +139,11 @@ class RoutePage extends React.Component {
             <div className="trip-page-alert-container">
               <AlertBanner
                 alerts={filteredAlerts}
-                linkAddress={`/${PREFIX_ROUTES}/${this.props.match.params.routeId}/${PREFIX_DISRUPTION}/${this.props.match.params.patternId}`}
+                linkAddress={routePagePath(
+                  this.props.match.params.routeId,
+                  PREFIX_DISRUPTION,
+                  this.props.match.params.patternId,
+                )}
               />
             </div>
           )}

--- a/app/component/routepage/RoutePatternSelect.js
+++ b/app/component/routepage/RoutePatternSelect.js
@@ -18,7 +18,7 @@ import { enrichPatterns } from '@digitransit-util/digitransit-util';
 import { FormattedMessage, intlShape } from 'react-intl';
 import { routeShape, relayShape, configShape } from '../../util/shapes';
 import Icon from '../Icon';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../../util/path';
+import { routePagePath, PREFIX_STOPS } from '../../util/path';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 import { unixToYYYYMMDD } from '../../util/timeUtils';
 
@@ -83,11 +83,10 @@ function renderPatternSelectSuggestion(item, currentPattern) {
     );
   }
   if (item.shortName && item.longName && item.mode) {
-    const routePath = `/${PREFIX_ROUTES}/${item.gtfsId}`;
     const lowerCaseItemMode = item.mode.toLowerCase();
     return (
       <Link
-        to={routePath}
+        to={routePagePath(item.gtfsId)}
         onClick={e => {
           e.stopPropagation();
         }}
@@ -216,9 +215,7 @@ class RoutePatternSelect extends Component {
       'countTripsForDate',
     ).reverse();
     if (options.every(o => o.code !== params.patternId)) {
-      router.replace(
-        `/${PREFIX_ROUTES}/${gtfsId}/${PREFIX_STOPS}/${options[0].code}`,
-      );
+      router.replace(routePagePath(gtfsId, PREFIX_STOPS, options[0].code));
     }
     return options;
   };
@@ -363,8 +360,7 @@ class RoutePatternSelect extends Component {
             onSuggestionSelected={(e, { suggestion, suggestionValue }) => {
               if (!suggestionValue && suggestion.gtfsId) {
                 // for similarRoute links to work when selected with keyboard
-                const routePath = `/${PREFIX_ROUTES}/${suggestion.gtfsId}`;
-                this.context.router.push(routePath);
+                this.context.router.push(routePagePath(suggestion.gtfsId));
               }
             }}
             inputProps={{

--- a/app/component/routepage/RouteTitle.js
+++ b/app/component/routepage/RouteTitle.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import Link from 'found/Link';
 import { FormattedMessage } from 'react-intl';
-import { PREFIX_ROUTES } from '../../util/path';
+import { routePagePath } from '../../util/path';
 import { routeShape } from '../../util/shapes';
 import withBreakpoint from '../../util/withBreakpoint';
 
@@ -13,7 +13,7 @@ const RouteTitle = ({ route, breakpoint }) =>
   breakpoint === 'large' || !route || !route.mode ? (
     <FormattedMessage id="route-page.title-short" defaultMessage="Route" />
   ) : (
-    <Link to={`/${PREFIX_ROUTES}/${route.gtfsId}`}>
+    <Link to={routePagePath(route.gtfsId)}>
       <RouteNumberContainer
         className="route-number-title"
         color={route.color}

--- a/app/component/routepage/ScheduleContainer.js
+++ b/app/component/routepage/ScheduleContainer.js
@@ -726,12 +726,10 @@ class ScheduleContainer extends PureComponent {
     this.testNoDataDay = ''; // set to next week's Thursday
 
     if (!this.props.pattern) {
-      if (this.props.match.params.routeId) {
+      if (routeId) {
         // Redirect back to routes default pattern
         // eslint-disable-next-line react/prop-types
-        this.props.router.replace(
-          routePagePath(this.props.match.params.routeId, PREFIX_TIMETABLE),
-        );
+        this.props.router.replace(routePagePath(routeId, PREFIX_TIMETABLE));
       }
       return false;
     }
@@ -860,7 +858,7 @@ class ScheduleContainer extends PureComponent {
       }
     }
 
-    const routeIdSplitted = this.props.match.params.routeId.split(':');
+    const routeIdSplitted = routeId.split(':');
     const routeTimetableHandler = routeIdSplitted
       ? this.context.config.timetables &&
         this.context.config.timetables[routeIdSplitted[0]]

--- a/app/component/routepage/ScheduleContainer.js
+++ b/app/component/routepage/ScheduleContainer.js
@@ -24,7 +24,7 @@ import hashCode from '../../util/hashUtil';
 import { getFormattedTimeDate } from '../../util/timeUtils';
 import ScheduleDropdown from './ScheduleDropdown';
 import RouteControlPanel from './RouteControlPanel';
-import { PREFIX_ROUTES, PREFIX_TIMETABLE } from '../../util/path';
+import { routePagePath, PREFIX_TIMETABLE } from '../../util/path';
 import ScrollableWrapper from '../ScrollableWrapper';
 import getTestData from './ScheduleDebugData';
 
@@ -436,7 +436,13 @@ class ScheduleContainer extends PureComponent {
     const trips = ScheduleContainer.sortTrips(currentPattern.trips);
 
     if (trips.length === 0 && newServiceDay) {
-      return `/${PREFIX_ROUTES}/${this.props.match.params.routeId}/${PREFIX_TIMETABLE}/${currentPattern.code}${queryParams}`;
+      return routePagePath(
+        this.props.match.params.routeId,
+        PREFIX_TIMETABLE,
+        currentPattern.code,
+        null,
+        queryParams,
+      );
     }
 
     if (trips !== null && !this.state.hasLoaded) {
@@ -724,7 +730,7 @@ class ScheduleContainer extends PureComponent {
         // Redirect back to routes default pattern
         // eslint-disable-next-line react/prop-types
         this.props.router.replace(
-          `/${PREFIX_ROUTES}/${this.props.match.params.routeId}/${PREFIX_TIMETABLE}`,
+          routePagePath(this.props.match.params.routeId, PREFIX_TIMETABLE),
         );
       }
       return false;

--- a/app/component/routepage/TripLink.js
+++ b/app/component/routepage/TripLink.js
@@ -6,7 +6,7 @@ import cx from 'classnames';
 import ReactRelayContext from 'react-relay/lib/ReactRelayContext';
 import VehicleIcon from '../VehicleIcon';
 import TripLinkWithScroll from './TripLinkWithScroll';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../../util/path';
+import { routePagePath, PREFIX_STOPS } from '../../util/path';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 import { vehicleShape } from '../../util/shapes';
 
@@ -60,7 +60,7 @@ function TripLink({ vehicleState, vehicle, shortName, ...rest }) {
         const trip = props.trip.gtfsId;
         return (
           <Link
-            to={`/${PREFIX_ROUTES}/${route}/${PREFIX_STOPS}/${pattern}/${trip}`}
+            to={routePagePath(route, PREFIX_STOPS, pattern, trip)}
             className="route-now-content"
             onClick={() => {
               addAnalyticsEvent({

--- a/app/component/routepage/TripLinkWithScroll.js
+++ b/app/component/routepage/TripLinkWithScroll.js
@@ -3,7 +3,7 @@ import React, { useRef, useEffect } from 'react';
 import Link from 'found/Link';
 import { intlShape } from 'react-intl';
 import VehicleIcon from '../VehicleIcon';
-import { PREFIX_ROUTES, PREFIX_STOPS } from '../../util/path';
+import { routePagePath, PREFIX_STOPS } from '../../util/path';
 
 function TripLinkWithScroll(
   {
@@ -88,7 +88,7 @@ function TripLinkWithScroll(
   }
   const icon = (
     <Link
-      to={`/${PREFIX_ROUTES}/${route}/${PREFIX_STOPS}/${pattern}/${tripId}`}
+      to={routePagePath(route, PREFIX_STOPS, pattern, tripId)}
       className="route-now-content"
       aria-label={ariaMessage}
     >

--- a/app/component/routepage/TripRouteStop.js
+++ b/app/component/routepage/TripRouteStop.js
@@ -9,7 +9,7 @@ import FuzzyTripLink from './FuzzyTripLink';
 import AddressRow from '../AddressRow';
 import ServiceAlertIcon from '../ServiceAlertIcon';
 import { fromStopTime } from './DepartureTime';
-import { PREFIX_STOPS } from '../../util/path';
+import { stopPagePath } from '../../util/path';
 import { getActiveAlertSeverityLevel } from '../../util/alertUtils';
 import { estimateItineraryDistance } from '../../util/geo-utils';
 import ZoneIcon from '../ZoneIcon';
@@ -134,11 +134,7 @@ const TripRouteStop = (props, { config }) => {
         />
       </div>
       <div className="route-stop-row_content-container">
-        <Link
-          as="button"
-          type="button"
-          to={`/${PREFIX_STOPS}/${encodeURIComponent(stop.gtfsId)}`}
-        >
+        <Link as="button" type="button" to={stopPagePath(false, stop.gtfsId)}>
           <div>
             <div className="route-details-upper-row">
               <div className={`route-details_container ${mode}`}>

--- a/app/component/stop/StopPageTabs.js
+++ b/app/component/stop/StopPageTabs.js
@@ -15,28 +15,22 @@ import { addAnalyticsEvent } from '../../util/analyticsUtils';
 import { unixTime } from '../../util/timeUtils';
 import {
   PREFIX_DISRUPTION,
-  PREFIX_ROUTES,
-  PREFIX_STOPS,
-  PREFIX_TERMINALS,
   PREFIX_TIMETABLE,
+  stopPagePath,
 } from '../../util/path';
 import Icon from '../Icon';
 
 const Tab = {
-  Disruptions: PREFIX_DISRUPTION,
-  RightNow: 'right-now',
-  RoutesAndPlatforms: PREFIX_ROUTES,
-  Timetable: PREFIX_TIMETABLE,
+  RightNow: 1,
+  Timetable: 2,
+  Disruptions: 3,
 };
 
 const getActiveTab = pathname => {
-  if (pathname.indexOf(`/${Tab.Disruptions}`) > -1) {
+  if (pathname.indexOf(PREFIX_DISRUPTION) > -1) {
     return Tab.Disruptions;
   }
-  if (pathname.indexOf(`/${Tab.RoutesAndPlatforms}`) > -1) {
-    return Tab.RoutesAndPlatforms;
-  }
-  if (pathname.indexOf(`/${Tab.Timetable}`) > -1) {
+  if (pathname.indexOf(PREFIX_TIMETABLE) > -1) {
     return Tab.Timetable;
   }
   return Tab.RightNow;
@@ -57,16 +51,8 @@ function StopPageTabs({ stop }, { match }) {
   const tabRefs = [rightNowTabRef, timetableTabRef, disruptionTabRef];
 
   const isTerminal = match.params.terminalId != null;
-  const urlBase = `/${
-    isTerminal ? PREFIX_TERMINALS : PREFIX_STOPS
-  }/${encodeURIComponent(
-    match.params.terminalId ? match.params.terminalId : match.params.stopId,
-  )}`;
-
   const currentTime = unixTime();
-
   const cancelations = getCancelationsForStop(stop);
-
   const maxAlertSeverity = getActiveAlertSeverityLevel(
     isTerminal ? getServiceAlertsForStation(stop) : getAlertsForObject(stop),
     currentTime,
@@ -125,7 +111,7 @@ function StopPageTabs({ stop }, { match }) {
             active: activeTab === Tab.RightNow,
           })}
           onClick={() => {
-            router.replace(`${urlBase}${search}`);
+            router.replace(stopPagePath(isTerminal, stop.gtfsId, null, search));
             addAnalyticsEvent({
               category: 'Stop',
               action: 'OpenRightNowTab',
@@ -149,7 +135,9 @@ function StopPageTabs({ stop }, { match }) {
             active: activeTab === Tab.Timetable,
           })}
           onClick={() => {
-            router.replace(`${urlBase}/${Tab.Timetable}${search}`);
+            router.replace(
+              stopPagePath(isTerminal, stop.gtfsId, PREFIX_TIMETABLE, search),
+            );
             addAnalyticsEvent({
               category: 'Stop',
               action: 'OpenTimetableTab',
@@ -176,7 +164,9 @@ function StopPageTabs({ stop }, { match }) {
               disruptionClassName === 'active-service-alert',
           })}
           onClick={() => {
-            router.replace(`${urlBase}/${Tab.Disruptions}${search}`);
+            router.replace(
+              stopPagePath(isTerminal, stop.gtfsId, PREFIX_DISRUPTION, search),
+            );
             addAnalyticsEvent({
               category: 'Stop',
               action: 'OpenDisruptionsTab',

--- a/app/component/stop/Timetable.js
+++ b/app/component/stop/Timetable.js
@@ -136,8 +136,7 @@ function Timetable(
 ) {
   const stop = useFragment(TimetableFragment, stopRef);
   if (!stop) {
-    const path = `/${PREFIX_STOPS}`;
-    router.replace(path);
+    router.replace(`/${PREFIX_STOPS}`);
   }
   const [showRoutes, setShowRoutes] = useState([]);
   const [showFilterModal, setShowFilterModal] = useState(false);

--- a/app/util/path.js
+++ b/app/util/path.js
@@ -170,16 +170,16 @@ export function routePagePath(routeId, tab, patternId, tripId, queryParams) {
   let path = `/${PREFIX_ROUTES}/${encodeURIComponent(routeId)}`;
 
   if (tab) {
-    path = `/${path}/${tab}`;
+    path = `${path}/${tab}`;
   }
   if (patternId) {
-    path = `/${path}/${encodeURIComponent(patternId)}`;
+    path = `${path}/${encodeURIComponent(patternId)}`;
   }
   if (tripId) {
-    path = `/${path}/${encodeURIComponent(tripId)}`;
+    path = `${path}/${encodeURIComponent(tripId)}`;
   }
   if (queryParams) {
-    path = `/${path}${queryParams}`; // note: '?' is not added
+    path = `${path}${queryParams}`; // note: '?' is not added
   }
   return path;
 }

--- a/app/util/path.js
+++ b/app/util/path.js
@@ -184,12 +184,17 @@ export function routePagePath(routeId, tab, patternId, tripId, queryParams) {
   return path;
 }
 
-export function stopPagePath(isStation, gtfsId, tab) {
-  const path = isStation
+export function stopPagePath(isStation, gtfsId, tab, search) {
+  let path = isStation
     ? `/${PREFIX_TERMINALS}/${encodeURIComponent(gtfsId)}`
     : `/${PREFIX_STOPS}/${encodeURIComponent(gtfsId)}`;
-
-  return tab ? `${path}/${tab}` : path;
+  if (tab) {
+    path = `${path}/${tab}`;
+  }
+  if (search) {
+    path = `${path}/${search}`;
+  }
+  return path;
 }
 
 export function definesItinerarySearch(origin, destination) {

--- a/app/util/path.js
+++ b/app/util/path.js
@@ -127,43 +127,39 @@ export const getIndexPath = (origin, destination, indexPath) => {
 };
 
 export const getStopRoutePath = searchObj => {
-  if (searchObj.properties && searchObj.properties.link) {
+  if (searchObj.properties.link) {
     return searchObj.properties.link;
   }
-  let id = searchObj.properties.id
-    ? searchObj.properties.id
-    : searchObj.properties.gtfsId;
+  let id = searchObj.properties.id || searchObj.properties.gtfsId;
   let path;
-  const network =
-    searchObj.properties.source &&
-    searchObj.properties.source.split('citybikes')[1];
   switch (searchObj.properties.layer) {
     case 'station':
     case 'favouriteStation':
-      path = `/${PREFIX_TERMINALS}/`;
-      id = id.replace('GTFS:', '').replace(':', '%3A');
+      path = PREFIX_TERMINALS;
+      id = id.replace('GTFS:', '');
       break;
-    case 'bikestation':
-      path = `/${PREFIX_BIKESTATIONS}/`;
-      id = `${network}%3A${searchObj.properties.id}`;
+    case 'bikestation': {
+      const network = searchObj.properties.source?.split('citybikes')[1];
+      path = PREFIX_BIKESTATIONS;
+      id = `${network}:${searchObj.properties.id}`;
       break;
+    }
     case 'favouriteVehicleRentalStation':
-      path = `/${PREFIX_BIKESTATIONS}/`;
+      path = PREFIX_BIKESTATIONS;
       id = searchObj.properties.labelId;
       break;
     case 'carpark':
-      path = `/${PREFIX_CARPARK}/`;
-      id = searchObj.properties.id;
+      path = PREFIX_CARPARK;
       break;
     case 'bikepark':
-      path = `/${PREFIX_BIKEPARK}/`;
-      id = searchObj.properties.id;
+      path = PREFIX_BIKEPARK;
       break;
     default:
-      path = `/${PREFIX_STOPS}/`;
-      id = id.replace('GTFS:', '').replace(':', '%3A');
+      path = PREFIX_STOPS;
+      // stop id from geocoding has GTFS prefix and possibly stopCode postfix. Strip them away
+      [id] = id.replace('GTFS:', '').split('#');
   }
-  return path.concat(id);
+  return `/${path}/${encodeURIComponent(id)}`;
 };
 
 export function routePagePath(routeId, tab, patternId, tripId, queryParams) {

--- a/app/util/path.js
+++ b/app/util/path.js
@@ -166,6 +166,24 @@ export const getStopRoutePath = searchObj => {
   return path.concat(id);
 };
 
+export function routePagePath(routeId, tab, patternId, tripId, queryParams) {
+  let path = `/${PREFIX_ROUTES}/${encodeURIComponent(routeId)}`;
+
+  if (tab) {
+    path = `/${path}/${tab}`;
+  }
+  if (patternId) {
+    path = `/${path}/${encodeURIComponent(patternId)}`;
+  }
+  if (tripId) {
+    path = `/${path}/${encodeURIComponent(tripId)}`;
+  }
+  if (queryParams) {
+    path = `/${path}${queryParams}`; // note: '?' is not added
+  }
+  return path;
+}
+
 export function definesItinerarySearch(origin, destination) {
   return get(origin, 'address') && get(destination, 'address');
 }

--- a/app/util/path.js
+++ b/app/util/path.js
@@ -184,6 +184,14 @@ export function routePagePath(routeId, tab, patternId, tripId, queryParams) {
   return path;
 }
 
+export function stopPagePath(isStation, gtfsId, tab) {
+  const path = isStation
+    ? `/${PREFIX_TERMINALS}/${encodeURIComponent(gtfsId)}`
+    : `/${PREFIX_STOPS}/${encodeURIComponent(gtfsId)}`;
+
+  return tab ? `${path}/${tab}` : path;
+}
+
 export function definesItinerarySearch(origin, destination) {
   return get(origin, 'address') && get(destination, 'address');
 }

--- a/test/unit/component/AlertsRow.test.js
+++ b/test/unit/component/AlertsRow.test.js
@@ -8,7 +8,7 @@ import {
   AlertSeverityLevelType,
   AlertEntityType,
 } from '../../../app/constants';
-import { PREFIX_STOPS, PREFIX_ROUTES } from '../../../app/util/path';
+import { PREFIX_STOPS, routePagePath } from '../../../app/util/path';
 import { mockContext } from '../helpers/mock-context';
 
 describe('<AlertRow />', () => {
@@ -174,7 +174,7 @@ describe('<AlertRow />', () => {
       context: mockContext,
     });
     expect(wrapper.find('.alert-row-link').get(0).props.to).to.equal(
-      `/${PREFIX_ROUTES}/HSL:2097N/${PREFIX_STOPS}`,
+      routePagePath('HSL:2097N', PREFIX_STOPS),
     );
   });
 


### PR DESCRIPTION
Links to stop page are now generated with a new util stopPagePath, which encodes identifiers before adding them to URL. Misc refactoring also included.

Note:  this PR is built on top of https://github.com/HSLdevcom/digitransit-ui/pull/5545