### PR TITLE
AB#431 Redirect to index page if location values are missing in embedded search

### DIFF
--- a/app/component/embedded/EmbeddedSearch.js
+++ b/app/component/embedded/EmbeddedSearch.js
@@ -14,6 +14,7 @@ import {
 import {
   buildQueryString,
   buildURL,
+  getIndexPath,
   getPathWithEndpointObjects,
   PREFIX_ITINERARY_SUMMARY,
 } from '../../util/path';
@@ -21,6 +22,7 @@ import Icon from '../Icon';
 import Loading from '../Loading';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 import useUTMCampaignParams from './hooks/useUTMCampaignParams';
+import { locationToOTP } from '../../util/otpStrings';
 
 const LocationSearch = withSearchContext(DTAutosuggestPanel, true);
 
@@ -243,14 +245,28 @@ const EmbeddedSearch = (props, context) => {
   const executeSearch = () => {
     const urlEnd = bikeOnly ? '/bike' : walkOnly ? '/walk' : '';
 
-    const targetUrl = buildURL([
-      lang,
-      getPathWithEndpointObjects(origin, destination, PREFIX_ITINERARY_SUMMARY),
-      urlEnd,
-    ]);
+    // if origin or destination is missing, redirect to index page instead
+    const isComplete = origin.lat && destination.lat;
+    const targetUrl = isComplete
+      ? buildURL([
+          lang,
+          getPathWithEndpointObjects(
+            origin,
+            destination,
+            PREFIX_ITINERARY_SUMMARY,
+          ),
+          urlEnd,
+        ])
+      : buildURL([
+          lang,
+          getIndexPath(
+            locationToOTP(origin),
+            locationToOTP(destination),
+            config.indexPath || '',
+          ),
+        ]);
 
     targetUrl.search += buildQueryString(utmCampaignParams);
-
     addAnalyticsEvent({
       category: 'EmbeddedSearch',
       action: 'executeSearch',


### PR DESCRIPTION
## Proposed Changes

  - Adds logic to redirect the user to the index page if both origin and destination are not filled when pressing search
  - The only downside to this is that in case of bikeOnly and walkOnly searches that property is lost when redirected to index page

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
