### PR TITLE
Fix national links to corresponding languages in waltti

### DIFF
--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -165,11 +165,11 @@ export default {
     },
     sv: {
       name: 'matka.fintraffic.fi',
-      href: 'https://matka.fintraffic.fi/',
+      href: 'https://matka.fintraffic.fi/sv/',
     },
     en: {
       name: 'matka.fintraffic.fi',
-      href: 'https://matka.fintraffic.fi/',
+      href: 'https://matka.fintraffic.fi/en/',
     },
   },
 


### PR DESCRIPTION
## Proposed Changes

  - When national planner links were updated, language was left out of the url in config.waltti.js but left in place in HSL config
  - This PR adds the corresponding languages back to the urls in waltti

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
