### PR TITLE
Fix broken 'show ticket' link in HSL planner's navigator

### DIFF
--- a/app/component/itinerary/navigator/NaviBottom.js
+++ b/app/component/itinerary/navigator/NaviBottom.js
@@ -25,7 +25,7 @@ function NaviBottom(
   const intl = useIntl();
 
   const isTicketSaleActive =
-    !config.hideNaviTickets &&
+    config.navigatorTicketLink &&
     shouldShowFareInfo(config, legs) &&
     getFaresFromLegs(legs, config)?.find(f => !f.isUnknown);
 
@@ -76,7 +76,7 @@ function NaviBottom(
         >
           <a
             onClick={handleTicketButtonClick}
-            href={localizedUrl(config.ticketLink, currentLanguage)}
+            href={localizedUrl(config.navigatorTicketLink, currentLanguage)}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -371,6 +371,9 @@ export default {
   ticketPurchaseLink: function purchaseTicketLink(fare) {
     return `https://open.app.hsl.fi/zoneTicketWizard/TICKET_TYPE_SINGLE_TICKET/${fare.ticketName}/adult/-`;
   },
+  navigatorTicketLink: {
+    fi: 'https://open.app.hsl.fi/tickets', // shows existing ticket
+  },
   ticketLinkOperatorCode: 'hsl',
   // mapping fareId from OTP fare identifiers to human readable form
   // in the new HSL zone model, just strip off the prefix 'HSL:'

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -286,7 +286,6 @@ export default {
   },
   analyticsClass: 'plausible-event-name=Ticket+Purchase+Link',
 
-  hideNaviTickets: true, // TODO: temporary force switch
   navigation: true,
 
   // TODO: flex disabled for now, proper configuration coming in the future


### PR DESCRIPTION
Add a dedicated configuration link for navigator's ticket button.