### PR TITLE
AB#496 Enable transit group relax function in planconnection query

### DIFF
--- a/app/component/itinerary/queries/PlanConnection.js
+++ b/app/component/itinerary/queries/PlanConnection.js
@@ -13,6 +13,7 @@ export const planConnection = graphql`
     $walkSpeed: Speed
     $wheelchair: Boolean
     $transferPenalty: Cost
+    $transitGroupRelaxFunction: LinearCostFunctionInput
     $bikeSpeed: Speed
     $allowedRentalNetworks: [String!]
     $after: String
@@ -52,6 +53,7 @@ export const planConnection = graphql`
         transit: {
           transfer: { cost: $transferPenalty, slack: $minTransferTime }
           filters: $filters
+          relaxTransitGroupPriority: $transitGroupRelaxFunction
         }
       }
     ) {

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -194,6 +194,10 @@ export default {
     includeCarSuggestions: false,
     showBikeAndParkItineraries: false,
     includeTaxiSuggestions: false,
+    transitGroupRelaxFunction: {
+      constant: 300,
+      coefficient: 1.2,
+    },
   },
 
   /**

--- a/app/store/localStorage.js
+++ b/app/store/localStorage.js
@@ -143,6 +143,10 @@ export function setCustomizedSettings(data) {
       data.includeTaxiSuggestions,
       oldSettings.includeTaxiSuggestions,
     ),
+    transitGroupRelaxFunction: getValueOrDefault(
+      data.transitGroupRelaxFunction,
+      oldSettings.transitGroupRelaxFunction,
+    ),
   };
   if (newSettings.modes) {
     // cleanup

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -516,6 +516,9 @@ export function getPlanParams(
   const transferPenalty = relaxSettings
     ? defaultSettings.transferPenalty
     : settings.transferPenalty;
+
+  const { transitGroupRelaxFunction } = defaultSettings;
+
   const timeStr = (time ? DateTime.fromSeconds(+time) : DateTime.now()).toISO({
     suppressMilliseconds: true,
   });
@@ -539,6 +542,7 @@ export function getPlanParams(
     walkReluctance,
     walkBoardCost,
     transferPenalty,
+    transitGroupRelaxFunction,
     modes,
     planType,
     noIterationsForShortTrips,

--- a/build/schema.graphql
+++ b/build/schema.graphql
@@ -3906,6 +3906,12 @@ enum RoutingErrorCode {
   """
   LOCATION_NOT_FOUND
   """
+  No usable itineraries were found for the requested direct mode (e.g. walking, cycling, car, flex)
+  and no transit modes were included in the search. This is returned both when no route exists and
+  when routes were found but didn't pass quality filters.
+  """
+  NO_DIRECT_MODE_CONNECTION
+  """
   No stops are reachable from the start or end locations specified.
     
   You can try searching using a different access or egress mode, for example cycling instead of walking,
@@ -4553,6 +4559,18 @@ input InputUnpreferred {
   useUnpreferredRoutesPenalty: Int @deprecated(reason : "Use unpreferredCost instead")
 }
 
+"""
+A generalized linear cost function that can be applied to a cost value.
+The coefficient is used to scale the input Cost linearly and the constant is used
+to add a fixed offset. If we assume a cost c, then f(c) = coefficient * c + constant.
+"""
+input LinearCostFunctionInput {
+  "The coefficient that scales the Cost input linearly."
+  coefficient: Float!
+  "The 0th degree constant of the function as a Cost, must be a non-negative integer"
+  constant: Cost!
+}
+
 "Filters an entity by a date range."
 input LocalDateRangeInput {
   """
@@ -5077,6 +5095,23 @@ input TransitPreferencesInput {
   an AND-condition.
   """
   filters: [TransitFilterInput!]
+  """
+  Relax generalized-cost when comparing itineraries with a different set of
+  transit-group-priorities. The groups are set server side for routes and
+  can not be configured in the API.
+    
+  This relaxes the comparison inside the routing engine for each stop-arrival. If two
+  paths have a different set of transit-group-priorities, then the generalized-cost
+  comparison is relaxed. The final set of paths are filtered through the normal
+  itinerary-filters.
+    
+  A relax-cost is used to increase the limit when comparing one cost to another cost
+  using a linear function applied to the generalized cost.
+  This is used to include more results into the result. A `coefficient=2.0` means a path (itinerary)
+  with twice as high cost as another one, is accepted. A `constant=300` means a "fixed"
+  constant is added to the limit.
+  """
+  relaxTransitGroupPriority: LinearCostFunctionInput
   "Preferences related to cancellations and real-time."
   timetable: TimetablePreferencesInput
   "Preferences related to transfers between transit vehicles (typically between stops)."

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/schema/schema.graphql
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/schema/schema.graphql
@@ -3906,6 +3906,12 @@ enum RoutingErrorCode {
   """
   LOCATION_NOT_FOUND
   """
+  No usable itineraries were found for the requested direct mode (e.g. walking, cycling, car, flex)
+  and no transit modes were included in the search. This is returned both when no route exists and
+  when routes were found but didn't pass quality filters.
+  """
+  NO_DIRECT_MODE_CONNECTION
+  """
   No stops are reachable from the start or end locations specified.
     
   You can try searching using a different access or egress mode, for example cycling instead of walking,
@@ -4553,6 +4559,18 @@ input InputUnpreferred {
   useUnpreferredRoutesPenalty: Int @deprecated(reason : "Use unpreferredCost instead")
 }
 
+"""
+A generalized linear cost function that can be applied to a cost value.
+The coefficient is used to scale the input Cost linearly and the constant is used
+to add a fixed offset. If we assume a cost c, then f(c) = coefficient * c + constant.
+"""
+input LinearCostFunctionInput {
+  "The coefficient that scales the Cost input linearly."
+  coefficient: Float!
+  "The 0th degree constant of the function as a Cost, must be a non-negative integer"
+  constant: Cost!
+}
+
 "Filters an entity by a date range."
 input LocalDateRangeInput {
   """
@@ -5077,6 +5095,23 @@ input TransitPreferencesInput {
   an AND-condition.
   """
   filters: [TransitFilterInput!]
+  """
+  Relax generalized-cost when comparing itineraries with a different set of
+  transit-group-priorities. The groups are set server side for routes and
+  can not be configured in the API.
+    
+  This relaxes the comparison inside the routing engine for each stop-arrival. If two
+  paths have a different set of transit-group-priorities, then the generalized-cost
+  comparison is relaxed. The final set of paths are filtered through the normal
+  itinerary-filters.
+    
+  A relax-cost is used to increase the limit when comparing one cost to another cost
+  using a linear function applied to the generalized cost.
+  This is used to include more results into the result. A `coefficient=2.0` means a path (itinerary)
+  with twice as high cost as another one, is accepted. A `constant=300` means a "fixed"
+  constant is added to the limit.
+  """
+  relaxTransitGroupPriority: LinearCostFunctionInput
   "Preferences related to cancellations and real-time."
   timetable: TimetablePreferencesInput
   "Preferences related to transfers between transit vehicles (typically between stops)."


### PR DESCRIPTION
## Proposed Changes

  - Adds a default relaxation of 5 minutes and 1.2 times the original time
  - The arguments are always included in the query but have no effect unless transit groups are defined on the backend side

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
