### PR TITLE
AB#436 Fixes a bug where terminals with stop codes broke routing from search

### DIFF
--- a/app/util/path.js
+++ b/app/util/path.js
@@ -136,7 +136,7 @@ export const getStopRoutePath = searchObj => {
     case 'station':
     case 'favouriteStation':
       path = PREFIX_TERMINALS;
-      id = id.replace('GTFS:', '');
+      [id] = id.replace('GTFS:', '').split('#');
       break;
     case 'bikestation': {
       const network = searchObj.properties.source?.split('citybikes')[1];


### PR DESCRIPTION
## Proposed Changes

  - In GTFS spec, stations can also have stop codes, but our path utils only remove it from the url in case of stops.
  - This fixes a bug where the routing broke in case a terminal had a stop code.
  - The functionality can be verified in Kotka using station K1400

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
