### PR TITLE
AB#600 - Fix itinerary summary overflow

### DIFF
--- a/app/component/itinerary/itinerary-summary.scss
+++ b/app/component/itinerary/itinerary-summary.scss
@@ -654,6 +654,10 @@
     border-left-width: 8px;
     padding: 0 0 0 60px;
 
+    .summary-clickable-area {
+      max-width: 385px;
+    }
+
     h3,
     h4 {
       margin-top: 10px;


### PR DESCRIPTION


## Proposed Changes

  - Fix itinerary summary overflow by setting 'max-width: 385px' for '.summary-clickable-area'
  - Set to 385 instead of 400 because of scroll bar taking 15px when enough itinerary summaries exist
  
### Wrong

<img width="579" height="800" alt="image" src="https://github.com/user-attachments/assets/0ed06c0d-1a8c-4597-a045-e89d52821598" />

### Fixed

<img width="556" height="695" alt="image" src="https://github.com/user-attachments/assets/83e6623f-1618-4f4e-8879-5f4ac50e726d" />
