### PR TITLE
Fix style for `platform-updated-icon` arrow

### DIFF
--- a/app/component/itinerary/itinerary.scss
+++ b/app/component/itinerary/itinerary.scss
@@ -3630,7 +3630,6 @@ $font-print-decrease: 0.7;
       justify-content: center;
 
       .platform-updated-icon {
-        vertical-align: middle;
         color: $cancelation-red;
       }
     }


### PR DESCRIPTION
## Proposed Changes

- Before
<img width="252" height="143" alt="image" src="https://github.com/user-attachments/assets/5f216212-6fd3-4f72-91d3-cd29062637bf" />

- After
<img width="215" height="136" alt="image" src="https://github.com/user-attachments/assets/5f0124fb-2e45-4f83-a0b4-f0d3c0530c22" />
