### PR TITLE
Enable car ferries for Kela configuration

### DIFF
--- a/app/component/itinerary/StreetModeSelectorButton.js
+++ b/app/component/itinerary/StreetModeSelectorButton.js
@@ -42,7 +42,7 @@ export default function StreetModeSelectorButton(
       break;
     case streetHash.carAndVehicle:
       distance = displayDistance(
-        getTotalDrivingDistance(itinerary),
+        getTotalDrivingDistance(itinerary, config),
         config,
         intl.formatNumber,
       );

--- a/app/configurations/config.kela.js
+++ b/app/configurations/config.kela.js
@@ -49,7 +49,9 @@ export default {
       },
     ],
   },
-
+  carBoardingModes: {
+    FERRY: { showNotification: false },
+  },
   transportModes: {
     citybike: {
       availableForSelection: false,

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -530,7 +530,7 @@ export function getTotalBikingDistance(itinerary) {
 
 export function getTotalDrivingDistance(itinerary, config = {}) {
   // Don't rely only driving legs when calculating the one way journey.
-  if (config?.emphasizeOneWayJourney) {
+  if (config.emphasizeOneWayJourney) {
     return sumDistances(itinerary.legs);
   }
   return sumDistances(itinerary.legs.filter(isDrivingLeg));

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -528,7 +528,11 @@ export function getTotalBikingDistance(itinerary) {
   return sumDistances(itinerary.legs.filter(isBikingLeg));
 }
 
-export function getTotalDrivingDistance(itinerary) {
+export function getTotalDrivingDistance(itinerary, config = {}) {
+  // Don't rely only driving legs when calculating the one way journey.
+  if (config?.emphasizeOneWayJourney) {
+    return sumDistances(itinerary.legs);
+  }
   return sumDistances(itinerary.legs.filter(isDrivingLeg));
 }
 


### PR DESCRIPTION
## Proposed Changes

  - Add car ferries to kela configuration.
  - Calculate the whole journey when `emphasizeOneWayJourney` is enabled

# Note on testing
 - It is asked by the stakeholders to verify that these changes does not enable routing to Sweden or Estonia.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
