### PR TITLE
AB#598 - Fix flashing suggestion in `digitransit-component-autosuggest`

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "8.3.5",
+  "version": "8.4.5",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^7.1.10",
+    "@digitransit-component/digitransit-component-autosuggest": "^7.2.10",
     "@digitransit-component/digitransit-component-icon": "^2.0.2",
     "@hsl-fi/sass": "1.0.0",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "7.1.10",
+  "version": "7.2.10",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/index.js
@@ -522,9 +522,15 @@ function DTAutosuggest({
     openMenu();
   };
 
-  // Fetch suggestions when isOpen, value, or fetchSuggestions dependies change
+  // Fetch suggestions when isOpen, value, or fetchSuggestions dependencies change
   useEffect(() => {
-    if (isOpen || state.renderMobile) {
+    // Don't search when the search field (state.value) contains position strings that were given as a prop (value),
+    // because they are UI labels not real search terms. Fetching suggestions with them caused a quickly flashing set of
+    // irrelevant results, e.g. 'Käytä nykyistä sijaintia' -> 'City-käytävä'.
+    if (
+      (isOpen || state.renderMobile) &&
+      !(state.value === value && positions.includes(value))
+    ) {
       fetchSuggestions(state.value);
     }
   }, [isOpen, state.renderMobile, state.value, fetchSuggestions]);

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component",
-  "version": "5.0.14",
+  "version": "5.1.14",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-component",
   "module": "digitransit-component.mjs",
@@ -18,8 +18,8 @@
     "url": "git://github.com/HSLdevcom/digitransit-ui.git"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^7.1.10",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^8.3.5",
+    "@digitransit-component/digitransit-component-autosuggest": "^7.2.10",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^8.4.5",
     "@digitransit-component/digitransit-component-control-panel": "^7.1.3",
     "@digitransit-component/digitransit-component-favourite-bar": "^5.0.5",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^5.0.4",


### PR DESCRIPTION
## Proposed Changes

  - This fixes the flashing 'City-käytävä' suggestion that was caused by a search being done for the string 'Käytä nykyistä sijaintia'