### PR TITLE
AB#437 Fix flickering real time vehicle positions

### DIFF
--- a/app/action/realTimeClientAction.js
+++ b/app/action/realTimeClientAction.js
@@ -19,9 +19,6 @@ export function stopRealTimeClient(actionContext, client, done) {
 }
 
 export function changeRealTimeClientTopics(actionContext, settings, done) {
-  // remove existing vehicles/topics
-  actionContext.dispatch('RealTimeClientReset');
-
   changeTopics(settings, actionContext);
   done();
 }

--- a/app/store/RealTimeInformationStore.js
+++ b/app/store/RealTimeInformationStore.js
@@ -86,12 +86,28 @@ class RealTimeInformationStore extends Store {
     this.topics = topics;
     this.topicsByRoute = topicsByRoute;
 
-    if (topicsByRoute) {
-      const allowedRoutes = new Set(Object.keys(topicsByRoute));
+    if (topicsByRoute && Object.keys(topicsByRoute).length > 0) {
       this.vehicles = Object.fromEntries(
         Object.entries(this.vehicles).filter(([, vehicle]) => {
           const routeId = vehicle.route?.split(':')[1];
-          return routeId && allowedRoutes.has(routeId);
+          return routeId && topicsByRoute[routeId];
+        }),
+      );
+    } else if (Array.isArray(topics) && topics.length > 0) {
+      this.vehicles = Object.fromEntries(
+        Object.entries(this.vehicles).filter(([, vehicle]) => {
+          const tripId = vehicle.tripId?.split(':')[1];
+          const routeId = vehicle.route?.split(':')[1];
+
+          if (tripId) {
+            return topics.some(topic => topic.includes(tripId));
+          }
+
+          if (routeId) {
+            return topics.some(topic => topic.includes(routeId));
+          }
+
+          return false;
         }),
       );
     }

--- a/app/store/RealTimeInformationStore.js
+++ b/app/store/RealTimeInformationStore.js
@@ -85,6 +85,18 @@ class RealTimeInformationStore extends Store {
   setTopics({ topics, topicsByRoute }) {
     this.topics = topics;
     this.topicsByRoute = topicsByRoute;
+
+    if (topicsByRoute) {
+      const allowedRoutes = new Set(Object.keys(topicsByRoute));
+      this.vehicles = Object.fromEntries(
+        Object.entries(this.vehicles).filter(([, vehicle]) => {
+          const routeId = vehicle.route?.split(':')[1];
+          return routeId && allowedRoutes.has(routeId);
+        }),
+      );
+    }
+
+    this.emitChange();
   }
 
   getVehicle = id => this.vehicles[id];


### PR DESCRIPTION
## Proposed Changes

  - When changing topics on the mqttClient, the real time store was always reset. This caused vehicles to disappear from the map momentarily.
  - This pr only removes vehicles that are not represented in the new topics instead of clearing everything.
  - This bug was appearing on the stop page when the departure list updates, and on nearyoupage everytime the user gps location was updated.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
