### PR TITLE
Add useConfigContext and useRouter stubs to tests

### DIFF
--- a/app/component/itinerary/ItineraryList.js
+++ b/app/component/itinerary/ItineraryList.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { useFragment } from 'react-relay';
 import { FormattedMessage } from 'react-intl';
 import cx from 'classnames';
-import { matchShape } from 'found';
-import { configShape, planEdgeShape } from '../../util/shapes';
+import { useRouter } from 'found';
+import { planEdgeShape } from '../../util/shapes';
 import Icon from '../Icon';
 import Itinerary from './Itinerary';
 import {
@@ -18,35 +18,33 @@ import Loading from '../Loading';
 import { streetHash } from '../../util/path';
 import { getIntermediatePlaces } from '../../util/otpStrings';
 import { ItineraryListPlanEdges } from './queries/ItineraryListPlanEdges';
+import { useConfigContext } from '../../configurations/ConfigContext';
 
 const spinnerPosition = {
   top: 'top',
   bottom: 'bottom',
 };
 
-function ItineraryList(
-  {
-    planEdges: planEdgesRef,
-    activeIndex,
-    onSelect,
-    onSelectImmediately,
-    searchTime,
-    bikeParkItineraryCount,
-    carDirectItineraryCount,
-    showRelaxedPlanNotifier,
-    rentalVehicleNotifierId,
-    separator2,
-    loadingMore,
-    separator1,
-    ...rest
-  },
-  context,
-) {
-  const { config } = context;
-  const { location } = context.match;
-  const { hash } = context.match.params;
+function ItineraryList({
+  planEdges: planEdgesRef,
+  activeIndex,
+  onSelect,
+  onSelectImmediately,
+  searchTime,
+  bikeParkItineraryCount = 0,
+  carDirectItineraryCount = 0,
+  showRelaxedPlanNotifier = false,
+  rentalVehicleNotifierId,
+  separator2,
+  loadingMore,
+  separator1,
+  ...rest
+}) {
+  const config = useConfigContext();
+  const { match } = useRouter();
+  const { hash } = match.params;
 
-  const planEdges = useFragment(ItineraryListPlanEdges, planEdgesRef);
+  const planEdges = useFragment(ItineraryListPlanEdges, planEdgesRef) || [];
 
   const co2s = planEdges
     .filter(e => e.node.emissionsPerPerson?.co2 >= 0)
@@ -62,7 +60,7 @@ function ItineraryList(
       passive={i !== activeIndex}
       onSelect={onSelect}
       onSelectImmediately={onSelectImmediately}
-      intermediatePlaces={getIntermediatePlaces(location.query)}
+      intermediatePlaces={getIntermediatePlaces(match.location.query)}
       hideSelectionIndicator={i !== activeIndex || planEdges.length === 1}
       lowestCo2value={lowestCo2value}
     />
@@ -250,22 +248,6 @@ ItineraryList.propTypes = {
   separator1: PropTypes.number,
   separator2: PropTypes.number,
   loadingMore: PropTypes.string,
-};
-
-ItineraryList.defaultProps = {
-  bikeParkItineraryCount: 0,
-  carDirectItineraryCount: 0,
-  planEdges: [],
-  showRelaxedPlanNotifier: false,
-  rentalVehicleNotifierId: undefined,
-  separator1: undefined,
-  separator2: undefined,
-  loadingMore: undefined,
-};
-
-ItineraryList.contextTypes = {
-  config: configShape.isRequired,
-  match: matchShape.isRequired,
 };
 
 export { ItineraryList as default, spinnerPosition };

--- a/test/unit/helpers/init.js
+++ b/test/unit/helpers/init.js
@@ -9,7 +9,10 @@ import { after, afterEach, before } from 'mocha';
 import { stub } from 'sinon';
 import { Settings } from 'luxon';
 import { initAnalyticsClientSide } from '../../../app/util/analyticsUtils';
-import { restoreOwnedIntlStub } from './mock-intl-enzyme';
+import {
+  restoreOwnedIntlStub,
+  restoreOwnedContextStubs,
+} from './mock-intl-enzyme';
 
 /**
  * Helper function to copy the properties of the source object to the
@@ -96,6 +99,7 @@ after('resetting the environment', () => {
 // make sure the local and session storage stays clear for each test
 afterEach(() => {
   restoreOwnedIntlStub();
+  restoreOwnedContextStubs();
   window.localStorage.clear();
   window.sessionStorage.clear();
 });

--- a/test/unit/helpers/mock-intl-enzyme.js
+++ b/test/unit/helpers/mock-intl-enzyme.js
@@ -2,7 +2,9 @@
  * Components using react-intl need an intl context.
  * - shallowWithIntl: injects a real intl object via legacy context AND stubs useIntl()
  *   so both class components (contextTypes) and function components (useIntl hook) work.
- * - mountWithIntl: wraps with IntlProvider + IntlBridge for full mount tests
+ *   Also stubs useConfigContext() and useRouter() since shallow rendering does not
+ *   support context providers for hooks.
+ * - mountWithIntl: wraps with IntlProvider + IntlBridge + TestProviders for full mount tests
  */
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -10,21 +12,59 @@ import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
 import * as ReactIntl from 'react-intl';
 import { createIntl, createIntlCache, IntlProvider } from 'react-intl';
+import * as found from 'found';
 import translations from '../../../app/translations/en';
 import IntlBridge from '../../../app/util/IntlBridge';
+import * as ConfigContext from '../../../app/configurations/ConfigContext';
+import TestProviders from './mock-providers';
+import { mockContext } from './mock-context';
 
 const getMessages = locale => translations[locale] || {};
 
 const intlCache = createIntlCache();
 
-// Tracks a useIntl stub created by shallowWithIntl (not by test-specific code)
-// so init.js can restore it after each test.
+// Tracks stubs created by shallowWithIntl (not by test-specific code)
+// so init.js can restore them after each test.
 let ownedUseIntlStub = null;
+let ownedConfigContextStub = null;
+let ownedUseRouterStub = null;
 
 export function restoreOwnedIntlStub() {
   if (ownedUseIntlStub) {
     ownedUseIntlStub.restore();
     ownedUseIntlStub = null;
+  }
+}
+
+export function restoreOwnedContextStubs() {
+  if (ownedConfigContextStub) {
+    ownedConfigContextStub.restore();
+    ownedConfigContextStub = null;
+  }
+  if (ownedUseRouterStub) {
+    ownedUseRouterStub.restore();
+    ownedUseRouterStub = null;
+  }
+}
+
+function applyContextStubs({ config, match, router } = {}) {
+  const configValue = config || mockContext.config;
+  const routerValue = {
+    match: match || mockContext.match,
+    router: router || mockContext.router,
+  };
+
+  const configAlreadyStubbed =
+    typeof ConfigContext.useConfigContext.restore === 'function';
+  if (!configAlreadyStubbed) {
+    ownedConfigContextStub = sinon
+      .stub(ConfigContext, 'useConfigContext')
+      .returns(configValue);
+  }
+
+  const routerAlreadyStubbed = typeof found.useRouter.restore === 'function';
+  if (!routerAlreadyStubbed) {
+    ownedUseRouterStub = sinon.stub(found, 'useRouter').returns(routerValue);
   }
 }
 
@@ -34,6 +74,9 @@ export const shallowWithIntl = (
     context = {},
     locale = 'en',
     messages = getMessages(locale),
+    config,
+    match,
+    router,
     ...additionalOptions
   } = {},
 ) => {
@@ -49,6 +92,8 @@ export const shallowWithIntl = (
     }
   }
 
+  applyContextStubs({ config, match, router });
+
   return shallow(node, {
     context: { intl, ...context },
     ...additionalOptions,
@@ -62,6 +107,9 @@ export const mountWithIntl = (
     childContextTypes = {},
     locale = 'en',
     messages = getMessages(locale),
+    config,
+    match,
+    router,
     ...additionalOptions
   } = {},
 ) => {
@@ -80,6 +128,8 @@ export const mountWithIntl = (
         ...context,
       },
       childContextTypes: fullChildContextTypes,
+      wrappingComponent: TestProviders,
+      wrappingComponentProps: { config, match, router },
       ...additionalOptions,
     },
   );

--- a/test/unit/helpers/mock-providers.js
+++ b/test/unit/helpers/mock-providers.js
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react';
+import { RouterContext, routerShape, matchShape } from 'found';
+import PropTypes from 'prop-types';
+import { ConfigProvider } from '../../../app/configurations/ConfigContext';
+import { mockContext } from './mock-context';
+import { configShape } from '../../../app/util/shapes';
+
+/**
+ * Wraps children with ConfigProvider and RouterContext.Provider
+ * so that hooks like useConfigContext() and useRouter() work
+ * without stubbing.
+ */
+export default function TestProviders({ children, ...props }) {
+  const config = useMemo(
+    () => props.config || mockContext.config,
+    [props.config],
+  );
+  const routerContextValue = useMemo(
+    () => ({
+      match: props.match || mockContext.match,
+      router: props.router || mockContext.router,
+    }),
+    [props.match, props.router],
+  );
+  return (
+    <ConfigProvider value={config}>
+      <RouterContext.Provider value={routerContextValue}>
+        {children}
+      </RouterContext.Provider>
+    </ConfigProvider>
+  );
+}
+
+TestProviders.propTypes = {
+  children: PropTypes.element.isRequired,
+  config: configShape,
+  match: matchShape,
+  router: routerShape,
+};


### PR DESCRIPTION
## Proposed Changes

  - Modifies shallow rendering such that useConfigContext and useRouter are stubbed before each time a component is shallow rendered
  - Also adds wrappers to mountWithIntl so the non-stubbed hooks can be used with it.
  - Gets rid of legacy context in ItineraryList and cleans proptypes
  - Ideally the stubs could be done using beforeEach and afterEach in init.js, but the way ES handles imports makes it so that the stubbed function bindings are not persisted accross modules.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
