### PR TITLE
AB#456 Refactor shared components to not use react-autosuggest

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -19,7 +19,6 @@ const globals = {
   'prop-types': 'PropTypes',
   'react-is': 'react-is',
   i18next: 'i18next',
-  'react-autosuggest': 'Autosuggest',
   'react-sortablejs': 'reactSortablejs',
   'react-modal': 'ReactModal',
   '@hsl-fi/modal': 'Modal',

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -19,6 +19,7 @@ const globals = {
   'prop-types': 'PropTypes',
   'react-is': 'react-is',
   i18next: 'i18next',
+  'react-i18next': 'reactI18next',
   'react-sortablejs': 'reactSortablejs',
   'react-modal': 'ReactModal',
   '@hsl-fi/modal': 'Modal',
@@ -48,6 +49,9 @@ const globals = {
   'lodash/uniq': 'uniq',
   'lodash/compact': 'compact',
   'react-relay': 'reactRelay',
+  downshift: 'downshift',
+  luxon: 'luxon',
+  'react-select': 'Select',
 };
 
 async function getSortedPackages() {

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "8.1.2",
+  "version": "8.2.0",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/src/helpers/Select.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/src/helpers/Select.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
-import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
-import Autosuggest from 'react-autosuggest';
+import cx from 'classnames';
+import React from 'react';
+import { useSelect } from 'downshift';
 import styles from './select.scss';
 
 const Select = ({
   value,
-  getDisplay,
   options,
   onSlackTimeSelected,
   viaPointIndex,
@@ -13,92 +13,67 @@ const Select = ({
   label,
   icon,
 }) => {
-  const [displayValue, changeDisplayValue] = useState(getDisplay(value));
-  const [open, changeOpen] = useState(false);
-  useEffect(() => changeDisplayValue(getDisplay(value)), [value]);
-  const scrollRef = useRef(null);
-  const scrollIndex = Math.floor(value / 600);
-  const elementHeight = 50;
-  useLayoutEffect(() => {
-    if (open && scrollRef.current) {
-      scrollRef.current.scrollTop = elementHeight * scrollIndex;
-    }
-  }, [value, open]);
-
-  const inputId = `${id}-input`;
   const labelId = `${id}-label`;
+  const selectedItem = options.find(option => option.value === value);
 
-  const onInputChange = (_, { newValue, method }) => {
-    switch (method) {
-      case 'enter':
-      case 'click':
-        onSlackTimeSelected(newValue, viaPointIndex);
-        break;
-      case 'escape':
-        changeDisplayValue(value);
-        break;
-      case 'up':
-      case 'down':
-      default:
-        break;
-    }
-  };
+  const {
+    isOpen,
+    getToggleButtonProps,
+    getMenuProps,
+    getItemProps,
+    getLabelProps,
+    highlightedIndex,
+  } = useSelect({
+    selectedItem,
+    items: options,
+    labelId,
+    id,
+    itemToString: item => item.displayName,
+    onSelectedItemChange: ({ selectedItem: newItem }) => {
+      onSlackTimeSelected(newItem.value, viaPointIndex);
+    },
+  });
+
   return (
-    <label className={styles['combobox-container']} htmlFor={inputId}>
-      <span className={styles['left-column']}>
-        <span className={styles['combobox-label']} id={labelId}>
-          {label}
-        </span>
-        <Autosuggest
-          id={id}
-          suggestions={options}
-          getSuggestionValue={s => s.value}
-          renderSuggestion={s => s.displayName}
-          onSuggestionsFetchRequested={() => null}
-          shouldRenderSuggestions={() => true}
-          focusInputOnSuggestionClick={false}
-          onSuggestionsClearRequested={() => null}
-          inputProps={{
-            value: displayValue,
-            onChange: onInputChange,
-            onFocus: () => {
-              changeOpen(true);
-            },
-            onBlur: () => {
-              changeOpen(false);
-            },
-            id: inputId,
-            'aria-labelledby': labelId,
-            'aria-autocomplete': 'none',
-            readOnly: true,
-          }}
-          renderSuggestionsContainer={({ containerProps, children }) => {
-            // set refs for autosuggest library and scrollbar positioning
-            const { ref, ...otherRefs } = containerProps;
-            const containerRef = elem => {
-              if (elem) {
-                scrollRef.current = elem;
-                ref(elem);
-              }
-            };
-            return (
-              <div tabIndex="-1" {...otherRefs} ref={containerRef}>
-                {children}
-              </div>
-            );
-          }}
-          theme={styles}
-        />
-      </span>
-      {icon}
-    </label>
+    <div className={styles['combobox-container']}>
+      <div className={styles.container}>
+        <div {...getToggleButtonProps()}>
+          <span className={styles['left-column']}>
+            <label {...getLabelProps()} className={styles['combobox-label']}>
+              {label}
+            </label>
+            <div className={styles.input}>
+              <span>{selectedItem.displayName}</span>
+            </div>
+          </span>
+          {icon}
+        </div>
+        <ul
+          className={cx([styles.suggestionsContainerOpen, !isOpen && 'hidden'])}
+          {...getMenuProps()}
+        >
+          {isOpen &&
+            options.map((option, index) => (
+              <li
+                key={option.value}
+                className={cx([
+                  styles.suggestion,
+                  index === highlightedIndex && styles.suggestionHighlighted,
+                ])}
+                {...getItemProps({ index })}
+              >
+                <span>{option.displayName}</span>
+              </li>
+            ))}
+        </ul>
+      </div>
+    </div>
   );
 };
 
 Select.propTypes = {
   value: PropTypes.number.isRequired,
   onSlackTimeSelected: PropTypes.func.isRequired,
-  getDisplay: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       displayName: PropTypes.string.isRequired,

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/src/helpers/select.scss
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/src/helpers/select.scss
@@ -41,6 +41,17 @@ $zindex: base, map-container, map-gradient, map-fullscreen-toggle, map-buttons,
 
 .container {
   position: relative;
+  width: 100%;
+  height: 100%;
+
+  > div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+  }
 
   .suggestion {
     font-size: 15px;
@@ -68,8 +79,13 @@ $zindex: base, map-container, map-gradient, map-fullscreen-toggle, map-buttons,
     border-radius: 5px;
     box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.06);
     border: 1px rgba(0, 0, 0, 0.1) solid;
-    top: 35px;
-    width: calc(100% + 45px); // 43px == width of icon next to input
+    top: calc(100% + 4px);
+    left: 0;
+    width: 100%;
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+
     ul {
       padding: 0;
       margin: 0;

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/src/index.js
@@ -606,7 +606,6 @@ class DTAutosuggestPanel extends React.Component {
                       label={t('viapoint-slack-amount', { lng })}
                       options={slackTime}
                       value={getViaPointSlackTimeOrDefault(viaPoints[i])}
-                      getDisplay={this.getSlackDisplay}
                       viaPointIndex={i}
                       icon={
                         <span

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [
@@ -31,13 +31,13 @@
   "peerDependencies": {
     "@digitransit-component/digitransit-component-icon": "^2.0.0",
     "classnames": "2.5.1",
+    "downshift": "9.0.10",
     "i18next": "^22.5.1",
     "lodash": "4.17.21",
     "lodash-es": "4.17.21",
     "luxon": "^3.6.1",
     "prop-types": "^15.8.1",
     "react": "^16.13.0",
-    "react-autosuggest": "^10.0.0",
     "react-i18next": "^12.3.1",
     "react-modal": "~3.11.2",
     "react-select": "5.8.0"

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
@@ -6,7 +6,15 @@ import cx from 'classnames';
 import styles from './styles.scss';
 import { isAndroid } from './mobileDetection';
 
-const AndroidSelect = ({ value, dateChoices, id, getDisplay, onChange }) => {
+const AndroidSelect = ({
+  value,
+  dateChoices,
+  id,
+  getDisplay,
+  onChange,
+  labelId,
+  inputId,
+}) => {
   const items = dateChoices.map(date => ({
     value: date,
     label: getDisplay(date),
@@ -33,7 +41,9 @@ const AndroidSelect = ({ value, dateChoices, id, getDisplay, onChange }) => {
 
   return (
     <div className={styles.container}>
-      <div {...getToggleButtonProps()}>
+      <div
+        {...getToggleButtonProps({ 'aria-labelledby': labelId, id: inputId })}
+      >
         <div className={styles.input}>{selectedItem.label}</div>
       </div>
       <div
@@ -65,6 +75,8 @@ AndroidSelect.propTypes = {
   id: PropTypes.string.isRequired,
   getDisplay: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
+  labelId: PropTypes.string.isRequired,
+  inputId: PropTypes.string.isRequired,
 };
 
 /**
@@ -97,6 +109,7 @@ function MobileDatepicker({
       </span>
       {nativeInput ? (
         <select
+          id={inputId}
           className={styles['mobile-input-display']}
           onChange={e => onChange(Number(e.target.value))}
           value={value}
@@ -117,6 +130,8 @@ function MobileDatepicker({
             id,
             getDisplay,
             onChange,
+            labelId,
+            inputId,
           }}
         />
       )}

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
@@ -1,9 +1,71 @@
 import PropTypes from 'prop-types';
-import React, { useState, useRef, useLayoutEffect } from 'react';
+import React from 'react';
 import { DateTime, Settings } from 'luxon';
-import Autosuggest from 'react-autosuggest';
+import { useSelect } from 'downshift';
+import cx from 'classnames';
 import styles from './styles.scss';
 import { isAndroid } from './mobileDetection';
+
+const AndroidSelect = ({ value, dateChoices, id, getDisplay, onChange }) => {
+  const items = dateChoices.map(date => ({
+    value: date,
+    label: getDisplay(date),
+  }));
+  const selectedItem =
+    items.find(option => option.value === value) || items[0] || null;
+  const {
+    isOpen,
+    getToggleButtonProps,
+    getMenuProps,
+    getItemProps,
+    highlightedIndex,
+  } = useSelect({
+    selectedItem,
+    items,
+    itemToString: item => (item ? item.displayName : ''),
+    onSelectedItemChange: ({ selectedItem: nextSelectedItem }) => {
+      if (nextSelectedItem) {
+        onChange(nextSelectedItem.value);
+      }
+    },
+    id,
+  });
+
+  return (
+    <div className={styles.container}>
+      <div {...getToggleButtonProps()}>
+        <div className={styles.input}>{selectedItem.label}</div>
+      </div>
+      <div
+        className={cx([styles.suggestionsContainerOpen, !isOpen && 'hidden'])}
+      >
+        <ul {...getMenuProps()}>
+          {isOpen &&
+            items.map((option, index) => (
+              <li
+                key={option.value}
+                className={cx([
+                  styles.suggestion,
+                  index === highlightedIndex && styles.suggestionHighlighted,
+                ])}
+                {...getItemProps({ index })}
+              >
+                <span>{option.label}</span>
+              </li>
+            ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+AndroidSelect.propTypes = {
+  value: PropTypes.number.isRequired,
+  dateChoices: PropTypes.arrayOf(PropTypes.number).isRequired,
+  id: PropTypes.string.isRequired,
+  getDisplay: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
 
 /**
  * Component to display a date input on mobile
@@ -20,24 +82,13 @@ function MobileDatepicker({
   timeZone,
 }) {
   Settings.defaultZone = timeZone;
-  const [open, changeOpen] = useState(false);
-  const scrollRef = useRef(null);
   const dateChoices = Array(itemCount)
     .fill()
     .map((_, i) => DateTime.fromMillis(startTime).plus({ days: i }).toMillis());
-  const minute = 1000 * 60;
-  const diffs = dateChoices.map(t => value - t);
-  const scrollIndex = diffs.findIndex(t => t < minute); // when time is now, the times might differ by less than one minute
-  const elementHeight = 50;
-  // scroll to selected time when dropdown is opened
-  useLayoutEffect(() => {
-    if (open && scrollRef.current) {
-      scrollRef.current.scrollTop = elementHeight * scrollIndex;
-    }
-  }, [value, open]);
   const nativeInput = !isAndroid();
-  const inputId = `${id}-input`;
   const labelId = `${id}-label`;
+  const inputId = `${id}-input`;
+
   return (
     <label className={styles['input-container']} htmlFor={inputId}>
       <span>{icon}</span>
@@ -59,46 +110,14 @@ function MobileDatepicker({
           })}
         </select>
       ) : (
-        <Autosuggest
-          id={id}
-          suggestions={dateChoices}
-          getSuggestionValue={s => s.toString()}
-          renderSuggestion={s => getDisplay(s)}
-          onSuggestionsFetchRequested={() => null}
-          shouldRenderSuggestions={() => true}
-          inputProps={{
-            value: getDisplay(value),
-            onChange: (_, { newValue }) => {
-              onChange(Number(newValue));
-            },
-            onFocus: () => {
-              changeOpen(true);
-            },
-            onBlur: () => {
-              changeOpen(false);
-            },
-            'aria-labelledby': labelId,
-            'aria-autocomplete': 'none',
-            readOnly: true,
+        <AndroidSelect
+          {...{
+            value,
+            dateChoices,
+            id,
+            getDisplay,
+            onChange,
           }}
-          focusInputOnSuggestionClick={false}
-          onSuggestionsClearRequested={() => null}
-          renderSuggestionsContainer={({ containerProps, children }) => {
-            // set refs for autosuggest library and scrollbar positioning
-            const { ref, ...otherRefs } = containerProps;
-            const containerRef = elem => {
-              if (elem) {
-                scrollRef.current = elem;
-                ref(elem);
-              }
-            };
-            return (
-              <div tabIndex="-1" {...otherRefs} ref={containerRef}>
-                {children}
-              </div>
-            );
-          }}
-          theme={styles}
         />
       )}
     </label>
@@ -113,13 +132,11 @@ MobileDatepicker.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   icon: PropTypes.node,
-  dateTimeCombined: PropTypes.bool,
   timeZone: PropTypes.string,
 };
 
 MobileDatepicker.defaultProps = {
   icon: null,
-  dateTimeCombined: false,
   timeZone: 'Europe/Helsinki',
 };
 

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/MobileDatepicker.js
@@ -22,7 +22,7 @@ const AndroidSelect = ({ value, dateChoices, id, getDisplay, onChange }) => {
   } = useSelect({
     selectedItem,
     items,
-    itemToString: item => (item ? item.displayName : ''),
+    itemToString: item => item?.label ?? '',
     onSelectedItemChange: ({ selectedItem: nextSelectedItem }) => {
       if (nextSelectedItem) {
         onChange(nextSelectedItem.value);

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/styles.scss
@@ -599,6 +599,7 @@ $zindex: base, map-container, map-gradient, map-fullscreen-toggle, map-buttons,
 
         // autosuggest
         .input {
+          color: black;
           box-shadow: none;
           border: none;
           background: none;

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -35,6 +35,7 @@
     "@hsl-fi/sass": "^0.2.0",
     "@hsl-fi/shimmer": "0.1.2",
     "classnames": "2.5.1",
+    "downshift": "9.0.10",
     "hoist-non-react-statics": "2.5.4",
     "i18next": "^22.5.1",
     "lodash": "4.17.21",
@@ -42,8 +43,6 @@
     "luxon": "^3.6.1",
     "prop-types": "^15.8.1",
     "react": "^16.13.0",
-    "react-autosuggest": "^10.0.0",
-    "react-autowhatever": "10.2.1",
     "react-modal": "~3.11.2",
     "react-sortablejs": "2.0.11"
   }

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-component",
   "module": "digitransit-component.mjs",
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@digitransit-component/digitransit-component-autosuggest": "^7.1.0",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^8.1.2",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^8.2.0",
     "@digitransit-component/digitransit-component-control-panel": "^7.0.1",
     "@digitransit-component/digitransit-component-favourite-bar": "^5.0.0",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -182,8 +182,6 @@
     "polyline-encoded": "0.0.9",
     "prop-types": "15.8.1",
     "react": "^16.13.0",
-    "react-autosuggest": "^10.0.0",
-    "react-autowhatever": "10.2.1",
     "react-click-outside": "3.0.1",
     "react-dom": "16.13.0",
     "react-helmet": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2061,7 +2061,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@^8.1.2, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@^8.2.0, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
@@ -2069,7 +2069,7 @@ __metadata:
     "@digitransit-component/digitransit-component-icon": ^2.0.0
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
-    downshift: 9.0.10
+    downshift: ^9.0.10
     i18next: ^22.5.1
     lodash: 4.17.21
     lodash-es: 4.17.21
@@ -2094,7 +2094,7 @@ __metadata:
     "@digitransit-component/digitransit-component-suggestion-item": ^3.0.0
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
-    downshift: 9.0.10
+    downshift: ^9.0.10
     i18next: ^22.5.1
     lodash: 4.17.21
     lodash-es: 4.17.21
@@ -2127,13 +2127,13 @@ __metadata:
   peerDependencies:
     "@digitransit-component/digitransit-component-icon": ^2.0.0
     classnames: 2.5.1
+    downshift: ^9.0.10
     i18next: ^22.5.1
     lodash: 4.17.21
     lodash-es: 4.17.21
     luxon: ^3.6.1
     prop-types: ^15.8.1
     react: ^16.13.0
-    react-autosuggest: ^10.0.0
     react-i18next: ^12.3.1
     react-modal: ~3.11.2
     react-select: 5.8.0
@@ -2262,7 +2262,7 @@ __metadata:
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
     "@digitransit-component/digitransit-component-autosuggest": ^7.1.0
-    "@digitransit-component/digitransit-component-autosuggest-panel": ^8.1.2
+    "@digitransit-component/digitransit-component-autosuggest-panel": ^8.2.0
     "@digitransit-component/digitransit-component-control-panel": ^7.0.1
     "@digitransit-component/digitransit-component-favourite-bar": ^5.0.0
     "@digitransit-component/digitransit-component-favourite-editing-modal": ^5.0.0
@@ -2277,6 +2277,7 @@ __metadata:
     "@hsl-fi/sass": ^0.2.0
     "@hsl-fi/shimmer": 0.1.2
     classnames: 2.5.1
+    downshift: ^9.0.10
     hoist-non-react-statics: 2.5.4
     i18next: ^22.5.1
     lodash: 4.17.21
@@ -2284,8 +2285,6 @@ __metadata:
     luxon: ^3.6.1
     prop-types: ^15.8.1
     react: ^16.13.0
-    react-autosuggest: ^10.0.0
-    react-autowhatever: 10.2.1
     react-modal: ~3.11.2
     react-sortablejs: 2.0.11
   languageName: unknown
@@ -11428,8 +11427,6 @@ __metadata:
     prettier: 3.1.1
     prop-types: 15.8.1
     react: ^16.13.0
-    react-autosuggest: ^10.0.0
-    react-autowhatever: 10.2.1
     react-click-outside: 3.0.1
     react-dom: 16.13.0
     react-helmet: 6.1.0
@@ -12378,7 +12375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es6-promise@npm:^4.1.1, es6-promise@npm:^4.2.8":
+"es6-promise@npm:^4.1.1":
   version: 4.2.8
   resolution: "es6-promise@npm:4.2.8"
   checksum: 95614a88873611cb9165a85d36afa7268af5c03a378b35ca7bda9508e1d4f1f6f19a788d4bc755b3fd37c8ebba40782018e02034564ff24c9d6fa37e959ad57d
@@ -20743,13 +20740,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "object-assign@npm:3.0.0"
-  checksum: 56c66a77318aea95b11bd16a65c313e98786cea1db673a7fdd3bc92aced671b35f62a9819ad9cf7846921c773818329636cda5cd1b7c4fa0ce9908440e091dac
-  languageName: node
-  linkType: hard
-
 "object-assign@npm:^4.0.1, object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
@@ -23579,34 +23569,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-autosuggest@npm:^10.0.0":
-  version: 10.1.0
-  resolution: "react-autosuggest@npm:10.1.0"
-  dependencies:
-    es6-promise: ^4.2.8
-    prop-types: ^15.7.2
-    react-themeable: ^1.1.0
-    section-iterator: ^2.0.0
-    shallow-equal: ^1.2.1
-  peerDependencies:
-    react: ">=16.3.0"
-  checksum: 3526b02bb1938374c2a0d108a03666eae24cddd8bef7686e7f6271bb4c25ad34f8b09e84d1cc2e9206aff577a742c1f8481964e75442a9e080326676ad71f8ae
-  languageName: node
-  linkType: hard
-
-"react-autowhatever@npm:10.2.1":
-  version: 10.2.1
-  resolution: "react-autowhatever@npm:10.2.1"
-  dependencies:
-    prop-types: ^15.5.8
-    react-themeable: ^1.1.0
-    section-iterator: ^2.0.0
-  peerDependencies:
-    react: ">=0.14.7"
-  checksum: 507a287d46984c6bc9fa3342ada2faf9002fee72568ce8151448908de553fd6daa501b32bec3406e18dee93939d403b8e8800c0d723f7b8435859b1ce36886e7
-  languageName: node
-  linkType: hard
-
 "react-click-outside@npm:3.0.1":
   version: 3.0.1
   resolution: "react-click-outside@npm:3.0.1"
@@ -23895,15 +23857,6 @@ __metadata:
   peerDependencies:
     react: ^16.14.0
   checksum: 96eb8a2566e67ebd246ef6e1b36d8c8498c68ebfdb94ca8399c19b4e3b73368caf0ffbe44767593e3499f2f58b4b5e57ba0565a47628048d2ab01b23a422724e
-  languageName: node
-  linkType: hard
-
-"react-themeable@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "react-themeable@npm:1.1.0"
-  dependencies:
-    object-assign: ^3.0.0
-  checksum: 80d8fa67d15f3136ae8054bfbecc2f1a396b7cda4f10380e13e8f344b07543a55adfb5aca0cf741071e406d8115ff3ea8e361476a086ba5ad55a1feb9cb9ae7a
   languageName: node
   linkType: hard
 
@@ -25246,13 +25199,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"section-iterator@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "section-iterator@npm:2.0.0"
-  checksum: d11ae54205baf1ccea5f847b3b5cd9394128ac1051b4ac236d145c9b386e5dd274371a63991e575e20373bacd1c287bfe6159ddf366cb21f30b123e185e6bc7d
-  languageName: node
-  linkType: hard
-
 "select-hose@npm:^2.0.0":
   version: 2.0.0
   resolution: "select-hose@npm:2.0.0"
@@ -25545,13 +25491,6 @@ __metadata:
   dependencies:
     kind-of: ^6.0.2
   checksum: 39b3dd9630a774aba288a680e7d2901f5c0eae7b8387fc5c8ea559918b29b3da144b7bdb990d7ccd9e11be05508ac9e459ce51d01fd65e583282f6ffafcba2e7
-  languageName: node
-  linkType: hard
-
-"shallow-equal@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "shallow-equal@npm:1.2.1"
-  checksum: 4f1645cc516e7754c4438db687e1da439a5f29a7dba2ba90c5f88e5708aeb17bc4355ba45cad805b0e95dc898e37d8bf6d77d854919c7512f89939986cff8cd1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,7 +2069,7 @@ __metadata:
     "@digitransit-component/digitransit-component-icon": ^2.0.0
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
-    downshift: ^9.0.10
+    downshift: 9.0.10
     i18next: ^22.5.1
     lodash: 4.17.21
     lodash-es: 4.17.21
@@ -2094,7 +2094,7 @@ __metadata:
     "@digitransit-component/digitransit-component-suggestion-item": ^3.0.0
     "@hsl-fi/sass": ^0.2.0
     classnames: 2.5.1
-    downshift: ^9.0.10
+    downshift: 9.0.10
     i18next: ^22.5.1
     lodash: 4.17.21
     lodash-es: 4.17.21
@@ -2127,7 +2127,7 @@ __metadata:
   peerDependencies:
     "@digitransit-component/digitransit-component-icon": ^2.0.0
     classnames: 2.5.1
-    downshift: ^9.0.10
+    downshift: 9.0.10
     i18next: ^22.5.1
     lodash: 4.17.21
     lodash-es: 4.17.21
@@ -2277,7 +2277,7 @@ __metadata:
     "@hsl-fi/sass": ^0.2.0
     "@hsl-fi/shimmer": 0.1.2
     classnames: 2.5.1
-    downshift: ^9.0.10
+    downshift: 9.0.10
     hoist-non-react-statics: 2.5.4
     i18next: ^22.5.1
     lodash: 4.17.21


### PR DESCRIPTION
## Proposed Changes

  - Completely removes the react-autosuggest dependency and replaces functionality with downshift useSelect hook.
  - MobileDatepicker can be tested using mobile android browser agent
  - Select component can be tested by setting the showSlackControl default parameter value to true in autosuggest panel.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
