### PR TITLE
AB#352 Hide Skibus ticket link in kuopio

### DIFF
--- a/app/configurations/config.kuopio.js
+++ b/app/configurations/config.kuopio.js
@@ -184,6 +184,7 @@ export default configMerger(walttiConfig, {
     stops: true,
     itinerary: true,
   },
+  externalFareRouteIds: ['600_Skibus'],
 
   modeDisclaimers: {
     RAIL: {


### PR DESCRIPTION
## Proposed Changes

  - Adds routeId 600_Skibus to externalRouteIds so the ticket link is not shown

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
