### PR TITLE
Accessibility fixes for near you view from AB#74

### DIFF
--- a/app/component/SwipeableTabs.js
+++ b/app/component/SwipeableTabs.js
@@ -1,21 +1,20 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import ReactSwipe from 'react-swipe';
-import { intlShape } from 'react-intl';
 import cx from 'classnames';
 import Icon from './Icon';
 import ScrollableWrapper from './ScrollableWrapper';
 import TabBalls from './TabBalls';
+import { useTranslationsContext } from '../util/useTranslationsContext';
 import { isKeyboardSelectionEvent } from '../util/browser';
 
-const setFocusables = () => {
+export function setFocusables() {
   // Set inactive tab focusables to unfocusable and for active tab set previously made unfocusable elements to focusable
   const focusableTags =
     'a, button, input, textarea, select, details, [tabindex="0"]';
   const unFocusableTags =
     'a, button, input, textarea, select, details, [tabindex="-2"]';
   const swipeableTabs = document.getElementsByClassName('swipeable-tab');
-
   for (let i = 0; i < swipeableTabs.length; i++) {
     const focusables = swipeableTabs[i].querySelectorAll(focusableTags);
     const unFocusables = swipeableTabs[i].querySelectorAll(unFocusableTags);
@@ -31,49 +30,33 @@ const setFocusables = () => {
       });
     }
   }
-};
+}
 
-export default class SwipeableTabs extends React.Component {
-  constructor(props) {
-    super(props);
-    this.reactSwipeEl = React.createRef();
-    this.swipeButtonNavRef = React.createRef(); // tracks if navigation was initiated by button.swipeButton
-    this.state = {
-      announceTabLabel: '',
-    };
-  }
+export default function SwipeableTabs({
+  tabIndex,
+  tabs,
+  onSwipe,
+  hideArrows,
+  navigationOnBottom,
+  classname,
+  ariaRole,
+}) {
+  const intl = useTranslationsContext();
+  const reactSwipeEl = useRef();
+  const swipeButtonNavRef = useRef(); // tracks if navigation was initiated by button.swipeButton
+  const [announceTabLabel, setAnnounceTabLabel] = useState('');
 
-  static propTypes = {
-    tabIndex: PropTypes.number.isRequired,
-    tabs: PropTypes.arrayOf(PropTypes.node).isRequired,
-    onSwipe: PropTypes.func.isRequired,
-    hideArrows: PropTypes.bool,
-    navigationOnBottom: PropTypes.bool,
-    classname: PropTypes.string,
-    ariaRole: PropTypes.string.isRequired,
-  };
-
-  static defaultProps = {
-    hideArrows: false,
-    navigationOnBottom: false,
-    classname: undefined,
-  };
-
-  static contextTypes = {
-    intl: intlShape.isRequired,
-  };
-
-  componentDidMount() {
+  useEffect(() => {
+    setFocusables();
     window.addEventListener('resize', setFocusables);
-    setFocusables();
-  }
+    return () => window.removeEventListener('resize', setFocusables);
+  }, []);
 
-  componentDidUpdate() {
+  useEffect(() => {
     setFocusables();
-  }
+  }, [tabIndex]);
 
-  handleSwipeButtonNav = direction => {
-    const { tabIndex, tabs, onSwipe } = this.props;
+  const handleSwipeButtonNav = direction => {
     let newIndex = tabIndex;
     if (direction === 'prev' && tabIndex > 0) {
       newIndex = tabIndex - 1;
@@ -81,183 +64,184 @@ export default class SwipeableTabs extends React.Component {
       newIndex = tabIndex + 1;
     }
     if (newIndex !== tabIndex) {
-      this.swipeButtonNavRef.current = true;
+      swipeButtonNavRef.current = true;
       // Get the tab context text from the DOM because aria-live cannot handle aria-describedby reference well enough
       const tabContextText =
         document.getElementById(`tab-${newIndex}-context`)?.textContent || '';
-      this.setState({
-        announceTabLabel: `${this.context.intl.formatMessage(
+      setAnnounceTabLabel(
+        `${intl.formatMessage(
           {
-            id: this.props.ariaRole,
+            id: ariaRole,
             defaultMessage: 'Tab {number}',
           },
           { number: newIndex + 1 },
         )} ${tabContextText}`,
-      });
+      );
 
       onSwipe(newIndex);
     }
   };
 
-  handleTabBallsNav = newIndex => {
-    this.swipeButtonNavRef.current = false;
-    this.props.onSwipe(newIndex);
+  const handleTabBallsNav = newIndex => {
+    swipeButtonNavRef.current = false;
+    onSwipe(newIndex);
   };
 
-  render() {
-    const { tabs, hideArrows, navigationOnBottom } = this.props;
-    const disabled = tabs.length < 2;
-
-    const tabsWithId = tabs.map((tab, i) =>
-      React.cloneElement(tab, {
-        id: `tabpanel-${i}`,
-        role: 'tabpanel',
-        'aria-labelledby': `tab-${i}`,
-      }),
-    );
-
-    return (
-      <div
-        className={
-          this.props.classname === 'swipe-desktop-view'
-            ? 'swipe-scroll-wrapper'
-            : ''
-        }
-        role="tablist"
-      >
-        {navigationOnBottom && (
-          <ScrollableWrapper>
-            <div className="swipe-scroll-container scroll-target">
-              <ReactSwipe
-                swipeOptions={{
-                  startSlide: this.props.tabIndex,
-                  stopPropagation: true,
-                  continuous: false,
-                  callback: i => {
-                    setTimeout(() => {
-                      this.props.onSwipe(i);
-                    }, 300);
-                  },
-                }}
-                childCount={tabs.length}
-                ref={this.reactSwipeEl}
-              >
-                {tabsWithId}
-              </ReactSwipe>
-            </div>
-          </ScrollableWrapper>
+  const disabled = tabs.length < 2;
+  const tabsWithId = tabs.map((tab, i) =>
+    React.cloneElement(tab, {
+      id: `tabpanel-${i}`,
+      role: 'tabpanel',
+      'aria-labelledby': `tab-${i}`,
+    }),
+  );
+  return (
+    <div
+      className={
+        classname === 'swipe-desktop-view' ? 'swipe-scroll-wrapper' : ''
+      }
+      role="tablist"
+    >
+      {navigationOnBottom && (
+        <ScrollableWrapper>
+          <div className="swipe-scroll-container scroll-target">
+            <ReactSwipe
+              swipeOptions={{
+                startSlide: tabIndex,
+                stopPropagation: true,
+                continuous: false,
+                callback: i => {
+                  setTimeout(() => onSwipe(i), 300);
+                },
+              }}
+              childCount={tabs.length}
+              ref={reactSwipeEl}
+            >
+              {tabsWithId}
+            </ReactSwipe>
+          </div>
+        </ScrollableWrapper>
+      )}
+      <div className={`swipe-header-container ${classname}`}>
+        {classname === 'swipe-desktop-view' && (
+          <div className="desktop-view-divider" />
         )}
-        <div className={`swipe-header-container ${this.props.classname}`}>
-          {this.props.classname === 'swipe-desktop-view' && (
-            <div className="desktop-view-divider" />
-          )}
 
-          <div className="sr-only" aria-live="polite">
-            {this.swipeButtonNavRef.current && this.state.announceTabLabel}
-          </div>
-
-          <div className={`swipe-header ${this.props.classname}`}>
-            {!hideArrows && (
-              <div
-                className={cx('swipe-button-container', {
-                  active: !(disabled || this.props.tabIndex <= 0),
-                })}
-              >
-                <button
-                  type="button"
-                  className="swipe-button"
-                  onClick={() => this.handleSwipeButtonNav('prev')}
-                  onKeyDown={e => {
-                    if (isKeyboardSelectionEvent(e)) {
-                      this.handleSwipeButtonNav('prev');
-                    }
-                  }}
-                  tabIndex="0"
-                  aria-disabled={disabled || this.props.tabIndex <= 0}
-                  aria-label={this.context.intl.formatMessage({
-                    id: 'swipe-result-tab-left',
-                    defaultMessage: 'Show previous tab.',
-                  })}
-                >
-                  <Icon
-                    img="icon_arrow-collapse--left"
-                    className={`itinerary-arrow-icon ${
-                      disabled || this.props.tabIndex <= 0 ? 'disabled' : ''
-                    }`}
-                  />
-                </button>
-              </div>
-            )}
-            <div className="swipe-tab-indicator">
-              {!disabled && (
-                <TabBalls
-                  tabIndex={this.props.tabIndex}
-                  tabsLength={tabs.length}
-                  onSwipe={this.handleTabBallsNav}
-                  reactSwipeEl={this.reactSwipeEl}
-                  ariaRole={this.props.ariaRole}
-                />
-              )}
-            </div>
-            {!hideArrows && (
-              <div
-                className={cx('swipe-button-container', {
-                  active: !(disabled || this.props.tabIndex >= tabs.length - 1),
-                })}
-              >
-                <button
-                  aria-disabled={
-                    disabled || this.props.tabIndex >= tabs.length - 1
-                  }
-                  type="button"
-                  className="swipe-button"
-                  onClick={() => this.handleSwipeButtonNav('next')}
-                  onKeyDown={e => {
-                    if (isKeyboardSelectionEvent(e)) {
-                      this.handleSwipeButtonNav('next');
-                    }
-                  }}
-                  tabIndex="0"
-                  aria-label={this.context.intl.formatMessage({
-                    id: 'swipe-result-tab-right',
-                    defaultMessage: 'Show next tab.',
-                  })}
-                >
-                  <Icon
-                    img="icon_arrow-collapse--right"
-                    className={`itinerary-arrow-icon ${
-                      disabled || this.props.tabIndex >= tabs.length - 1
-                        ? 'disabled'
-                        : ''
-                    }`}
-                  />
-                </button>
-              </div>
-            )}
-          </div>
+        <div className="sr-only" aria-live="polite">
+          {swipeButtonNavRef.current && announceTabLabel}
         </div>
-        {!navigationOnBottom && (
-          <ScrollableWrapper>
-            <div className="swipe-scroll-container scroll-target">
-              <ReactSwipe
-                swipeOptions={{
-                  startSlide: this.props.tabIndex,
-                  continuous: false,
-                  callback: i => {
-                    setTimeout(() => {
-                      this.props.onSwipe(i);
-                    }, 300);
-                  },
+
+        <div className={`swipe-header ${classname}`}>
+          {!hideArrows && (
+            <div
+              className={cx('swipe-button-container', {
+                active: !(disabled || tabIndex <= 0),
+              })}
+            >
+              <button
+                type="button"
+                className="swipe-button"
+                onClick={() => handleSwipeButtonNav('prev')}
+                onKeyDown={e => {
+                  if (isKeyboardSelectionEvent(e)) {
+                    handleSwipeButtonNav('prev');
+                  }
                 }}
-                childCount={tabs.length}
-                ref={this.reactSwipeEl}
+                tabIndex="0"
+                aria-disabled={disabled || tabIndex <= 0}
+                aria-label={intl.formatMessage({
+                  id: 'swipe-result-tab-left',
+                  defaultMessage: 'Show previous tab.',
+                })}
               >
-                {tabsWithId}
-              </ReactSwipe>
+                <Icon
+                  img="icon_arrow-collapse--left"
+                  className={`itinerary-arrow-icon ${
+                    disabled || tabIndex <= 0 ? 'disabled' : ''
+                  }`}
+                />
+              </button>
             </div>
-          </ScrollableWrapper>
-        )}
+          )}
+          <div className="swipe-tab-indicator">
+            {!disabled && (
+              <TabBalls
+                tabIndex={tabIndex}
+                tabsLength={tabs.length}
+                onSwipe={handleTabBallsNav}
+                reactSwipeEl={reactSwipeEl}
+                ariaRole={ariaRole}
+              />
+            )}
+          </div>
+          {!hideArrows && (
+            <div
+              className={cx('swipe-button-container', {
+                active: !(disabled || tabIndex >= tabs.length - 1),
+              })}
+            >
+              <button
+                aria-disabled={disabled || tabIndex >= tabs.length - 1}
+                type="button"
+                className="swipe-button"
+                onClick={() => handleSwipeButtonNav('next')}
+                onKeyDown={e => {
+                  if (isKeyboardSelectionEvent(e)) {
+                    handleSwipeButtonNav('next');
+                  }
+                }}
+                tabIndex="0"
+                aria-label={intl.formatMessage({
+                  id: 'swipe-result-tab-right',
+                  defaultMessage: 'Show next tab.',
+                })}
+              >
+                <Icon
+                  img="icon_arrow-collapse--right"
+                  className={`itinerary-arrow-icon ${
+                    disabled || tabIndex >= tabs.length - 1 ? 'disabled' : ''
+                  }`}
+                />
+              </button>
+            </div>
+          )}
+        </div>
       </div>
-    );
-  }
+      {!navigationOnBottom && (
+        <ScrollableWrapper>
+          <div className="swipe-scroll-container scroll-target">
+            <ReactSwipe
+              swipeOptions={{
+                startSlide: tabIndex,
+                continuous: false,
+                callback: i => {
+                  setTimeout(() => onSwipe(i), 300);
+                },
+              }}
+              childCount={tabs.length}
+              ref={reactSwipeEl}
+            >
+              {tabsWithId}
+            </ReactSwipe>
+          </div>
+        </ScrollableWrapper>
+      )}
+    </div>
+  );
 }
+
+SwipeableTabs.propTypes = {
+  tabIndex: PropTypes.number.isRequired,
+  tabs: PropTypes.arrayOf(PropTypes.node).isRequired,
+  onSwipe: PropTypes.func.isRequired,
+  hideArrows: PropTypes.bool,
+  navigationOnBottom: PropTypes.bool,
+  classname: PropTypes.string,
+  ariaRole: PropTypes.string.isRequired,
+};
+
+SwipeableTabs.defaultProps = {
+  hideArrows: false,
+  navigationOnBottom: false,
+  classname: undefined,
+};

--- a/app/component/nearyou/NearYouPage.js
+++ b/app/component/nearyou/NearYouPage.js
@@ -155,7 +155,9 @@ function NearYouPage(
   }, []);
 
   useEffect(() => {
-    window.addEventListener('keydown', tabHandler);
+    // rendering of hidden sub components of inactive tabs
+    // sets tabIndex=0 to hidden elements
+    // we must fix this when user shifts focus with the tab key    window.addEventListener('keydown', tabHandler);
     return () => window.removeEventListener('keydown', tabHandler);
   }, []);
 

--- a/app/component/nearyou/NearYouPage.js
+++ b/app/component/nearyou/NearYouPage.js
@@ -26,7 +26,7 @@ import StopRouteSearch from './StopRouteSearch';
 import { getGeolocationState } from '../../store/localStorage';
 import { PREFIX_NEARYOU } from '../../util/path';
 import NearYouContainer from './NearYouContainer';
-import SwipeableTabs from '../SwipeableTabs';
+import SwipeableTabs, { setFocusables } from '../SwipeableTabs';
 import NearYouFavourites from './NearYouFavourites';
 import { mapLayerShape } from '../../store/MapLayerStore';
 import { getDefaultNetworks } from '../../util/vehicleRentalUtils';
@@ -59,6 +59,12 @@ function getModes(config) {
         mode => transportModes[mode].availableForSelection,
       );
   return modes.map(nearYouMode => nearYouMode.toUpperCase());
+}
+
+function tabHandler(e) {
+  if (e.key === 'Tab') {
+    setFocusables();
+  }
 }
 
 function NearYouPage(
@@ -146,6 +152,11 @@ function NearYouPage(
       setSearchPosition(newSearchPosition);
       setPhase(newPhase);
     });
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('keydown', tabHandler);
+    return () => window.removeEventListener('keydown', tabHandler);
   }, []);
 
   useEffect(() => {

--- a/app/component/nearyou/NearYouPage.js
+++ b/app/component/nearyou/NearYouPage.js
@@ -157,7 +157,8 @@ function NearYouPage(
   useEffect(() => {
     // rendering of hidden sub components of inactive tabs
     // sets tabIndex=0 to hidden elements
-    // we must fix this when user shifts focus with the tab key    window.addEventListener('keydown', tabHandler);
+    // we must fix this when user shifts focus with the tab key
+    window.addEventListener('keydown', tabHandler);
     return () => window.removeEventListener('keydown', tabHandler);
   }, []);
 

--- a/digitransit-component/packages/digitransit-component-control-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-control-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-control-panel",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "digitransit-component control-panel module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-control-panel/src/helpers/NearYouButton.js
+++ b/digitransit-component/packages/digitransit-component-control-panel/src/helpers/NearYouButton.js
@@ -9,7 +9,6 @@ export default function NearYouButton({
   colors,
   getIconName,
   title,
-  srMsg,
   withAlert,
   boxed,
   withBorder,
@@ -58,25 +57,22 @@ export default function NearYouButton({
     ? 'near-you-button-with-border'
     : 'near-you-button';
   return (
-    <>
-      {srMsg && <span className={styles['sr-only']}>{srMsg}</span>}
-      <button className={styles[buttonClass]} style={buttonStyle}>
-        <span className={styles['icon-container']} style={iconContainerStyle}>
-          <Icon {...iconProps} />
-          {withAlert && (
-            <span className={styles['transport-mode-alert-icon']}>
-              <Icon img="caution" color={colors.caution} />
-            </span>
-          )}
-        </span>
-        {title}
-        {withArrow && (
-          <div className={styles['near-you-button-caret']}>
-            <Icon img="arrow" color={colors.primary} width={0.9} height={0.9} />
-          </div>
+    <div aria-hidden="true" className={styles[buttonClass]} style={buttonStyle}>
+      <span className={styles['icon-container']} style={iconContainerStyle}>
+        <Icon {...iconProps} />
+        {withAlert && (
+          <span className={styles['transport-mode-alert-icon']}>
+            <Icon img="caution" color={colors.caution} />
+          </span>
         )}
-      </button>
-    </>
+      </span>
+      {title}
+      {withArrow && (
+        <div className={styles['near-you-button-caret']}>
+          <Icon img="arrow" color={colors.primary} width={0.9} height={0.9} />
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -86,7 +82,6 @@ NearYouButton.propTypes = {
   colors: PropTypes.objectOf(PropTypes.string).isRequired,
   getIconName: PropTypes.func.isRequired,
   title: PropTypes.node,
-  srMsg: PropTypes.string,
   withAlert: PropTypes.bool,
   boxed: PropTypes.bool,
   withBorder: PropTypes.bool,
@@ -98,7 +93,6 @@ NearYouButton.propTypes = {
 
 NearYouButton.defaultProps = {
   title: '',
-  srMsg: undefined,
   withAlert: false,
   boxed: false,
   withBorder: false,

--- a/digitransit-component/packages/digitransit-component-control-panel/src/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-control-panel/src/helpers/styles.scss
@@ -164,16 +164,6 @@
         height: 50px;
       }
     }
-
-    .sr-only:not(:focus, :active) {
-      clip: rect(0 0 0 0);
-      clip-path: inset(50%);
-      height: 1px;
-      overflow: hidden;
-      position: absolute;
-      white-space: nowrap;
-      width: 1px;
-    }
   }
 
   .near-you-button-with-border {
@@ -225,16 +215,6 @@
   }
 
   .near-you-buttons-container-wide {
-    .sr-only:not(:focus, :active) {
-      clip: rect(0 0 0 0);
-      clip-path: inset(50%);
-      height: 1px;
-      overflow: hidden;
-      position: absolute;
-      white-space: nowrap;
-      width: 1px;
-    }
-
     .near-you-button,
     .near-you-button-with-border {
       margin-bottom: var(--margin);

--- a/digitransit-component/packages/digitransit-component-control-panel/src/index.js
+++ b/digitransit-component/packages/digitransit-component-control-panel/src/index.js
@@ -178,9 +178,8 @@ function NearStopsAndRoutes({
             {t(key, { lng: language })}
           </span>
         );
-      } else {
-        buttonProps.srMsg = t(mode, { lng: language });
       }
+
       if (!forModal) {
         buttonProps.withBorder = true;
       } else {
@@ -209,7 +208,12 @@ function NearStopsAndRoutes({
             };
 
       const button = (
-        <div key={mode} {...clickProps} {...linkedButtonProps}>
+        <div
+          aria-label={t(mode, { lng: language })}
+          key={mode}
+          {...clickProps}
+          {...linkedButtonProps}
+        >
           <NearYouButton {...buttonProps} />
         </div>
       );

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@digitransit-component/digitransit-component-autosuggest": "^7.1.0",
     "@digitransit-component/digitransit-component-autosuggest-panel": "^8.1.2",
-    "@digitransit-component/digitransit-component-control-panel": "^7.0.0",
+    "@digitransit-component/digitransit-component-control-panel": "^7.0.1",
     "@digitransit-component/digitransit-component-favourite-bar": "^5.0.0",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^5.0.0",
     "@digitransit-component/digitransit-component-favourite-modal": "^4.0.0",


### PR DESCRIPTION
These changes fix some bad accessibility problems in V3. Needed to enable the release  next week.
- near you buttons on front page needed two tab key presses to pass, fixed
- After opening the near you page, focus was often in wrong tab. It was possibe to move the focus to a hidden tab using tab key. 