### PR TITLE
AB:595: HSL crisis banner

### DIFF
--- a/app/component/AppBarContainer.js
+++ b/app/component/AppBarContainer.js
@@ -7,6 +7,7 @@ import withBreakpoint from '../util/withBreakpoint';
 import { favouriteShape, userShape } from '../util/shapes';
 import AppBar from './AppBar';
 import AppBarHsl from './AppBarHsl';
+import CrisisBannerHsl from './CrisisBannerHsl';
 import MessageBar from './MessageBar';
 
 const AppBarContainer = (
@@ -27,6 +28,7 @@ const AppBarContainer = (
       </a>
       {style === 'hsl' ? (
         <div className="hsl-header-container" style={{ display: 'block' }}>
+          <CrisisBannerHsl lang={lang} />
           <AppBarHsl user={user} lang={lang} favourites={favourites} />
           <MessageBar breakpoint={breakpoint} />
         </div>

--- a/app/component/AppBarContainer.js
+++ b/app/component/AppBarContainer.js
@@ -28,7 +28,7 @@ const AppBarContainer = (
       </a>
       {style === 'hsl' ? (
         <div className="hsl-header-container" style={{ display: 'block' }}>
-          <CrisisBannerHsl lang={lang} />
+          <CrisisBannerHsl />
           <AppBarHsl user={user} lang={lang} favourites={favourites} />
           <MessageBar breakpoint={breakpoint} />
         </div>

--- a/app/component/CrisisBannerHsl.js
+++ b/app/component/CrisisBannerHsl.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
 import { classList } from '@hsl-fi/utilities';
 import { Alert } from '@hsl-fi/icons';
 import { CrisisPriority } from '@hsl-fi/content-delivery-api-types';
@@ -7,8 +8,9 @@ import { useConfigContext } from '../configurations/ConfigContext';
 import { getJson } from '../util/xhrPromise';
 import './crisis-banner-hsl.scss';
 
-const CrisisBannerHsl = ({ lang = 'fi', initialBanners = null }) => {
+const CrisisBannerHsl = ({ initialBanners = null }) => {
   const config = useConfigContext();
+  const { locale } = useIntl();
   const [banners, setBanners] = useState(() => {
     if (initialBanners) {
       return initialBanners;
@@ -27,10 +29,10 @@ const CrisisBannerHsl = ({ lang = 'fi', initialBanners = null }) => {
     ) {
       return;
     }
-    getJson(`${config.URL.BANNERS}&language=${lang}`)
+    getJson(`${config.URL.BANNERS}&language=${locale}`)
       .then(data => setBanners(data))
       .catch(() => setBanners([]));
-  }, [lang]);
+  }, []);
 
   if (!banners.length) {
     return null;
@@ -62,7 +64,6 @@ const CrisisBannerHsl = ({ lang = 'fi', initialBanners = null }) => {
 };
 
 CrisisBannerHsl.propTypes = {
-  lang: PropTypes.string,
   initialBanners: PropTypes.arrayOf(
     PropTypes.shape({
       body: PropTypes.string,

--- a/app/component/CrisisBannerHsl.js
+++ b/app/component/CrisisBannerHsl.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { classList } from '@hsl-fi/utilities';
+import { Alert } from '@hsl-fi/icons';
+import { CrisisPriority } from '@hsl-fi/content-delivery-api-types';
+import { useConfigContext } from '../configurations/ConfigContext';
+import { getJson } from '../util/xhrPromise';
+import './crisis-banner-hsl.scss';
+
+const CrisisBannerHsl = ({ lang = 'fi', initialBanners = null }) => {
+  const config = useConfigContext();
+  const [banners, setBanners] = useState(() => {
+    if (initialBanners) {
+      return initialBanners;
+    }
+    if (config.showStaticCrisisBanners) {
+      return config.staticCrisisBanners || [];
+    }
+    return [];
+  });
+
+  useEffect(() => {
+    if (
+      initialBanners ||
+      config.showStaticCrisisBanners ||
+      !config.URL.BANNERS
+    ) {
+      return;
+    }
+    getJson(`${config.URL.BANNERS}&language=${lang}`)
+      .then(data => setBanners(data))
+      .catch(() => setBanners([]));
+  }, [lang]);
+
+  if (!banners.length) {
+    return null;
+  }
+
+  return (
+    <div className="crisis-banners">
+      {banners.map(({ body, priority }) => (
+        <div
+          key={body}
+          className={classList(
+            'crisis-banners-banner',
+            priority === CrisisPriority.Primary
+              ? 'crisis-banners-banner-primary'
+              : 'crisis-banners-banner-secondary',
+          )}
+        >
+          {priority === CrisisPriority.Primary && (
+            <div className="crisis-banners-banner-primary-icon">
+              <Alert width="19" fill="#ffffff" />
+            </div>
+          )}
+          {/* eslint-disable-next-line react/no-danger */}
+          <div dangerouslySetInnerHTML={{ __html: body }} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+CrisisBannerHsl.propTypes = {
+  lang: PropTypes.string,
+  initialBanners: PropTypes.arrayOf(
+    PropTypes.shape({
+      body: PropTypes.string,
+      priority: PropTypes.string,
+    }),
+  ),
+};
+
+export default CrisisBannerHsl;

--- a/app/component/crisis-banner-hsl.scss
+++ b/app/component/crisis-banner-hsl.scss
@@ -1,0 +1,60 @@
+@import '~@hsl-fi/sass/fonts';
+@import '~@hsl-fi/sass/mixins/text';
+
+$banner-major-level-color: #dc0451;
+$banner-neutral-level-color: #333;
+
+.crisis-banners {
+  position: relative;
+
+  .crisis-banners-banner {
+    min-height: 40px;
+    padding: 5px 15px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    @include text-typography(small);
+
+    font-family: $font-stack;
+    font-weight: 500;
+    color: #fff;
+    margin: 0;
+
+    a,
+    p {
+      @include text-typography(small);
+
+      font-family: $font-stack;
+      font-weight: 500;
+      color: #fff;
+      margin: 0;
+    }
+
+    &.crisis-banners-banner-primary {
+      background-color: $banner-major-level-color;
+    }
+
+    &.crisis-banners-banner-secondary {
+      background-color: $banner-neutral-level-color;
+
+      *:focus {
+        outline-color: white;
+      }
+    }
+  }
+
+  .crisis-banners-banner-primary-icon {
+    margin-top: 3px;
+    margin-right: 10px;
+
+    svg {
+      width: 19px;
+    }
+  }
+
+  .crisis-banners-banner-primary + .crisis-banners-banner-primary,
+  .crisis-banners-banner-secondary + .crisis-banners-banner-secondary {
+    border-top: 1px solid #fff;
+  }
+}

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -757,4 +757,15 @@ export default {
   showRouteDescNotification: IS_DEV,
   personalization: false,
   showNewRoutePage: true,
+  staticCrisisBanners: [
+    {
+      body: 'Dummy crisis alert — primary',
+      priority: 'Primary',
+    },
+    {
+      body: 'Dummy crisis alert — secondary',
+      priority: 'Secondary',
+    },
+  ],
+  showStaticCrisisBanners: false,
 };

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
     "@rollup/plugin-commonjs": "^28.0.8",
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
+    "@testing-library/react": "^12",
     "@testing-library/react-hooks": "^8.0.1",
     "async": "^3.2.6",
     "autoprefixer": "^10.4.21",

--- a/test/unit/CrisisBannerHsl.test.js
+++ b/test/unit/CrisisBannerHsl.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { ConfigProvider } from '../../app/configurations/ConfigContext';
+import CrisisBannerHsl from '../../app/component/CrisisBannerHsl';
+
+const primaryBanner = { body: 'Primary alert', priority: 'Primary' };
+const secondaryBanner = { body: 'Secondary alert', priority: 'Secondary' };
+
+const baseConfig = {
+  CONFIG: 'hsl',
+  URL: { BANNERS: null },
+};
+
+const renderWithBanners = (banners = []) => {
+  const { container } = render(
+    <ConfigProvider value={baseConfig}>
+      <CrisisBannerHsl lang="fi" initialBanners={banners} />
+    </ConfigProvider>,
+  );
+  return container;
+};
+
+describe('<CrisisBannerHsl />', () => {
+  it('renders nothing when no banners are provided', () => {
+    const container = renderWithBanners([]);
+    expect(container.firstChild).to.equal(null);
+  });
+
+  it('renders the correct number of banners', () => {
+    const container = renderWithBanners([primaryBanner, secondaryBanner]);
+    expect(
+      container.querySelectorAll('.crisis-banners-banner'),
+    ).to.have.lengthOf(2);
+  });
+
+  it('renders primary banner with the alert icon', () => {
+    const container = renderWithBanners([primaryBanner]);
+    expect(
+      container.querySelector('.crisis-banners-banner-primary'),
+    ).to.not.equal(null);
+    expect(
+      container.querySelector('.crisis-banners-banner-primary-icon'),
+    ).to.not.equal(null);
+  });
+
+  it('renders secondary banner without the alert icon', () => {
+    const container = renderWithBanners([secondaryBanner]);
+    expect(
+      container.querySelector('.crisis-banners-banner-secondary'),
+    ).to.not.equal(null);
+    expect(
+      container.querySelector('.crisis-banners-banner-primary-icon'),
+    ).to.equal(null);
+  });
+
+  it('renders banner body as HTML', () => {
+    const container = renderWithBanners([
+      { body: '<b>Alert!</b>', priority: 'Secondary' },
+    ]);
+    expect(container.querySelector('b')).to.not.equal(null);
+    expect(container.querySelector('b').textContent).to.equal('Alert!');
+  });
+});

--- a/test/unit/CrisisBannerHsl.test.js
+++ b/test/unit/CrisisBannerHsl.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
@@ -16,9 +17,11 @@ const baseConfig = {
 
 const renderWithBanners = (banners = []) => {
   const { container } = render(
-    <ConfigProvider value={baseConfig}>
-      <CrisisBannerHsl lang="fi" initialBanners={banners} />
-    </ConfigProvider>,
+    <IntlProvider locale="fi" messages={{}}>
+      <ConfigProvider value={baseConfig}>
+        <CrisisBannerHsl initialBanners={banners} />
+      </ConfigProvider>
+    </IntlProvider>,
   );
   return container;
 };

--- a/test/unit/helpers/babel-register.js
+++ b/test/unit/helpers/babel-register.js
@@ -7,8 +7,9 @@ require('@babel/register')({
   ],
 });
 
-// Prevent Node.js from trying to parse CSS files as JavaScript
+// Prevent Node.js from trying to parse CSS/SCSS files as JavaScript
 require.extensions['.css'] = () => {};
+require.extensions['.scss'] = () => {};
 
 // @hsl-fi/* packages are ESM-only ("type": "module") and cannot be require()'d
 // in the CommonJS test environment. Node throws ERR_REQUIRE_ESM before Babel can
@@ -48,8 +49,13 @@ Module._load = function interceptEsmPackages(request, ...args) {
       },
     );
   }
-  // Fallback: stub any other @hsl-fi/* package generically
-  if (request.startsWith('@hsl-fi/')) {
+  // Fallback: stub any other @hsl-fi/* package generically.
+  // Exceptions: CJS packages that can be loaded normally.
+  if (
+    request.startsWith('@hsl-fi/') &&
+    request !== '@hsl-fi/utilities' &&
+    request !== '@hsl-fi/content-delivery-api-types'
+  ) {
     return new Proxy(
       function StubComponent() {
         return null;

--- a/test/unit/helpers/init.js
+++ b/test/unit/helpers/init.js
@@ -8,6 +8,7 @@ import { JSDOM } from 'jsdom';
 import { after, afterEach, before } from 'mocha';
 import { stub } from 'sinon';
 import { Settings } from 'luxon';
+import { cleanup } from '@testing-library/react';
 import { initAnalyticsClientSide } from '../../../app/util/analyticsUtils';
 import {
   restoreOwnedIntlStub,
@@ -99,6 +100,7 @@ after('resetting the environment', () => {
 
 // make sure the local and session storage stays clear for each test
 afterEach(() => {
+  cleanup();
   restoreOwnedIntlStub();
   restoreOwnedContextStubs();
   window.localStorage.clear();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6774,6 +6774,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^8.0.0":
+  version: 8.20.1
+  resolution: "@testing-library/dom@npm:8.20.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.1.3"
+    chalk: "npm:^4.1.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10/6c7a92fcc89931ef62a9a92dacec09b3e5ee5c3aba2171aa8de6c7504927b7c9364d73d2ed87b72447d6783108c1c92c207d16f788de64c69bc97059d7105e3c
+  languageName: node
+  linkType: hard
+
 "@testing-library/react-hooks@npm:^8.0.1":
   version: 8.0.1
   resolution: "@testing-library/react-hooks@npm:8.0.1"
@@ -6793,6 +6809,20 @@ __metadata:
     react-test-renderer:
       optional: true
   checksum: 10/f7b69373feebe99bc7d60595822cc5c00a1a5a4801bc4f99b597256a5c1d23c45a51f359051dd8a7bdffcc23b26f324c582e9433c25804934fd351a886812790
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^12":
+  version: 12.1.5
+  resolution: "@testing-library/react@npm:12.1.5"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+    "@testing-library/dom": "npm:^8.0.0"
+    "@types/react-dom": "npm:<18.0.0"
+  peerDependencies:
+    react: <18.0.0
+    react-dom: <18.0.0
+  checksum: 10/24ea6ed298ae65c374b3068974359371f551fa1ffdeb5de9853432856ff63b71576d8bbfa8ee1e45d4fa214c2135e49561bafc9b11528cecc8a7943e2a942255
   languageName: node
   linkType: hard
 
@@ -6836,6 +6866,13 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/aa58e64753a420ad1eefaf7bacef3dda61d74f9336925943d9244132d5b48d9242f734f1e707fd5ccfa6dd1d8ec8e6debc234b4dedb3a5b0d8486d1f373350b2
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: 10/c0084c389dc030daeaf0115a92ce43a3f4d42fc8fef2d0e22112d87a42798d4a15aac413019d4a63f868327d52ad6740ab99609462b442fe6b9286b172d2e82e
   languageName: node
   linkType: hard
 
@@ -7220,6 +7257,15 @@ __metadata:
   version: 1.2.7
   resolution: "@types/range-parser@npm:1.2.7"
   checksum: 10/95640233b689dfbd85b8c6ee268812a732cf36d5affead89e806fe30da9a430767af8ef2cd661024fd97e19d61f3dec75af2df5e80ec3bea000019ab7028629a
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:<18.0.0":
+  version: 17.0.26
+  resolution: "@types/react-dom@npm:17.0.26"
+  peerDependencies:
+    "@types/react": ^17.0.0
+  checksum: 10/86be1faf019b58f2b470a037c291c9c9efa5cf8b3927bfec436d83b12dd7a6a0369554c567c4ca8b59e1ee341b835c1b272cd0340628cbbea75ec43168858e5b
   languageName: node
   linkType: hard
 
@@ -8269,6 +8315,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-query@npm:5.1.3":
+  version: 5.1.3
+  resolution: "aria-query@npm:5.1.3"
+  dependencies:
+    deep-equal: "npm:^2.0.5"
+  checksum: 10/e5da608a7c4954bfece2d879342b6c218b6b207e2d9e5af270b5e38ef8418f02d122afdc948b68e32649b849a38377785252059090d66fa8081da95d1609c0d2
+  languageName: node
+  linkType: hard
+
 "aria-query@npm:^5.3.0":
   version: 5.3.2
   resolution: "aria-query@npm:5.3.2"
@@ -8297,7 +8352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-buffer-byte-length@npm:^1.0.1, array-buffer-byte-length@npm:^1.0.2":
+"array-buffer-byte-length@npm:^1.0.0, array-buffer-byte-length@npm:^1.0.1, array-buffer-byte-length@npm:^1.0.2":
   version: 1.0.2
   resolution: "array-buffer-byte-length@npm:1.0.2"
   dependencies:
@@ -9714,6 +9769,18 @@ __metadata:
     es-errors: "npm:^1.3.0"
     function-bind: "npm:^1.1.2"
   checksum: 10/00482c1f6aa7cfb30fb1dbeb13873edf81cfac7c29ed67a5957d60635a56b2a4a480f1016ddbdb3395cc37900d46037fb965043a51c5c789ffeab4fc535d18b5
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.2, call-bind@npm:^1.0.5":
+  version: 1.0.9
+  resolution: "call-bind@npm:1.0.9"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    get-intrinsic: "npm:^1.3.0"
+    set-function-length: "npm:^1.2.2"
+  checksum: 10/25b1a98d6158f0adf9fface594ca82be4e3ed481d8ff7f36ad1fccb0c8377e38c6a04ff3248693723222d378677e93077c739defc8a6741c82b7e00bcee1245d
   languageName: node
   linkType: hard
 
@@ -11992,6 +12059,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-equal@npm:^2.0.5":
+  version: 2.2.3
+  resolution: "deep-equal@npm:2.2.3"
+  dependencies:
+    array-buffer-byte-length: "npm:^1.0.0"
+    call-bind: "npm:^1.0.5"
+    es-get-iterator: "npm:^1.1.3"
+    get-intrinsic: "npm:^1.2.2"
+    is-arguments: "npm:^1.1.1"
+    is-array-buffer: "npm:^3.0.2"
+    is-date-object: "npm:^1.0.5"
+    is-regex: "npm:^1.1.4"
+    is-shared-array-buffer: "npm:^1.0.2"
+    isarray: "npm:^2.0.5"
+    object-is: "npm:^1.1.5"
+    object-keys: "npm:^1.1.1"
+    object.assign: "npm:^4.1.4"
+    regexp.prototype.flags: "npm:^1.5.1"
+    side-channel: "npm:^1.0.4"
+    which-boxed-primitive: "npm:^1.0.2"
+    which-collection: "npm:^1.0.1"
+    which-typed-array: "npm:^1.1.13"
+  checksum: 10/1ce49d0b71d0f14d8ef991a742665eccd488dfc9b3cada069d4d7a86291e591c92d2589c832811dea182b4015736b210acaaebce6184be356c1060d176f5a05f
+  languageName: node
+  linkType: hard
+
 "deep-extend@npm:^0.5.1":
   version: 0.5.1
   resolution: "deep-extend@npm:0.5.1"
@@ -12306,6 +12399,7 @@ __metadata:
     "@rollup/plugin-commonjs": "npm:^28.0.8"
     "@rollup/plugin-json": "npm:4.1.0"
     "@rollup/plugin-node-resolve": "npm:^16.0.3"
+    "@testing-library/react": "npm:^12"
     "@testing-library/react-hooks": "npm:^8.0.1"
     async: "npm:^3.2.6"
     autoprefixer: "npm:^10.4.21"
@@ -12580,6 +12674,13 @@ __metadata:
   bin:
     documentation: bin/documentation.js
   checksum: 10/19fcf9549041c9966e9b21b4e6f3174f71935ac1ec3f96b7970e59a9fe9ad8ee7c76466d994855f33d99f19eda47aab928c03ce20f2fb0cdfb29713a67b6d540
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 10/377b4a7f9eae0a5d72e1068c369c99e0e4ca17fdfd5219f3abd32a73a590749a267475a59d7b03a891f9b673c27429133a818c44b2e47e32fec024b34274e2ca
   languageName: node
   linkType: hard
 
@@ -13266,6 +13367,23 @@ __metadata:
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: 10/96e65d640156f91b707517e8cdc454dd7d47c32833aa3e85d79f24f9eb7ea85f39b63e36216ef0114996581969b59fe609a94e30316b08f5f4df1d44134cf8d5
+  languageName: node
+  linkType: hard
+
+"es-get-iterator@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "es-get-iterator@npm:1.1.3"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.1.3"
+    has-symbols: "npm:^1.0.3"
+    is-arguments: "npm:^1.1.1"
+    is-map: "npm:^2.0.2"
+    is-set: "npm:^2.0.2"
+    is-string: "npm:^1.0.7"
+    isarray: "npm:^2.0.5"
+    stop-iteration-iterator: "npm:^1.0.0"
+  checksum: 10/bc2194befbe55725f9489098626479deee3c801eda7e83ce0dff2eb266a28dc808edb9b623ff01d31ebc1328f09d661333d86b601036692c2e3c1a6942319433
   languageName: node
   linkType: hard
 
@@ -15185,7 +15303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.2, get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -17012,7 +17130,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
+"is-arguments@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "is-arguments@npm:1.2.0"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10/471a8ef631b8ee8829c43a8ab05c081700c0e25180c73d19f3bf819c1a8448c426a9e8e601f278973eca68966384b16ceb78b8c63af795b099cd199ea5afc457
+  languageName: node
+  linkType: hard
+
+"is-array-buffer@npm:^3.0.2, is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
   version: 3.0.5
   resolution: "is-array-buffer@npm:3.0.5"
   dependencies:
@@ -17350,7 +17478,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-map@npm:^2.0.3":
+"is-map@npm:^2.0.2, is-map@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-map@npm:2.0.3"
   checksum: 10/8de7b41715b08bcb0e5edb0fb9384b80d2d5bcd10e142188f33247d19ff078abaf8e9b6f858e2302d8d05376a26a55cd23a3c9f8ab93292b02fcd2cc9e4e92bb
@@ -17515,7 +17643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.0.5, is-regex@npm:^1.1.0, is-regex@npm:^1.2.0, is-regex@npm:^1.2.1":
+"is-regex@npm:^1.0.5, is-regex@npm:^1.1.0, is-regex@npm:^1.1.4, is-regex@npm:^1.2.0, is-regex@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-regex@npm:1.2.1"
   dependencies:
@@ -17557,14 +17685,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-set@npm:^2.0.3":
+"is-set@npm:^2.0.2, is-set@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-set@npm:2.0.3"
   checksum: 10/5685df33f0a4a6098a98c72d94d67cad81b2bc72f1fb2091f3d9283c4a1c582123cd709145b02a9745f0ce6b41e3e43f1c944496d1d74d4ea43358be61308669
   languageName: node
   linkType: hard
 
-"is-shared-array-buffer@npm:^1.0.4":
+"is-shared-array-buffer@npm:^1.0.2, is-shared-array-buffer@npm:^1.0.4":
   version: 1.0.4
   resolution: "is-shared-array-buffer@npm:1.0.4"
   dependencies:
@@ -19690,6 +19818,15 @@ __metadata:
   version: 3.7.2
   resolution: "luxon@npm:3.7.2"
   checksum: 10/b24cd205ed306ce7415991687897dcc4027921ae413c9116590bc33a95f93b86ce52cf74ba72b4f5c5ab1c10090517f54ac8edfb127c049e0bf55b90dc2260be
+  languageName: node
+  linkType: hard
+
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 10/e86f0280e99a8d8cd4eef24d8601ddae15ce54e43ac9990dfcb79e1e081c255ad24424a30d78d2ad8e51a8ce82a66a930047fed4b4aa38c6f0b392ff9300edfc
   languageName: node
   linkType: hard
 
@@ -23994,6 +24131,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^17.0.1"
+  checksum: 10/248990cbef9e96fb36a3e1ae6b903c551ca4ddd733f8d0912b9cc5141d3d0b3f9f8dfb4d799fb1c6723382c9c2083ffbfa4ad43ff9a0e7535d32d41fd5f01da6
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
@@ -24715,7 +24863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^17.0.2":
+"react-is@npm:^17.0.1, react-is@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10/73b36281e58eeb27c9cc6031301b6ae19ecdc9f18ae2d518bdb39b0ac564e65c5779405d623f1df9abf378a13858b79442480244bd579968afc1faf9a2ce5e05
@@ -25349,7 +25497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
+"regexp.prototype.flags@npm:^1.5.1, regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
   dependencies:
@@ -26750,7 +26898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.6, side-channel@npm:^1.1.0":
+"side-channel@npm:^1.0.4, side-channel@npm:^1.0.6, side-channel@npm:^1.1.0":
   version: 1.1.0
   resolution: "side-channel@npm:1.1.0"
   dependencies:
@@ -27373,7 +27521,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stop-iteration-iterator@npm:^1.1.0":
+"stop-iteration-iterator@npm:^1.0.0, stop-iteration-iterator@npm:^1.1.0":
   version: 1.1.0
   resolution: "stop-iteration-iterator@npm:1.1.0"
   dependencies:
@@ -30148,7 +30296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
+"which-boxed-primitive@npm:^1.0.2, which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
   version: 1.1.1
   resolution: "which-boxed-primitive@npm:1.1.1"
   dependencies:
@@ -30182,7 +30330,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-collection@npm:^1.0.2":
+"which-collection@npm:^1.0.1, which-collection@npm:^1.0.2":
   version: 1.0.2
   resolution: "which-collection@npm:1.0.2"
   dependencies:
@@ -30208,7 +30356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.19":
+"which-typed-array@npm:^1.1.13, which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.19":
   version: 1.1.20
   resolution: "which-typed-array@npm:1.1.20"
   dependencies:


### PR DESCRIPTION
## Proposed Changes

  - HSL crisis banner. Initial implementation.
    - You can test this by enabling the `showStaticCrisisBanners` in `config.hsl`
  - Added React Testing Library
    - With RTL we can start phasing out enzyme tests. 

We should have an discussion is this worth implementing as a package, so it would be easy to implement in other projects that needs the crisis banner as well. But for now let's keep it simple.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
