### PR TITLE
AB#611 - Change flex setting format

### DIFF
--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -212,7 +212,7 @@ function ItineraryDetails({
       itinerary.legs.some(
         leg =>
           isCallAgencyLeg(leg) &&
-          !config.flex.internalAgencies.includes(leg.route.agency.gtfsId),
+          !config.flex.internal.agencies.includes(leg.route.agency.gtfsId),
       )
     ) {
       disclaimers.push(

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -583,7 +583,7 @@ export default function ItineraryPage(props, context) {
       const flexPlan = {
         edges: filterItinerariesByRouteType(
           plan.edges,
-          config.flex.allowedExternalFlexRouteTypes,
+          config.flex.external.allowedRouteTypes,
         ),
       };
       setRelaxExternalFlexState({ plan: flexPlan, loading: LOADSTATE.DONE });
@@ -1152,7 +1152,7 @@ export default function ItineraryPage(props, context) {
           externalFlexState.plan,
           plan,
           match.location.query.arriveBy === 'true',
-          config.flex.allowedExternalFlexRouteTypes,
+          config.flex.external.allowedRouteTypes,
         );
       }
 

--- a/app/component/itinerary/customizesearch/CustomizeSearch.js
+++ b/app/component/itinerary/customizesearch/CustomizeSearch.js
@@ -101,7 +101,7 @@ function CustomizeSearch({ onToggleClick, settings, mobile }) {
             <Scooters />
           </div>
         )}
-        {config.flex?.allowTaxiJourneys &&
+        {config.flex.external.enabled &&
           config.transportModes.taxi.availableForSelection && (
             <div className="settings-section">
               <TaxiOptions currentSettings={currentSettings} />

--- a/app/component/itinerary/customizesearch/TaxiOptions.js
+++ b/app/component/itinerary/customizesearch/TaxiOptions.js
@@ -11,7 +11,7 @@ import { useConfigContext } from '../../../configurations/ConfigContext';
 export default function TaxiOptions({ currentSettings }, { executeAction }) {
   const config = useConfigContext();
   const taxiLabelId =
-    config.flex.taxiSettingLabelOverride || 'taxis-and-ride-hailing';
+    config.flex.settingLabelOverride || 'taxis-and-ride-hailing';
   const taxiRoutingState = currentSettings.includeTaxiSuggestions
     ? 'Disable'
     : 'Enable';

--- a/app/component/map/RoutePageMap.js
+++ b/app/component/map/RoutePageMap.js
@@ -67,10 +67,10 @@ function RoutePageMap(
   const routeId = rest.match.params.routeId.split(':')[0];
   const flexAgencies = useMemo(
     () =>
-      [...config.flex.internalAgencies, ...config.flex.externalAgencies].map(
+      [...config.flex.internal.agencies, ...config.flex.external.agencies].map(
         agency => agency.split(':')[0],
       ),
-    [config.flex.internalAgencies, config.flex.externalAgencies],
+    [config.flex.internal.agencies, config.flex.external.agencies],
   );
   const isFlexRoute = flexAgencies.includes(routeId);
 

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -864,13 +864,20 @@ export default {
   showRouteDescNotification: false,
   showStopStatusMarkers: false,
   flex: {
-    internalFlexEnabled: false,
-    allowTaxiJourneys: false,
-    directOnlyTaxiJourneys: false,
-    internalAgencies: [], // "FeedId:AgencyId"
-    externalAgencies: [], // "FeedId:AgencyId"
-    allowedExternalFlexRouteTypes: [1501],
-    minTransferTime: 900, // seconds
+    external: {
+      enabled: false,
+      transit: false,
+      direct: false,
+      agencies: [], // "FeedId:AgencyId"
+      allowedRouteTypes: [1501],
+    },
+    internal: {
+      enabled: false,
+      transit: false,
+      direct: false,
+      agencies: [], // "FeedId:AgencyId"
+      minTransferTime: 900, // seconds
+    },
   },
   personalization: false,
   showNewRoutePage: false,

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -747,14 +747,20 @@ export default {
 
   // TODO add when enabling Uber taxis
   /* flex: {
-    internalFlexEnabled: IS_DEV,
-    allowTaxiJourneys: IS_DEV,
-    directOnlyTaxiJourneys: false,
-    internalAgencies: ['KirkkonummiE:612', 'KirkkonummiP:612'],
-    externalAgencies: ['Uber:agency-mog2skf5-1'],
-    allowedExternalFlexRouteTypes: [1501],
+    external: {
+      enabled: true,
+      transit: true,
+      direct: false,
+      agencies: ['Uber:agency-mog2skf5-1'],
+    },
+    internal: {
+      enabled: true,
+      transit: true,
+      direct: true,
+      agencies: ['KirkkonummiE:612', 'KirkkonummiP:612'],
+    },
     infoLanguage: 'fi',
-    taxiSettingLabelOverride: 'demand-responsive-traffic',
+    settingLabelOverride: 'demand-responsive-traffic',
   }, */
 
   showRouteDescNotification: IS_DEV,

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -445,19 +445,27 @@ export default {
 
   // TODO: flex + transit disabled for now, proper configuration coming in the future
   /* flex: {
-    internalFlexEnabled: IS_DEV,
-    allowTaxiJourneys: true,
-    directOnlyTaxiJourneys: !IS_DEV,
-    internalAgencies: ['KirkkonummiE:612', 'KirkkonummiP:612'],
-    externalAgencies: ['02Taksi:02_taksi'],
+    external: {
+      enabled: true,
+      transit: true,
+      direct: true,
+      agencies: ['02Taksi:02_taksi'],
+    },
+    internal: {
+      enabled: true,
+      transit: true,
+      direct: true,
+      agencies: ['KirkkonummiE:612', 'KirkkonummiP:612'],
+    },
     infoLanguage: 'fi',
   }, */
   flex: {
-    internalFlexEnabled: false,
-    allowTaxiJourneys: true,
-    directOnlyTaxiJourneys: true,
-    internalAgencies: [],
-    externalAgencies: ['02Taksi:02_taksi'],
+    external: {
+      enabled: true,
+      transit: false,
+      direct: true,
+      agencies: ['02Taksi:02_taksi'],
+    },
     infoLanguage: 'fi',
   },
 

--- a/app/configurations/config.varely.js
+++ b/app/configurations/config.varely.js
@@ -154,11 +154,12 @@ export default configMerger(walttiConfig, {
 
   // TODO: flex disabled for now, proper configuration coming in the future
   /* flex: {
-    internalFlexEnabled: false,
-    allowTaxiJourneys: IS_DEV,
-    directOnlyTaxiJourneys: false,
-    internalAgencies: [],
-    externalAgencies: ['02Taksi:02_taksi'],
+    external: {
+      enabled: true,
+      transit: true,
+      direct: false,
+      agencies: ['02Taksi:02_taksi'],
+    },
     infoLanguage: 'fi',
   }, */
 

--- a/app/configurations/config.waltti.js
+++ b/app/configurations/config.waltti.js
@@ -290,11 +290,12 @@ export default {
 
   // TODO: flex disabled for now, proper configuration coming in the future
   /* flex: {
-    internalFlexEnabled: false,
-    allowTaxiJourneys: IS_DEV,
-    directOnlyTaxiJourneys: false,
-    internalAgencies: [],
-    externalAgencies: ['02Taksi:02_taksi'],
+    external: {
+      enabled: true,
+      transit: true,
+      direct: false,
+      agencies: ['02Taksi:02_taksi'],
+    },
     infoLanguage: 'fi',
   }, */
 

--- a/app/util/fareUtils.js
+++ b/app/util/fareUtils.js
@@ -113,7 +113,7 @@ export const shouldShowFareInfo = (config, legs, fares) => {
       leg =>
         isCallAgencyLeg(leg) &&
         leg.route &&
-        config.flex.internalAgencies.includes(leg.route.agency.gtfsId),
+        config.flex.internal.agencies.includes(leg.route.agency.gtfsId),
     )
   ) {
     return false;

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -1009,6 +1009,6 @@ export function isLocalCallAgency(leg, config) {
   }
   return (
     isCallAgencyLeg(leg) &&
-    config.flex.internalAgencies.includes(leg.route.agency.gtfsId)
+    config.flex.internal.agencies.includes(leg.route.agency.gtfsId)
   );
 }

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -265,14 +265,13 @@ export function planQueryNeeded(
     /* special logic: relaxed flex query is made only if taxis are not allowed */
     case PLANTYPE.FLEXTRANSIT_EXTERNAL:
       return (
-        config.flex?.allowTaxiJourneys &&
-        (transitModes.length > 0 || config.flex?.directOnlyTaxiJourneys) &&
+        config.flex.external.enabled &&
+        (transitModes.length > 0 || config.flex.external.direct) &&
         settings.includeTaxiSuggestions !== relaxSettings
       );
     case PLANTYPE.FLEXTRANSIT_INTERNAL:
       return (
-        config.flex?.internalFlexEnabled &&
-        transitModes.includes(TransportMode.Bus)
+        config.flex.internal.enabled && transitModes.includes(TransportMode.Bus)
       );
 
     case PLANTYPE.TRANSIT:
@@ -400,10 +399,6 @@ export function getPlanParams(
     });
   }
 
-  // non-direct for testing purposes on planners that only allow direct
-  const directFlexOnly =
-    config.flex?.directOnlyTaxiJourneys &&
-    !window.localStorage.getItem('favouriteStore')?.includes('Flextestaus2025');
   const directOnly = directModes.includes(planType) || otpModes.length === 0;
   let transitOnly = !!relaxSettings;
   const wheelchair = !!settings.accessibilityOption;
@@ -460,19 +455,19 @@ export function getPlanParams(
       direct = access;
       break;
     case PLANTYPE.FLEXTRANSIT_EXTERNAL:
-      access = directFlexOnly ? null : ['WALK', 'FLEX'];
+      access = config.flex.external.transit ? ['WALK', 'FLEX'] : null;
       egress = access;
-      direct = directFlexOnly ? ['WALK', 'FLEX'] : null;
+      direct = config.flex.external.direct ? ['WALK', 'FLEX'] : null;
       transitOnly = false;
-      filters = excludeAgencies(config.flex?.internalAgencies);
+      filters = excludeAgencies(config.flex.internal.agencies);
       via = null;
       break;
     case PLANTYPE.FLEXTRANSIT_INTERNAL:
-      access = [...access, 'FLEX'];
+      access = config.flex.internal.transit ? ['WALK', 'FLEX'] : null;
       egress = access;
-      direct = access;
-      filters = excludeAgencies(config.flex?.externalAgencies);
-      minTransferTime = config.flex?.minTransferTime || minTransferTime;
+      direct = config.flex.internal.direct ? ['WALK', 'FLEX'] : null;
+      filters = excludeAgencies(config.flex.external.agencies);
+      minTransferTime = config.flex.internal.minTransferTime || minTransferTime;
       via = null;
       break;
     default: // direct modes

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -466,6 +466,7 @@ export function getPlanParams(
       access = config.flex.internal.transit ? ['WALK', 'FLEX'] : null;
       egress = access;
       direct = config.flex.internal.direct ? ['WALK', 'FLEX'] : null;
+      transitOnly = false;
       filters = excludeAgencies(config.flex.external.agencies);
       minTransferTime = config.flex.internal.minTransferTime || minTransferTime;
       via = null;

--- a/test/unit/component/RoutePage.test.js
+++ b/test/unit/component/RoutePage.test.js
@@ -21,7 +21,7 @@ const baseConfig = {
   title: 'Digitransit',
   colors: { primary: '#00AFFF', accessiblePrimary: '#000' },
   URL: {},
-  flex: { internalAgencies: [] },
+  flex: { internal: { agencies: [] } },
 };
 
 const baseRoute = {


### PR DESCRIPTION
## Proposed Changes

  - Change format to be more clear.
  - Add possibility to set transit or direct separately.
  - Remove
```
  // non-direct for testing purposes on planners that only allow direct
  const directFlexOnly =
    config.flex?.directOnlyTaxiJourneys &&
    !window.localStorage.getItem('favouriteStore')?.includes('Flextestaus2025');
```