### PR TITLE
AB#238 - Remove least transfers filtering for flex

### DIFF
--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -11,12 +11,7 @@ import {
 import { PlannerMessageType, ExtendedRouteTypes } from '../../constants';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 import { boundWithMinimumArea } from '../../util/geo-utils';
-import {
-  compressLegs,
-  getTotalBikingDistance,
-  getTotalTransitLegsInExternalFlexTransitItinerary,
-  getTotalTransitLegsInInternalFlexTransitItinerary,
-} from '../../util/legUtils';
+import { compressLegs, getTotalBikingDistance } from '../../util/legUtils';
 import { getMapLayerOptions } from '../../util/mapLayerUtils';
 import { getDefaultSettings, getSettings } from '../../util/planParamUtil';
 import { getStartTimeWithColon } from '../../util/timeUtils';
@@ -433,28 +428,6 @@ export function filterItinerariesByRouteType(
 }
 
 /**
- * This function filters away itineraries that have a greater count than the
- * itinerary with the lowest count. The count is determined by the countFunction.
- */
-export function filterItinerariesKeepOnlyLeastCount(edges, countFunction) {
-  if (!edges || edges.length === 0) {
-    return [];
-  }
-
-  let leastAmountOfTransitLegs = countFunction(edges[0].node);
-  edges.forEach(edge => {
-    const amountOfTransitLegs = countFunction(edge.node);
-    if (leastAmountOfTransitLegs > amountOfTransitLegs) {
-      leastAmountOfTransitLegs = amountOfTransitLegs;
-    }
-  });
-
-  return edges.filter(
-    edge => countFunction(edge.node) === leastAmountOfTransitLegs,
-  );
-}
-
-/**
  * Pick combination of itineraries for bike and transit
  */
 export function mergeBikeTransitPlans(bikeParkPlan, bikeTransitPlan) {
@@ -589,13 +562,10 @@ export function mergeExternalTransitPlan(
   allowedExternalFlexRouteTypes,
   includeTaxiSuggestions,
 ) {
-  const externalTransitEdges = filterItinerariesKeepOnlyLeastCount(
-    filterItinerariesByRouteType(
-      externalPlan.edges,
-      allowedExternalFlexRouteTypes,
-      includeTaxiSuggestions,
-    ),
-    getTotalTransitLegsInExternalFlexTransitItinerary,
+  const externalTransitEdges = filterItinerariesByRouteType(
+    externalPlan.edges,
+    allowedExternalFlexRouteTypes,
+    includeTaxiSuggestions,
   );
   return sortAndMergePlans(externalTransitEdges, transitPlan, arriveBy);
 }
@@ -623,10 +593,7 @@ export function mergeFlexPlan(
   arriveBy,
   maxAdditionalEdges = 1,
 ) {
-  const edges = filterItinerariesKeepOnlyLeastCount(
-    flexEdges(flexPlan.edges),
-    getTotalTransitLegsInInternalFlexTransitItinerary,
-  );
+  const edges = flexEdges(flexPlan.edges);
   return sortAndMergePlans(edges, plan, arriveBy, maxAdditionalEdges);
 }
 

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -109,7 +109,6 @@ export const LegMode = {
   Car: 'CAR',
   Rail: 'RAIL',
   Wait: 'WAIT',
-  Taxi: 'TAXI',
 };
 
 /**
@@ -136,8 +135,6 @@ export function getLegMode(legOrMode) {
       return LegMode.Car;
     case LegMode.Rail:
       return LegMode.Rail;
-    case LegMode.Taxi:
-      return LegMode.Taxi;
     default:
       return undefined;
   }
@@ -445,9 +442,6 @@ function isBikingLeg(leg) {
 function isDrivingLeg(leg) {
   return LegMode.Car === getLegMode(leg);
 }
-function isTaxiLeg(leg) {
-  return LegMode.Taxi === getLegMode(leg);
-}
 export function isCallAgencyLeg(leg) {
   return leg.route?.type === ExtendedRouteTypes.CallAgency;
 }
@@ -510,29 +504,6 @@ export function legContainsBikePark(leg) {
  */
 export function legContainsCarPark(leg) {
   return leg.mode === LegMode.Car && leg.to.vehicleParking;
-}
-
-/**
- * Checks how many transit legs an external flex itinerary contains.
- *
- * @param {*} itinerary - The itinerary to check.
- * @returns {number} - Count of transit legs in itinerary.
- */
-export function getTotalTransitLegsInExternalFlexTransitItinerary(itinerary) {
-  return itinerary.legs.filter(leg => !isWalkingLeg(leg) && !isTaxiLeg(leg))
-    .length;
-}
-
-/**
- * Checks how many transit legs an internal flex itinerary contains.
- *
- * @param {*} itinerary - The itinerary to check.
- * @returns {number} - Count of transit legs in itinerary.
- */
-export function getTotalTransitLegsInInternalFlexTransitItinerary(itinerary) {
-  return itinerary.legs.filter(
-    leg => !isWalkingLeg(leg) && !isCallAgencyLeg(leg),
-  ).length;
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

  - The filtering did not work optimally for all cases. A better solution would be to show a couple of flex routes. However, with the current solution of only showing one flex route, always choosing the one with the earliest arrival time is probably the best solution.
