### PR TITLE
Rename Helsinki/Espoo rental network id back to smoove

### DIFF
--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -447,7 +447,7 @@ export default {
     minZoomStopsNearYou: 10,
     showFullInfo: true,
     networks: {
-      hsl: {
+      smoove: {
         enabled: true,
         season: {
           preSeasonStart: '1.3',


### PR DESCRIPTION
## Proposed Changes

  - We decided to use the old id for the network again because we couldn't update all integrations

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
