### PR TITLE
Ab#414 Fix the order of the routepage selectors

### DIFF
--- a/app/component/routepage/RouteControlPanel.js
+++ b/app/component/routepage/RouteControlPanel.js
@@ -447,6 +447,16 @@ class RouteControlPanel extends React.Component {
           {routeNotifications}
           {showStandardControls(route) && (
             <>
+              {patternId && (
+                <RoutePatternSelectContainer
+                  params={match.params}
+                  route={route}
+                  onSelectChange={this.onPatternChange}
+                  gtfsId={route.gtfsId}
+                  className={cx({ 'bp-large': breakpoint === 'large' })}
+                  useCurrentTime={useCurrentTime}
+                />
+              )}
               {/* eslint-disable jsx-a11y/interactive-supports-focus */}
               <div
                 className="route-tabs"
@@ -550,16 +560,6 @@ class RouteControlPanel extends React.Component {
                   </div>
                 </button>
               </div>
-              {patternId && (
-                <RoutePatternSelectContainer
-                  params={match.params}
-                  route={route}
-                  onSelectChange={this.onPatternChange}
-                  gtfsId={route.gtfsId}
-                  className={cx({ 'bp-large': breakpoint === 'large' })}
-                  useCurrentTime={useCurrentTime}
-                />
-              )}
             </>
           )}
         </div>

--- a/app/component/routepage/route.scss
+++ b/app/component/routepage/route.scss
@@ -1144,7 +1144,7 @@ $margin-left-right: 21.3px;
   background-color: $light-gray;
   border: 2px solid $light-gray;
   border-radius: var(--radius-radius-pill, 999px);
-  margin: 0;
+  margin: var(--space-s) 0 0 0;
   padding: var(--space-xxs);
 
   button {


### PR DESCRIPTION
## Proposed Changes

  - The order of selectors on the route page should be pattern selector, tabs, date picker.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
