### PR TITLE
AB#422 Avoid new search queries after viewing a viapoint route

### DIFF
--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -5,7 +5,13 @@ import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import polyline from 'polyline-encoded';
 import PropTypes from 'prop-types';
-import React, { cloneElement, useEffect, useRef, useState } from 'react';
+import React, {
+  cloneElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
 import { fetchQuery } from 'react-relay';
 import { saveFutureRoute } from '../../action/FutureRoutesActions';
@@ -942,6 +948,18 @@ export default function ItineraryPage(props, context) {
     };
   }, []);
 
+  // A stable reference for intermediatePlaces based on content
+  const intermediatePlacesKey = useMemo(() => {
+    const { intermediatePlaces } = query;
+    if (!intermediatePlaces) {
+      return '';
+    }
+    if (Array.isArray(intermediatePlaces)) {
+      return intermediatePlaces.join('|');
+    }
+    return intermediatePlaces;
+  }, [query.intermediatePlaces]);
+
   useEffect(() => {
     setCombinedState({ ...emptyState, loading: LOADSTATE.LOADING });
     makeScooterQuery();
@@ -963,7 +981,7 @@ export default function ItineraryPage(props, context) {
     params.to,
     query.time,
     query.arriveBy,
-    query.intermediatePlaces,
+    intermediatePlacesKey,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Proposed Changes

  - Only trigger new searches if the actual viapoints change, not if the object changes.   

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
