### PR TITLE
Disable eslint rule react/require-default-props

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
     'react/jsx-key': 'error',
     'react/jsx-props-no-spreading': 'off',
     'react/forbid-prop-types': ['warn', { forbid: ['any', 'array', 'object'] }],
-    'react/require-default-props': 'warn',
+    'react/require-default-props': 'off',
     'react/sort-comp': 'off',
     'react/state-in-constructor': 'off',
     'react/static-property-placement': 'off',


### PR DESCRIPTION
## Proposed Changes

  - defaultProps are not supported in future react versions and can be replaced with JavaScripts native default parameters.
  - The rule also forces to define unnecessary default props such as undefined
  - Disabling the rule allows to write new components using modern syntax, without any needed changes to existing code