### PR TITLE
AB#460 sass regression fixes for v3

### DIFF
--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/styles.scss
@@ -302,6 +302,7 @@ $zindex: base, map-container, map-gradient, map-fullscreen-toggle, map-buttons,
       background: inherit;
       position: relative;
       margin-left: 40px;
+      margin-top: -4px;
 
       input {
         opacity: 1 !important; // TODO
@@ -486,6 +487,10 @@ $zindex: base, map-container, map-gradient, map-fullscreen-toggle, map-buttons,
         top: 3px;
 
         &.time-input-icon > svg {
+          height: 20px;
+        }
+
+        &.date-input-icon > svg {
           height: 20px;
         }
       }

--- a/sass/base/_button.scss
+++ b/sass/base/_button.scss
@@ -8,6 +8,7 @@ button {
   border-width: 0;
   cursor: pointer;
   font-family: $button-font-family;
+  line-height: $line-height-normal;
   position: relative;
   background-color: transparent;
   transition: none;


### PR DESCRIPTION
- Text inside buttons had strange fixed line height. For example, navi cards had ugly too dense layout. Fixed.
- Ridiculously small calendar icon in mobile date picker fixed (old bug, not a regression)
- Desktop time picker's time input was aligned too low, fixed.
