### PR TITLE
AB#394 Remove national alerts from kela

### DIFF
--- a/app/configurations/config.kela.js
+++ b/app/configurations/config.kela.js
@@ -149,7 +149,6 @@ export default {
       },
     ],
   },
-  staticMessagesUrl: process.env.STATIC_MESSAGE_URL,
 
   showNearYouButtons: false,
   showVehiclesOnStopPage: false,


### PR DESCRIPTION
## Proposed Changes

  - Removes national alerts from kela by removing the static message url from config

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
