### PR TITLE
AB#344 Add new default transfer time to turku config

### DIFF
--- a/app/configurations/config.jyvaskyla.js
+++ b/app/configurations/config.jyvaskyla.js
@@ -185,7 +185,6 @@ export default configMerger(walttiConfig, {
   sendAnalyticsCustomEventGoals: true,
 
   defaultSettings: {
-    ...walttiConfig.defaultSettings,
     minTransferTime: 180,
   },
 });

--- a/app/configurations/config.turku.js
+++ b/app/configurations/config.turku.js
@@ -105,7 +105,6 @@ export default configMerger(walttiConfig, {
   },
 
   defaultSettings: {
-    ...walttiConfig.defaultSettings,
     minTransferTime: 5 * 60,
   },
 

--- a/app/configurations/config.turku.js
+++ b/app/configurations/config.turku.js
@@ -104,6 +104,11 @@ export default configMerger(walttiConfig, {
     },
   },
 
+  defaultSettings: {
+    ...walttiConfig.defaultSettings,
+    minTransferTime: 5 * 60,
+  },
+
   transportModes: {
     bus: {
       color: '#e8aa27',


### PR DESCRIPTION
## Proposed Changes

  - Changes the default transfer time from 90 seconds to 5 minutes in Turku

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
