### PR TITLE
Add DAST security scan workflow

### DIFF
--- a/.github/workflows/dast.yaml
+++ b/.github/workflows/dast.yaml
@@ -1,0 +1,45 @@
+name: DAST Security Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+jobs:
+  zap-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run ZAP Scan
+        env:
+          TARGET_URL: ${{ secrets.TARGET_URL }}
+          SUBSCRIPTION_KEY: ${{ secrets.SUBSCRIPTION_KEY }}
+        run: |
+          chmod -R 777 ./
+          wget -q https://raw.githubusercontent.com/opentripplanner/OpenTripPlanner/refs/heads/dev-2.x/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+          docker run \
+            -v "$(pwd):/zap/wrk/:rw" \
+            -e TARGET_URL="${TARGET_URL}" \
+            -e SUBSCRIPTION_KEY="${SUBSCRIPTION_KEY}" \
+            -t zaproxy/zap-stable \
+            zap.sh -cmd -autorun /zap/wrk/security/zap.yml \
+            > /dev/null 2>&1
+
+      - name: Encrypt and upload ZAP Report
+        if: always()
+        env:
+          REPORT_PASSPHRASE: ${{ secrets.ZAP_REPORT_PASSPHRASE }}
+        run: |
+          openssl enc -aes-256-cbc -pbkdf2 \
+            -in zap-report.html \
+            -out zap-report.html.enc \
+            -pass pass:"${REPORT_PASSPHRASE}"
+
+      - name: Upload encrypted ZAP Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-report
+          path: zap-report.html.enc

--- a/.github/workflows/dast.yaml
+++ b/.github/workflows/dast.yaml
@@ -23,7 +23,7 @@ jobs:
             -v "$(pwd):/zap/wrk/:rw" \
             -e TARGET_URL="${TARGET_URL}" \
             -e SUBSCRIPTION_KEY="${SUBSCRIPTION_KEY}" \
-            -t zaproxy/zap-stable:2.17.0@sha256:c4da4c234258d444d9988fce9d034b00323724818daa4c91ca46f09aa04b46db \
+            -t zaproxy/zap-stable:2.17.0@sha256:707fc6b9fd8327ba48bb7b49d0c5732c179b045dab9c99f8b95410627dff4a00 \
             zap.sh -cmd -autorun /zap/wrk/security/zap.yml \
             > /dev/null 2>&1
 

--- a/.github/workflows/dast.yaml
+++ b/.github/workflows/dast.yaml
@@ -23,7 +23,7 @@ jobs:
             -v "$(pwd):/zap/wrk/:rw" \
             -e TARGET_URL="${TARGET_URL}" \
             -e SUBSCRIPTION_KEY="${SUBSCRIPTION_KEY}" \
-            -t zaproxy/zap-stable \
+            -t zaproxy/zap-stable:2.17.0@sha256:c4da4c234258d444d9988fce9d034b00323724818daa4c91ca46f09aa04b46db \
             zap.sh -cmd -autorun /zap/wrk/security/zap.yml \
             > /dev/null 2>&1
 

--- a/security/zap.yml
+++ b/security/zap.yml
@@ -1,0 +1,98 @@
+env:
+  contexts:
+    - name: zap
+      urls:
+        - "${TARGET_URL}"
+
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: false
+
+jobs:
+  - type: replacer
+    name: "Inject subscription key"
+    parameters:
+      deleteAllRules: false
+    rules:
+      - description: "Set subscription key"
+        matchType: req_header
+        matchString: "digitransit-subscription-key"
+        matchRegex: false
+        replacementString: "${SUBSCRIPTION_KEY}"
+
+  - type: alertFilter
+    name: "Filter out false positives and non-issues"
+    parameters:
+      deleteGlobalAlerts: true
+    alertFilters:
+      # Not an issue with API
+      - ruleId: 10021
+        ruleName: X-Content-Type-Options Header Missing
+        newRisk: False Positive
+      # CloudFlare limitation
+      - ruleId: 10054
+        ruleName: Cookie Without SameSite Attribute
+        newRisk: False Positive
+        parameter: _cfuvid
+      # CloudFlare limitation
+      - ruleId: 90033
+        ruleName: Loosely Scoped Cookie
+        newRisk: False Positive
+      # CloudFlare limitation
+      - ruleId: 10112
+        ruleName: Session Management Response Identified
+        newRisk: False Positive
+        parameter: _cfuvid
+      # Not actual timestamps
+      - ruleId: 10096
+        ruleName: Timestamp Disclosure - Unix
+        newRisk: False Positive
+      # Non-issue
+      - ruleId: 10112
+        ruleName: Session Management Response Identified
+        newRisk: False Positive
+      # Works as intended
+      - ruleId: 50007
+        ruleName: GraphQL Circular Type Reference
+        newRisk: False Positive
+      # Works as intended
+      - ruleId: 50007
+        ruleName: GraphQL Server Implementation Identified
+        newRisk: False Positive
+
+  - type: graphql
+    name: "GraphQL Spider"
+    parameters:
+      endpoint: "${TARGET_URL}"
+      schemaFile: "/zap/wrk/schema.graphqls"
+      maxQueryDepth: 1
+      maxArgsDepth: 1
+      maxCycleDetectionAlerts: 10
+
+  - type: passiveScan-wait
+    name: "Wait for passive scan to finish"
+    parameters:
+      maxDuration: 10
+
+  - type: report
+    parameters:
+      template: "traditional-html"
+      reportDir: "/zap/wrk"
+      reportFile: "zap-report.html"
+      reportTitle: "ZAP Scan for ${TARGET_URL}"
+    risks:
+      - info
+      - low
+      - medium
+      - high
+    confidences:
+      - falsepositive
+      - low
+      - medium
+      - high
+      - confirmed
+    sections:
+      - instancecount
+      - alertdetails
+      - alertcount


### PR DESCRIPTION
## Proposed Changes

A regularly (nightly) run dynamic security scan workflow against a target environment. The workflow will fail on new vulnerabilities. The scan itself is based on ZAP and the configuration suppression list is maintained in the zap.yaml. Output may contain vulnerability info so it is suppressed. The report itself is downloadable but encrypted.

The workflow needs the following secrets:
- TARGET_URL = Target environment URL, e.g. dev
- SUBSCRIPTION_KEY = For APIM
- ZAP_REPORT_PASSPHRASE = Passphrase for encrypting the scan report

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
