### PR TITLE
Ab#324 Fix trip page showing all stops as passed

### DIFF
--- a/app/component/routepage/TripStopListContainer.js
+++ b/app/component/routepage/TripStopListContainer.js
@@ -77,12 +77,18 @@ class TripStopListContainer extends React.PureComponent {
     const nextStop = vehicle && vehicle.next_stop;
     let stopPassed = true;
 
+    const nextStopExistsOnRoute =
+      nextStop &&
+      trip.stoptimesForDate.some(stoptime => stoptime.stop.gtfsId === nextStop);
+
     return trip.stoptimesForDate.map((stoptime, index) => {
       if (nextStop === stoptime.stop.gtfsId) {
         stopPassed = false;
       } else if (
         stoptime.realtimeDeparture + stoptime.serviceDay > currentTime &&
-        (isEmpty(vehicle) || (vehicle && vehicle.next_stop === undefined))
+        (isEmpty(vehicle) ||
+          (vehicle && vehicle.next_stop === undefined) ||
+          !nextStopExistsOnRoute)
       ) {
         stopPassed = false;
       }

--- a/app/component/routepage/TripStopListContainer.js
+++ b/app/component/routepage/TripStopListContainer.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import cx from 'classnames';
-import isEmpty from 'lodash/isEmpty';
 import connectToStores from 'fluxible-addons-react/connectToStores';
 import groupBy from 'lodash/groupBy';
 import values from 'lodash/values';
@@ -74,7 +73,7 @@ class TripStopListContainer extends React.PureComponent {
     // selected vehicle
     const vehicle =
       matchingVehicles.length > 0 ? matchingVehicles[0] : undefined;
-    const nextStop = vehicle && vehicle.next_stop;
+    const nextStop = vehicle?.next_stop;
     let stopPassed = true;
 
     const nextStopExistsOnRoute =
@@ -86,9 +85,7 @@ class TripStopListContainer extends React.PureComponent {
         stopPassed = false;
       } else if (
         stoptime.realtimeDeparture + stoptime.serviceDay > currentTime &&
-        (isEmpty(vehicle) ||
-          (vehicle && vehicle.next_stop === undefined) ||
-          !nextStopExistsOnRoute)
+        (!vehicle || !vehicle.next_stop || !nextStopExistsOnRoute)
       ) {
         stopPassed = false;
       }


### PR DESCRIPTION
## Proposed Changes

  - When the platform changes but the vehicle is still showing the original platform as the next stop, the trip page greyed out all stops on the route. The code now checks if the next stop is on route and if not, the route is greyed out based on time. 

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
