### PR TITLE
AB#326 Fix cancellation related bugs on stop page

### DIFF
--- a/app/component/DepartureListContainer.js
+++ b/app/component/DepartureListContainer.js
@@ -209,6 +209,13 @@ class DepartureListContainer extends Component {
   };
 
   getHeadsign = departure => {
+    if (departure.canceled && departure.isLastStop) {
+      return this.context.intl.formatMessage({
+        id: 'route-destination-endpoint',
+        defaultMessage: 'Arrives / Terminus',
+      });
+    }
+
     if (departure.isArrival) {
       if (departure.isLastStop) {
         return this.context.intl.formatMessage({

--- a/app/component/stop/Timetable.js
+++ b/app/component/stop/Timetable.js
@@ -28,7 +28,12 @@ const mapStopTimes = stoptimesObject =>
   stoptimesObject
     .map(stoptime =>
       stoptime.stoptimes
-        .filter(st => st.pickupType !== 'NONE')
+        .filter(
+          st =>
+            st.pickupType !== 'NONE' ||
+            st.stop.gtfsId !==
+              stoptime.pattern.stops[stoptime.pattern.stops.length - 1].gtfsId,
+        )
         .map(st => ({
           id: stoptime.pattern.code,
           name: stoptime.pattern.route.shortName || stoptime.pattern.headsign,

--- a/app/component/stop/queries/TimetableFragment.js
+++ b/app/component/stop/queries/TimetableFragment.js
@@ -11,6 +11,9 @@ export const TimetableFragment = graphql`
       pattern {
         headsign
         code
+        stops {
+          gtfsId
+        }
         route {
           id
           shortName


### PR DESCRIPTION
Cancelled trips result in some unwanted behavior on stops that are the last stop of some route. The logic is based on the `pickupType` of the stoptime, but cancelled trips omit this property so the current logic fails.

## Proposed Changes

  - On departure list, cancelled trips are now correctly shown with arriving / last stop as the headsign
  - Timetable view correctly filters out arrivals even if they belong to a cancelled trip

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
