### PR TITLE
AB#574 Fix some stop view bugs

### DIFF
--- a/app/component/stop/FilterTimeTableModal.js
+++ b/app/component/stop/FilterTimeTableModal.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
-import cx from 'classnames';
 import { Modal, ModalContent } from '@hsl-fi/dialog';
 import Icon from '../Icon';
 import routeCompare from '../../util/route-compare';
@@ -65,7 +64,6 @@ export default function FilterTimeTableModal({
   };
 
   const routeDivs = [];
-  const LONG_LINE_NAME = 5;
 
   // Find out which departures are ARRIVING to their final stop,
   // not real departures, then remove them
@@ -93,6 +91,7 @@ export default function FilterTimeTableModal({
   routesWithStopTimes.forEach(o => {
     const mode = getRouteMode(o);
     const checked = showRoutes.includes(o.code);
+    const label = o.shortName || o.agency || '';
 
     routeDivs.push(
       <div key={o.code} className="route-row">
@@ -132,14 +131,8 @@ export default function FilterTimeTableModal({
         <div className="route-mode">
           <Icon className={mode} img={`icon_${mode}`} />
         </div>
-        <div
-          className={`route-number ${mode} ${cx({
-            'overflow-fade':
-              (o.shortName ? o.shortName : o.agency) &&
-              (o.shortName ? o.shortName : o.agency).length > LONG_LINE_NAME,
-          })}`}
-        >
-          {o.shortName ? o.shortName : o.agency}
+        <div className="route-label">
+          <span className={mode}> {label} </span>
         </div>
         <div className="route-headsign">{o.headsign}</div>
       </div>,
@@ -183,9 +176,7 @@ export default function FilterTimeTableModal({
                 ) : null}
               </label>
             </div>
-            <div className="all-routes-header-title">
-              <FormattedMessage id="all-routes" defaultMessage="All lines" />
-            </div>
+            <FormattedMessage id="all-routes" defaultMessage="All lines" />
           </div>
 
           <div className="routes-container">

--- a/app/component/stop/FilterTimeTableModal.js
+++ b/app/component/stop/FilterTimeTableModal.js
@@ -2,22 +2,22 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
 import cx from 'classnames';
-import Modal from '@hsl-fi/modal';
+import { Modal, ModalContent } from '@hsl-fi/dialog';
 import Icon from '../Icon';
 import routeCompare from '../../util/route-compare';
-import withBreakpoint from '../../util/withBreakpoint';
 import { isKeyboardSelectionEvent } from '../../util/browser';
 import { getRouteMode } from '../../util/modeUtils';
 import { stopShape } from '../../util/shapes';
+import { useConfigContext } from '../../configurations/ConfigContext';
 
-function FilterTimeTableModal({
+export default function FilterTimeTableModal({
   stop,
   setRoutes,
   showFilterModal,
   showRoutesList,
-  breakpoint,
 }) {
   const intl = useIntl();
+  const config = useConfigContext();
 
   const [showRoutes, setShowRoutes] = useState(showRoutesList);
   const [allRoutes, setAllRoutes] = useState(showRoutesList.length === 0);
@@ -147,61 +147,52 @@ function FilterTimeTableModal({
   });
 
   return (
-    <Modal
-      appElement="#app"
-      contentLabel=""
-      closeButtonLabel={intl.formatMessage({ id: 'close' })}
-      isOpen
-      onCrossClick={closeModal}
-      className="filter-stop-modal"
-      overlayClassName={
-        breakpoint === 'large'
-          ? 'filter-stop-modal-overlay'
-          : 'mobile mobile-filter-stop-modal-overlay stop-scroll-container'
-      }
-    >
-      <h2 className="filter-stop-modal-header">
-        <FormattedMessage id="show-routes" defaultMessage="Show Lines" />
-      </h2>
+    <Modal lang={config.language} onOpenChange={closeModal} open>
+      <ModalContent
+        title={intl.formatMessage({ id: 'show-routes' })}
+        lang={config.language}
+      >
+        <div className="filter-stop-modal">
+          <div className="all-routes-header">
+            <div className="checkbox-container">
+              <input
+                type="checkbox"
+                id="input-all-routes"
+                aria-label={intl.formatMessage({
+                  id: 'select-all-routes',
+                  defaultMessage: 'Select all routes',
+                })}
+                checked={allRoutes}
+                aria-checked={allRoutes}
+                onClick={e => allRoutes === true && e.preventDefault()}
+                onKeyDown={e => {
+                  if (isKeyboardSelectionEvent(e)) {
+                    toggleAllRoutes(e);
+                  }
+                }}
+                onChange={() => {
+                  toggleAllRoutes();
+                }}
+              />
+              <label
+                htmlFor="input-all-routes"
+                className={allRoutes ? 'checked' : ''}
+              >
+                {allRoutes ? (
+                  <Icon img="icon_box-checked" className="checkbox-icon" />
+                ) : null}
+              </label>
+            </div>
+            <div className="all-routes-header-title">
+              <FormattedMessage id="all-routes" defaultMessage="All lines" />
+            </div>
+          </div>
 
-      <div className="all-routes-header">
-        <div className="checkbox-container">
-          <input
-            type="checkbox"
-            id="input-all-routes"
-            aria-label={intl.formatMessage({
-              id: 'select-all-routes',
-              defaultMessage: 'Select all routes',
-            })}
-            checked={allRoutes}
-            aria-checked={allRoutes}
-            onClick={e => allRoutes === true && e.preventDefault()}
-            onKeyDown={e => {
-              if (isKeyboardSelectionEvent(e)) {
-                toggleAllRoutes(e);
-              }
-            }}
-            onChange={() => {
-              toggleAllRoutes();
-            }}
-          />
-          <label
-            htmlFor="input-all-routes"
-            className={allRoutes ? 'checked' : ''}
-          >
-            {allRoutes ? (
-              <Icon img="icon_box-checked" className="checkbox-icon" />
-            ) : null}
-          </label>
+          <div className="routes-container">
+            {routeDivs.length > 0 ? routeDivs : null}
+          </div>
         </div>
-        <div className="all-routes-header-title">
-          <FormattedMessage id="all-routes" defaultMessage="All lines" />
-        </div>
-      </div>
-
-      <div className="routes-container">
-        {routeDivs.length > 0 ? routeDivs : null}
-      </div>
+      </ModalContent>
     </Modal>
   );
 }
@@ -211,7 +202,4 @@ FilterTimeTableModal.propTypes = {
   setRoutes: PropTypes.func.isRequired,
   showFilterModal: PropTypes.func.isRequired,
   showRoutesList: PropTypes.arrayOf(PropTypes.string).isRequired,
-  breakpoint: PropTypes.string.isRequired,
 };
-
-export default withBreakpoint(FilterTimeTableModal);

--- a/app/component/stop/FilterTimeTableModal.js
+++ b/app/component/stop/FilterTimeTableModal.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import intersection from 'lodash/intersection';
-import { FormattedMessage } from 'react-intl';
+import React, { useState } from 'react';
+import { useIntl, FormattedMessage } from 'react-intl';
 import cx from 'classnames';
 import Modal from '@hsl-fi/modal';
 import Icon from '../Icon';
@@ -11,226 +10,208 @@ import { isKeyboardSelectionEvent } from '../../util/browser';
 import { getRouteMode } from '../../util/modeUtils';
 import { stopShape } from '../../util/shapes';
 
-class FilterTimeTableModal extends React.Component {
-  static propTypes = {
-    stop: stopShape.isRequired,
-    setRoutes: PropTypes.func.isRequired,
-    showFilterModal: PropTypes.func.isRequired,
-    showRoutesList: PropTypes.arrayOf(PropTypes.string).isRequired,
-    breakpoint: PropTypes.string.isRequired,
-  };
+function FilterTimeTableModal({
+  stop,
+  setRoutes,
+  showFilterModal,
+  showRoutesList,
+  breakpoint,
+}) {
+  const intl = useIntl();
 
-  static contextTypes = {
-    intl: PropTypes.object.isRequired,
-  };
+  const [showRoutes, setShowRoutes] = useState(showRoutesList);
+  const [allRoutes, setAllRoutes] = useState(showRoutesList.length === 0);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      showRoutes: this.props.showRoutesList,
-      allRoutes: this.props.showRoutesList.length === 0 && true,
-    };
-  }
-
-  toggleAllRoutes = () => {
-    if (this.state.allRoutes === true) {
-      this.setState({
-        allRoutes: false,
-      });
-      this.updateParent({ showRoutes: [] });
-    } else {
-      this.setState({
-        allRoutes: true,
-        showRoutes: [],
-      });
-      this.updateParent({ showRoutes: [] });
-    }
-  };
-
-  handleCheckbox = routesToAdd => {
-    const chosenRoutes =
-      this.state.showRoutes.length > 0 ? this.state.showRoutes.slice() : [];
-
-    const newChosenRoutes =
-      chosenRoutes.indexOf(routesToAdd) < 0
-        ? chosenRoutes.concat([routesToAdd]) // concat when handling React state based array to avoid array length being assigned as a value
-        : chosenRoutes.map(o => o !== routesToAdd && o).filter(o => o);
-
-    if (newChosenRoutes.length === 0) {
-      this.updateParent({ showRoutes: newChosenRoutes, allRoutes: true });
-      this.setState({ showRoutes: newChosenRoutes, allRoutes: true });
-    } else {
-      this.updateParent({ showRoutes: newChosenRoutes });
-      this.setState({ allRoutes: false, showRoutes: newChosenRoutes });
-    }
-  };
-
-  constructRouteDivs = () => {
-    const routeDivs = [];
-    const LONG_LINE_NAME = 5;
-    // Find out which departures are ARRIVING to their final stop, not real departures
-    // then remove them
-    const routesWithStopTimes = this.props.stop.stoptimesForServiceDate
-      .map(
-        o =>
-          o.stoptimes.length > 0 &&
-          o.stoptimes[0].pickupType !== 'NONE' && {
-            code: o.pattern.code,
-            headsign: o.pattern.headsign,
-            shortName: o.pattern.route.shortName,
-            mode: o.pattern.route.mode,
-            type: o.pattern.route.type,
-            agency: o.pattern.route.agency.name,
-          },
-      )
-      .filter(o => o)
-      .sort(routeCompare)
-      // deduplicate patterns with same code
-      .filter(
-        (pattern, index, self) =>
-          self.map(itm => itm.code).indexOf(pattern.code) === index,
-      );
-
-    routesWithStopTimes.forEach(o => {
-      const mode = getRouteMode(o);
-      routeDivs.push(
-        <div key={o.code} className="route-row">
-          <div className="checkbox-container">
-            <input
-              type="checkbox"
-              aria-label={this.context.intl.formatMessage(
-                {
-                  id: 'select-route',
-                  defaultMessage:
-                    'Select {mode} route {shortName} to {headsign}',
-                },
-                {
-                  mode: this.context.intl.formatMessage({
-                    id: mode,
-                  }),
-                  shortName: o.shortName,
-                  headsign: o.headsign,
-                },
-              )}
-              checked={intersection(this.state.showRoutes, [o.code]).length > 0}
-              aria-checked={
-                intersection(this.state.showRoutes, [o.code]).length > 0
-              }
-              id={`input-${o.code}`}
-              onChange={() => this.handleCheckbox(o.code)}
-              onKeyDown={e => {
-                if (isKeyboardSelectionEvent(e)) {
-                  this.handleCheckbox(o.code);
-                }
-              }}
-            />
-            {/* eslint-disable jsx-a11y/label-has-associated-control */}
-            <label
-              htmlFor={`input-${o.code}`}
-              className={
-                intersection(this.state.showRoutes, [o.code]).length > 0
-                  ? 'checked'
-                  : ''
-              }
-            >
-              {intersection(this.state.showRoutes, [o.code]).length > 0 && (
-                <Icon img="icon_box-checked" className="checkbox-icon" />
-              )}
-            </label>
-            {/* eslint-enable jsx-a11y/label-has-associated-control */}
-          </div>
-          <div className="route-mode">
-            <Icon className={mode} img={`icon_${mode}`} />
-          </div>
-          <div
-            className={`route-number ${mode} ${cx({
-              'overflow-fade':
-                (o.shortName ? o.shortName : o.agency) &&
-                (o.shortName ? o.shortName : o.agency).length > LONG_LINE_NAME,
-            })}`}
-          >
-            {o.shortName ? o.shortName : o.agency}
-          </div>
-          <div className="route-headsign">{o.headsign}</div>
-        </div>,
-      );
-    });
-    return routeDivs;
-  };
-
-  closeModal = () => {
-    this.props.showFilterModal(false);
-  };
-
-  updateParent(newOptions) {
-    this.props.setRoutes({
+  const updateParent = newOptions => {
+    setRoutes({
       showRoutes: newOptions.showRoutes,
     });
-  }
+  };
 
-  /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-  render() {
-    const routeList = this.constructRouteDivs();
-    const { intl } = this.context;
-    return (
-      <Modal
-        appElement="#app"
-        contentLabel=""
-        closeButtonLabel={intl.formatMessage({ id: 'close' })}
-        isOpen
-        onCrossClick={this.closeModal}
-        className="filter-stop-modal"
-        overlayClassName={
-          this.props.breakpoint === 'large'
-            ? 'filter-stop-modal-overlay'
-            : 'mobile mobile-filter-stop-modal-overlay stop-scroll-container'
-        }
-      >
-        <h2 className="filter-stop-modal-header">
-          <FormattedMessage id="show-routes" defaultMessage="Show Lines" />
-        </h2>
-        <div className="all-routes-header">
-          <div className="checkbox-container">
-            <input
-              type="checkbox"
-              id="input-all-routes"
-              aria-label={intl.formatMessage({
-                id: 'select-all-routes',
-                defaultMessage: 'Select all routes',
-              })}
-              checked={this.state.allRoutes}
-              aria-checked={this.state.allRoutes}
-              onClick={e => this.state.allRoutes === true && e.preventDefault()}
-              onKeyDown={e => {
-                if (isKeyboardSelectionEvent(e)) {
-                  this.toggleAllRoutes(e);
-                }
-              }}
-              onChange={e => {
-                this.toggleAllRoutes(e);
-              }}
-            />
-            {/* eslint-disable jsx-a11y/label-has-associated-control */}
-            <label
-              htmlFor="input-all-routes"
-              className={this.state.allRoutes ? 'checked' : ''}
-            >
-              {this.state.allRoutes ? (
-                <Icon img="icon_box-checked" className="checkbox-icon" />
-              ) : null}
-            </label>
-            {/* eslint-enable jsx-a11y/label-has-associated-control */}
-          </div>
-          <div className="all-routes-header-title">
-            <FormattedMessage id="all-routes" defaultMessage="All lines" />
-          </div>
-        </div>
-        <div className="routes-container">
-          {routeList.length > 0 ? routeList : null}
-        </div>
-      </Modal>
+  const toggleAllRoutes = () => {
+    if (allRoutes) {
+      setAllRoutes(false);
+      setShowRoutes([]);
+      updateParent({ showRoutes: [] });
+    } else {
+      setAllRoutes(true);
+      setShowRoutes([]);
+      updateParent({ showRoutes: [] });
+    }
+  };
+
+  const handleCheckbox = routesToAdd => {
+    const chosenRoutes = showRoutes.length > 0 ? showRoutes.slice() : [];
+
+    // concat when handling React state based array to avoid array length being assigned as a value
+    const newChosenRoutes =
+      chosenRoutes.indexOf(routesToAdd) < 0
+        ? chosenRoutes.concat([routesToAdd])
+        : chosenRoutes.filter(o => o !== routesToAdd);
+
+    if (newChosenRoutes.length === 0) {
+      updateParent({ showRoutes: newChosenRoutes, allRoutes: true });
+      setShowRoutes(newChosenRoutes);
+      setAllRoutes(true);
+    } else {
+      updateParent({ showRoutes: newChosenRoutes });
+      setShowRoutes(newChosenRoutes);
+      setAllRoutes(false);
+    }
+  };
+
+  const closeModal = () => {
+    showFilterModal(false);
+  };
+
+  const routeDivs = [];
+  const LONG_LINE_NAME = 5;
+
+  // Find out which departures are ARRIVING to their final stop,
+  // not real departures, then remove them
+  const routesWithStopTimes = stop.stoptimesForServiceDate
+    .map(
+      o =>
+        o.stoptimes.length > 0 &&
+        o.stoptimes[0].pickupType !== 'NONE' && {
+          code: o.pattern.code,
+          headsign: o.pattern.headsign,
+          shortName: o.pattern.route.shortName,
+          mode: o.pattern.route.mode,
+          type: o.pattern.route.type,
+          agency: o.pattern.route.agency.name,
+        },
+    )
+    .filter(o => o)
+    .sort(routeCompare)
+    // deduplicate patterns with same code
+    .filter(
+      (pattern, index, self) =>
+        self.map(itm => itm.code).indexOf(pattern.code) === index,
     );
-  }
+
+  routesWithStopTimes.forEach(o => {
+    const mode = getRouteMode(o);
+    const checked = showRoutes.includes(o.code);
+
+    routeDivs.push(
+      <div key={o.code} className="route-row">
+        <div className="checkbox-container">
+          <input
+            type="checkbox"
+            aria-label={intl.formatMessage(
+              {
+                id: 'select-route',
+                defaultMessage: 'Select {mode} route {shortName} to {headsign}',
+              },
+              {
+                mode: intl.formatMessage({ id: mode }),
+                shortName: o.shortName,
+                headsign: o.headsign,
+              },
+            )}
+            checked={checked}
+            aria-checked={checked}
+            id={`input-${o.code}`}
+            onChange={() => handleCheckbox(o.code)}
+            onKeyDown={e => {
+              if (isKeyboardSelectionEvent(e)) {
+                handleCheckbox(o.code);
+              }
+            }}
+          />
+          <label
+            htmlFor={`input-${o.code}`}
+            className={checked ? 'checked' : ''}
+          >
+            {checked && (
+              <Icon img="icon_box-checked" className="checkbox-icon" />
+            )}
+          </label>
+        </div>
+        <div className="route-mode">
+          <Icon className={mode} img={`icon_${mode}`} />
+        </div>
+        <div
+          className={`route-number ${mode} ${cx({
+            'overflow-fade':
+              (o.shortName ? o.shortName : o.agency) &&
+              (o.shortName ? o.shortName : o.agency).length > LONG_LINE_NAME,
+          })}`}
+        >
+          {o.shortName ? o.shortName : o.agency}
+        </div>
+        <div className="route-headsign">{o.headsign}</div>
+      </div>,
+    );
+  });
+
+  return (
+    <Modal
+      appElement="#app"
+      contentLabel=""
+      closeButtonLabel={intl.formatMessage({ id: 'close' })}
+      isOpen
+      onCrossClick={closeModal}
+      className="filter-stop-modal"
+      overlayClassName={
+        breakpoint === 'large'
+          ? 'filter-stop-modal-overlay'
+          : 'mobile mobile-filter-stop-modal-overlay stop-scroll-container'
+      }
+    >
+      <h2 className="filter-stop-modal-header">
+        <FormattedMessage id="show-routes" defaultMessage="Show Lines" />
+      </h2>
+
+      <div className="all-routes-header">
+        <div className="checkbox-container">
+          <input
+            type="checkbox"
+            id="input-all-routes"
+            aria-label={intl.formatMessage({
+              id: 'select-all-routes',
+              defaultMessage: 'Select all routes',
+            })}
+            checked={allRoutes}
+            aria-checked={allRoutes}
+            onClick={e => allRoutes === true && e.preventDefault()}
+            onKeyDown={e => {
+              if (isKeyboardSelectionEvent(e)) {
+                toggleAllRoutes(e);
+              }
+            }}
+            onChange={() => {
+              toggleAllRoutes();
+            }}
+          />
+          <label
+            htmlFor="input-all-routes"
+            className={allRoutes ? 'checked' : ''}
+          >
+            {allRoutes ? (
+              <Icon img="icon_box-checked" className="checkbox-icon" />
+            ) : null}
+          </label>
+        </div>
+        <div className="all-routes-header-title">
+          <FormattedMessage id="all-routes" defaultMessage="All lines" />
+        </div>
+      </div>
+
+      <div className="routes-container">
+        {routeDivs.length > 0 ? routeDivs : null}
+      </div>
+    </Modal>
+  );
 }
+
+FilterTimeTableModal.propTypes = {
+  stop: stopShape.isRequired,
+  setRoutes: PropTypes.func.isRequired,
+  showFilterModal: PropTypes.func.isRequired,
+  showRoutesList: PropTypes.arrayOf(PropTypes.string).isRequired,
+  breakpoint: PropTypes.string.isRequired,
+};
 
 export default withBreakpoint(FilterTimeTableModal);

--- a/app/component/stop/TimetableRow.js
+++ b/app/component/stop/TimetableRow.js
@@ -1,11 +1,10 @@
-/* eslint-disable no-return-assign */
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { DateTime } from 'luxon';
 
-const TimetableRow = ({ title, stoptimes, showRoutes, timerows }) => {
+const TimetableRow = ({ title, stoptimes, showRoutes = [], timerows = [] }) => {
   const intl = useIntl();
   return (
     <div
@@ -49,17 +48,11 @@ const TimetableRow = ({ title, stoptimes, showRoutes, timerows }) => {
               `}
               </div>
               <span aria-hidden>
-                <div>
-                  <span>
-                    {DateTime.fromSeconds(
-                      time.serviceDay + time.scheduledDeparture,
-                    ).toFormat('mm')}
-                  </span>
-                  <span className="line-name" title={time.name}>
-                    /{time.name}
-                    {time.duplicate}
-                  </span>
-                </div>
+                {DateTime.fromSeconds(
+                  time.serviceDay + time.scheduledDeparture,
+                ).toFormat('mm')}
+                /{time.name}
+                {time.duplicate}
               </span>
             </div>
           ))}
@@ -80,11 +73,6 @@ TimetableRow.propTypes = {
   ).isRequired,
   showRoutes: PropTypes.arrayOf(PropTypes.string),
   timerows: PropTypes.arrayOf(PropTypes.string),
-};
-
-TimetableRow.defaultProps = {
-  showRoutes: [],
-  timerows: [],
 };
 
 export default TimetableRow;

--- a/app/component/stop/stop.scss
+++ b/app/component/stop/stop.scss
@@ -671,6 +671,7 @@ hr.action-bar {
   justify-content: flex-start;
   min-width: 4.0625rem;
   margin-bottom: 4px;
+  padding-right: 10px;
 }
 
 .timetable-topbar {

--- a/app/component/stop/stop.scss
+++ b/app/component/stop/stop.scss
@@ -554,49 +554,25 @@ hr.action-bar {
 }
 
 .filter-stop-modal {
-  .filter-stop-modal-header {
-    margin: auto;
-    margin-top: 2.5em;
-    text-align: center;
-  }
+  font-size: $font-size-small;
+  font-weight: $font-weight-medium;
 
   .all-routes-header {
     display: flex;
-    padding-bottom: 0.6em;
-    margin-top: 1.1em;
-    width: 100%;
-    border-bottom: 1px solid $background-color;
-  }
-
-  .all-routes-header-title {
-    margin-top: 0.3em;
-    font-size: $font-size-small;
-    font-weight: $font-weight-medium;
-  }
-
-  .routes-container {
-    overflow-y: scroll;
-    height: 500px;
-    border-radius: 0 0 8px 8px;
-  }
-
-  .route-row {
-    display: flex;
-    border-top: 1px solid $background-color;
-    padding-top: 0.75em;
-    padding-bottom: 0.3em;
-    width: 100%;
+    margin-top: 1em;
+    align-items: center;
   }
 
   .checkbox-container {
+    display: flex;
     margin-right: 2em;
-    margin-top: 0.2em;
     position: relative;
 
     & input[type='checkbox'] {
       opacity: 0;
       width: 2em;
       height: 2em;
+      margin: 0;
     }
 
     & label {
@@ -626,20 +602,36 @@ hr.action-bar {
     }
   }
 
+  .routes-container {
+    margin-top: 1em;
+    overflow-y: scroll;
+    border-radius: 0 0 8px 8px;
+  }
+
+  .route-row {
+    display: flex;
+    padding-top: 0.75em;
+    padding-bottom: 0.3em;
+  }
+
   .route-mode {
-    margin-right: 3px;
+    display: flex;
+    margin-right: 4px;
 
     svg {
       width: 1.6em;
-      height: 1.2em;
-      margin-top: 4px;
+      height: 1.6em;
     }
+  }
+
+  .route-label {
+    min-width: 64px;
+    padding-right: 12px;
   }
 
   .route-headsign {
     font-family: $font-family-narrow;
     font-weight: $font-weight-book;
-    margin-top: 0.1em;
   }
 }
 
@@ -772,31 +764,6 @@ hr.action-bar {
 
   .stop-page-departure-wrapper {
     padding: 0 16px 0 16px;
-  }
-
-  .filter-stop-modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    height: 100vh;
-    width: 100%;
-    bottom: 0;
-    right: 0;
-    background-color: transparent;
-    z-index: 1000; // Needs to be higher than the navbar
-  }
-
-  .filter-stop-modal {
-    background-color: #fff;
-    z-index: 99999;
-    height: 100%;
-    width: 100%;
-    overflow: scroll;
-    min-height: 100%;
-    max-width: 100%;
-    position: fixed;
-    border-radius: 0;
-    transform: translate(-50%, -50%);
   }
 
   .routes-container {

--- a/app/component/stop/stop.scss
+++ b/app/component/stop/stop.scss
@@ -553,37 +553,15 @@ hr.action-bar {
   }
 }
 
-.filter-stop-modal-overlay {
-  position: fixed;
-  height: 100%;
-  width: 100%;
-  top: 0;
-  left: 0;
-  background-color: rgba(0, 0, 0, 0.2);
-  z-index: 1000; // Needs to be higher than the navbar
-}
-
 .filter-stop-modal {
-  position: absolute;
-  z-index: 99999;
-  background-color: #fff;
-  border-radius: 8px;
-  width: 100%;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  max-width: 720px;
-
   .filter-stop-modal-header {
     margin: auto;
     margin-top: 2.5em;
-    margin-left: 1em;
     text-align: center;
   }
 
   .all-routes-header {
     display: flex;
-    padding-left: 1em;
     padding-bottom: 0.6em;
     margin-top: 1.1em;
     width: 100%;
@@ -607,7 +585,6 @@ hr.action-bar {
     border-top: 1px solid $background-color;
     padding-top: 0.75em;
     padding-bottom: 0.3em;
-    padding-left: 1em;
     width: 100%;
   }
 
@@ -773,18 +750,6 @@ hr.action-bar {
   @media print {
     margin-left: 0;
   }
-}
-
-.mobile-filter-stop-modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100vh;
-  width: 100%;
-  bottom: 0;
-  right: 0;
-  background-color: transparent;
-  z-index: 1000; // Needed to cover up the navbar
 }
 
 .mobile {


### PR DESCRIPTION
- Stop page/timetable tab did not render any space between long  route  short names. For example, a train station view in matka.fi was impossible to read. Fixed now.
- Stop page's route filter modal was badly positioned. In low displays, top part was clipped away (ticket [AB#528](https://dev.azure.com/digitransit/49576af7-d55f-4602-9722-2d62a5d321b2/_workitems/edit/528)). Fixed by removing bad styles and using the new design system modal.
- Filter modal converted to a react function and modernized
- Filter modal's styles were really silly: long names were faded although the space was expanded, vertical centering was  inaccurate etc. Styling errors fixed.
- Filter modal refactored