### PR TITLE
AB#613 Handle gtfs entities with colons in ids

### DIFF
--- a/app/component/CardHeader.js
+++ b/app/component/CardHeader.js
@@ -8,6 +8,7 @@ import ZoneIcon from './ZoneIcon';
 import SplitBars from './SplitBars';
 import BackButton from './BackButton';
 import { getZoneLabel } from '../util/legUtils';
+import { splitGtfsId } from '../util/gtfs';
 
 export default function CardHeader(
   {
@@ -65,7 +66,7 @@ export default function CardHeader(
               {config.zones?.stops &&
                 zoneId &&
                 stop.gtfsId &&
-                config.feedIds.includes(stop.gtfsId.split(':')[0]) && (
+                config.feedIds.includes(splitGtfsId(stop.gtfsId).feedId) && (
                   <ZoneIcon
                     zoneId={getZoneLabel(zoneId, config)}
                     showUnknown={false}

--- a/app/component/DepartureListContainer.js
+++ b/app/component/DepartureListContainer.js
@@ -16,6 +16,7 @@ import {
   getHeadsignFromRouteLongName,
   isPlatformChanged,
 } from '../util/legUtils';
+import { splitGtfsId } from '../util/gtfs';
 
 const getDropoffMessage = (hasOnlyDropoff, hasNoStop) => {
   if (hasNoStop) {
@@ -154,7 +155,7 @@ class DepartureListContainer extends Component {
             .indexOf(departure.stop.code) >= 0,
       )
       .map(departure => ({
-        tripId: departure.trip.gtfsId.split(':')[1],
+        tripId: splitGtfsId(departure.trip.gtfsId).entityId,
       }));
 
     const { config } = this.context;

--- a/app/component/ParkOrStationHeader.js
+++ b/app/component/ParkOrStationHeader.js
@@ -9,8 +9,8 @@ import { getJson } from '../util/xhrPromise';
 import getZoneId from '../util/zoneIconUtils';
 import ZoneIcon from './ZoneIcon';
 import { hasVehicleRentalCode } from '../util/vehicleRentalUtils';
-import { getIdWithoutFeed } from '../util/feedScopedIdUtils';
 import FavouriteVehicleRentalStationContainer from './FavouriteVehicleRentalStationContainer';
+import { splitGtfsId } from '../util/gtfs';
 
 const ParkOrBikeStationHeader = (
   { parkOrStation, breakpoint, parkType, backButton, withSeparator },
@@ -56,7 +56,7 @@ const ParkOrBikeStationHeader = (
             id={isRentalStation ? 'citybike-station-no-id' : parkHeaderId}
           />
           {isRentalStation && hasVehicleRentalCode(stationId) && (
-            <StopCode code={getIdWithoutFeed(stationId)} />
+            <StopCode code={splitGtfsId(stationId).entityId} />
           )}
           {zoneId && (
             <span className="station-zone-icon">

--- a/app/component/itinerary/IntermediateLeg.js
+++ b/app/component/itinerary/IntermediateLeg.js
@@ -7,6 +7,7 @@ import { legTimeStr } from '../../util/legUtils';
 import ZoneIcon from '../ZoneIcon';
 import { stopPagePath } from '../../util/path';
 import Icon from '../Icon';
+import { splitGtfsId } from '../../util/gtfs';
 
 function IntermediateLeg(
   {
@@ -90,7 +91,7 @@ function IntermediateLeg(
         {showZoneLimits &&
           currentZoneId &&
           gtfsId &&
-          feedIds.includes(gtfsId.split(':')[0]) && (
+          feedIds.includes(splitGtfsId(gtfsId).feedId) && (
             <div className="time-column-zone-icons-container intermediate-leg">
               {previousZoneId && <ZoneIcon zoneId={previousZoneId} />}
               <ZoneIcon

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -15,6 +15,7 @@ import { compressLegs, getTotalBikingDistance } from '../../util/legUtils';
 import { getMapLayerOptions } from '../../util/mapLayerUtils';
 import { getDefaultSettings, getSettings } from '../../util/planParamUtil';
 import { getStartTimeWithColon } from '../../util/timeUtils';
+import { splitGtfsId } from '../../util/gtfs';
 
 /**
  * Returns the index of selected itinerary. Attempts to look for
@@ -82,10 +83,10 @@ export function getTopics(legs, config) {
 
     legs.forEach(leg => {
       if (leg.transitLeg && leg.trip) {
-        const feedId = leg.trip.gtfsId.split(':')[0];
+        const { feedId, entityId: tripId } = splitGtfsId(leg.trip.gtfsId);
         if (realTime && feedIds.includes(feedId)) {
           itineraryTopics.push({
-            route: leg.route.gtfsId.split(':')[1],
+            route: splitGtfsId(leg.route.gtfsId).entityId,
             shortName: leg.route.shortName,
             type: leg.route.type,
             feedId,
@@ -94,7 +95,7 @@ export function getTopics(legs, config) {
             tripStartTime: getStartTimeWithColon(
               leg.trip.stoptimesForDate[0].scheduledDeparture,
             ),
-            tripId: leg.trip.gtfsId.split(':')[1],
+            tripId,
           });
         }
       }
@@ -174,7 +175,7 @@ export function filterItinerariesByFeedId(plan, config) {
   plan.edges.forEach(edge => {
     let skip = false;
     for (let i = 0; i < edge.node.legs.length; i++) {
-      const feedId = edge.node.legs[i].route?.gtfsId?.split(':')[0];
+      const { feedId } = splitGtfsId(edge.node.legs[i].route?.gtfsId);
 
       if (
         feedId && // if feedId is undefined, leg  is non transit -> don't drop

--- a/app/component/itinerary/TransitLeg.js
+++ b/app/component/itinerary/TransitLeg.js
@@ -51,6 +51,7 @@ import ExternalLink from '../ExternalLink';
 import { getBoardingInformationText } from './BoardingInformation';
 import { getTrackOrPierOrPlatformChangeText } from '../../util/modeUtils';
 import { useConfigContext } from '../../configurations/ConfigContext';
+import { splitGtfsId } from '../../util/gtfs';
 
 const stopCode = code => code && <StopCode code={code} />;
 
@@ -123,10 +124,11 @@ export default function TransitLeg({
     const startZone = leg.from.stop.zoneId;
     const endZone = leg.to.stop.zoneId;
 
+    const { feedId } = splitGtfsId(leg.from.stop.gtfsId);
     const renderZoneIcons =
       config.zones.itinerary &&
       leg.from.stop.gtfsId &&
-      config.feedIds.includes(leg.from.stop.gtfsId.split(':')[0]);
+      config.feedIds.includes(feedId);
 
     if (
       startZone !== endZone &&

--- a/app/component/itinerary/VehicleRentalLeg.js
+++ b/app/component/itinerary/VehicleRentalLeg.js
@@ -24,9 +24,9 @@ import {
   getVehicleAvailabilityTextColor,
   getVehicleAvailabilityIndicatorColor,
 } from '../../util/legUtils';
-import { getIdWithoutFeed } from '../../util/feedScopedIdUtils';
 import ScooterLinkContainer from './ScooterLinkContainer';
 import IconBadge from '../icon/IconBadge';
+import { splitGtfsId } from '../../util/gtfs';
 
 function VehicleRentalLeg(
   {
@@ -138,7 +138,7 @@ function VehicleRentalLeg(
                 {vehicleRentalStation &&
                   hasVehicleRentalCode(vehicleRentalStation.stationId) && (
                     <span className="itinerary-stop-code">
-                      {getIdWithoutFeed(vehicleRentalStation?.stationId)}
+                      {splitGtfsId(vehicleRentalStation?.stationId).entityId}
                     </span>
                   )}
               </span>

--- a/app/component/map/NearYouMap.js
+++ b/app/component/map/NearYouMap.js
@@ -32,6 +32,7 @@ import { getRouteMode } from '../../util/modeUtils';
 import CookieSettingsButton from '../CookieSettingsButton';
 import { streetQuery } from './StreetQuery';
 import LocationMarker from './LocationMarker';
+import { splitGtfsId } from '../../util/gtfs';
 
 function getId(edge) {
   const { place } = edge.node;
@@ -251,7 +252,7 @@ function NearYouMap(
       const stopArray = place.stops || [place]; // station stops, single stop or other place
       stopArray.forEach(stop => {
         stop.patterns?.forEach(pattern => {
-          const [feedId, route] = pattern.route.gtfsId.split(':');
+          const { feedId, entityId: route } = splitGtfsId(pattern.route.gtfsId);
           realtimeTopics.push({
             feedId,
             route,
@@ -397,7 +398,7 @@ NearYouMap.propTypes = {
     PropTypes.shape({
       nearest: PropTypes.shape({
         // eslint-disable-next-line
-      edges: PropTypes.arrayOf(PropTypes.object).isRequired,
+        edges: PropTypes.arrayOf(PropTypes.object).isRequired,
       }).isRequired,
     }),
     PropTypes.arrayOf(PropTypes.object),

--- a/app/component/map/RoutePageMap.js
+++ b/app/component/map/RoutePageMap.js
@@ -14,6 +14,7 @@ import { isActiveDate } from '../../util/patternUtils';
 import { boundWithMinimumArea } from '../../util/geo-utils';
 import { getMapLayerOptions } from '../../util/mapLayerUtils';
 import CookieSettingsButton from '../CookieSettingsButton';
+import { splitGtfsId } from '../../util/gtfs';
 
 function RoutePageMap(
   { pattern, lat, lon, breakpoint, trip, error, ...rest },
@@ -64,11 +65,11 @@ function RoutePageMap(
     }
   };
 
-  const routeId = rest.match.params.routeId.split(':')[0];
+  const { entityId: routeId } = splitGtfsId(rest.match.params.routeId);
   const flexAgencies = useMemo(
     () =>
       [...config.flex.internal.agencies, ...config.flex.external.agencies].map(
-        agency => agency.split(':')[0],
+        agency => splitGtfsId(agency).feedId,
       ),
     [config.flex.internal.agencies, config.flex.external.agencies],
   );

--- a/app/component/map/VehicleMarkerContainer.js
+++ b/app/component/map/VehicleMarkerContainer.js
@@ -5,6 +5,7 @@ import { configShape } from '../../util/shapes';
 import { ExtendedRouteTypes } from '../../constants';
 import VehicleIcon from '../VehicleIcon';
 import IconMarker from './IconMarker';
+import { splitGtfsId } from '../../util/gtfs';
 
 const MODES_WITH_ICONS = [
   'bus',
@@ -47,7 +48,7 @@ function shouldShowVehicle(
   headsign,
   trip,
 ) {
-  const msgTrip = message.tripId?.split(':')[1];
+  const { entityId: tripId } = splitGtfsId(message.tripId);
   return (
     !Number.isNaN(parseFloat(message.lat)) &&
     !Number.isNaN(parseFloat(message.long)) &&
@@ -63,7 +64,7 @@ function shouldShowVehicle(
     (tripStart === undefined ||
       message.tripStartTime === undefined ||
       message.tripStartTime === tripStart) &&
-    (trip === undefined || msgTrip === undefined || msgTrip === trip)
+    (trip === undefined || tripId === undefined || tripId === trip)
   );
 }
 
@@ -71,11 +72,11 @@ function VehicleMarkerContainer(props, { config }) {
   // TODO: move vehicle filtering logic to RealtimeInformationStore
   const visibleVehicles = Object.entries(props.vehicles).filter(
     ([, message]) => {
-      const routeParts = message.route?.split(':');
-      const feed = routeParts?.[0];
-      const id = routeParts?.[1]; // route id without feed
-      const { ignoreHeadsign } = config.realTime[feed];
-      const desc = id ? props.topics?.find(t => t.route === id) : undefined;
+      const { feedId, entityId: routeId } = splitGtfsId(message.route);
+      const { ignoreHeadsign } = config.realTime[feedId];
+      const desc = routeId
+        ? props.topics?.find(t => t.route === routeId)
+        : undefined;
       return shouldShowVehicle(
         message,
         props.direction || desc?.direction,
@@ -90,9 +91,9 @@ function VehicleMarkerContainer(props, { config }) {
   props.setVisibleVehicles(visibleVehicleIds);
 
   return visibleVehicles.map(([id, message]) => {
-    const r = message.route.split(':')[1];
+    const { entityId: routeId } = splitGtfsId(message.route);
     const type = props.topics?.find(
-      t => t.shortName === message.shortName || t.route === r,
+      t => t.shortName === message.shortName || t.route === routeId,
     )?.type;
     let mode;
     if (type === ExtendedRouteTypes.BusExpress) {
@@ -107,10 +108,10 @@ function VehicleMarkerContainer(props, { config }) {
     } else {
       mode = message.mode;
     }
-    const feed = message.route?.split(':')[0];
+    const { feedId } = splitGtfsId(message.route);
     let vehicleNumber = message.shortName
-      ? config.realTime[feed].vehicleNumberParser(message.shortName)
-      : r;
+      ? config.realTime[feedId].vehicleNumberParser(message.shortName)
+      : routeId;
     // Fallback to a question mark if the vehicle number is too long to fit in the icon
     vehicleNumber = vehicleNumber.length > 5 ? '?' : vehicleNumber;
     return (

--- a/app/component/map/tile-layer/SelectRentalVehicleClusterRow.js
+++ b/app/component/map/tile-layer/SelectRentalVehicleClusterRow.js
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { configShape } from '../../../util/shapes';
 import Icon from '../../Icon';
 import { hasVehicleRentalCode } from '../../../util/vehicleRentalUtils';
-import { getIdWithoutFeed } from '../../../util/feedScopedIdUtils';
+import { splitGtfsId } from '../../../util/gtfs';
 
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 function SelectVehicleRentalClusterRow(
@@ -29,7 +29,9 @@ function SelectVehicleRentalClusterRow(
         <span className="choose-row-text">
           <span className="choose-row-address">{address}</span>
           {hasVehicleRentalCode(id) && (
-            <span className="choose-row-number">{getIdWithoutFeed(id)}</span>
+            <span className="choose-row-number">
+              {splitGtfsId(id).entityId}
+            </span>
           )}
         </span>
       </span>

--- a/app/component/map/tile-layer/SelectVehicleRentalRow.js
+++ b/app/component/map/tile-layer/SelectVehicleRentalRow.js
@@ -9,7 +9,7 @@ import {
   getRentalNetworkIcon,
   hasVehicleRentalCode,
 } from '../../../util/vehicleRentalUtils';
-import { getIdWithoutFeed } from '../../../util/feedScopedIdUtils';
+import { splitGtfsId } from '../../../util/gtfs';
 
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 function SelectVehicleRentalRow(
@@ -42,7 +42,9 @@ function SelectVehicleRentalRow(
         <span className="choose-row-text">
           <span className="choose-row-address">{address}</span>
           {hasVehicleRentalCode(id) && (
-            <span className="choose-row-number">{getIdWithoutFeed(id)}</span>
+            <span className="choose-row-number">
+              {splitGtfsId(id).entityId}
+            </span>
           )}
         </span>
       </span>

--- a/app/component/map/tile-layer/Stops.js
+++ b/app/component/map/tile-layer/Stops.js
@@ -15,6 +15,7 @@ import {
   getLayerBaseUrl,
 } from '../../../util/mapLayerUtils';
 import { PREFIX_ITINERARY_SUMMARY, PREFIX_ROUTES } from '../../../util/path';
+import { splitGtfsId } from '../../../util/gtfs';
 import { fetchWithLanguageAndSubscription } from '../../../util/fetchUtils';
 
 const stopAlertsQuery = graphql`
@@ -134,8 +135,8 @@ class Stops {
   }
 
   stopsToShowCheck(feature, isStation) {
-    const feedid = feature.properties.gtfsId.split(':')[0];
-    if (!isStation && !this.config.feedIds.includes(feedid)) {
+    const { feedId } = splitGtfsId(feature.properties.gtfsId);
+    if (!isStation && !this.config.feedIds.includes(feedId)) {
       return false;
     }
     if (this.tile.stopsToShow) {

--- a/app/component/nearyou/NearYouHeader.js
+++ b/app/component/nearyou/NearYouHeader.js
@@ -8,6 +8,7 @@ import PlatformNumber from '../PlatformNumber';
 import FavouriteStopContainer from '../FavouriteStopContainer';
 import { getZoneLabel } from '../../util/legUtils';
 import { useConfigContext } from '../../configurations/ConfigContext';
+import { splitGtfsId } from '../../util/gtfs';
 
 const NearYouHeader = ({ stop, desc, isStation, linkAddress, mode }) => {
   const config = useConfigContext();
@@ -38,7 +39,7 @@ const NearYouHeader = ({ stop, desc, isStation, linkAddress, mode }) => {
           <PlatformNumber number={stop.platformCode} short mode={mode} />
           {zoneId &&
             config.zones.stops &&
-            config.feedIds.includes(stop.gtfsId.split(':')[0]) && (
+            config.feedIds.includes(splitGtfsId(stop.gtfsId).feedId) && (
               <ZoneIcon
                 zoneId={getZoneLabel(zoneId, config)}
                 showUnknown={false}

--- a/app/component/nearyou/VehicleRentalStationNearYou.js
+++ b/app/component/nearyou/VehicleRentalStationNearYou.js
@@ -8,8 +8,8 @@ import FavouriteVehicleRentalStationContainer from '../FavouriteVehicleRentalSta
 import { PREFIX_BIKESTATIONS } from '../../util/path';
 import { isKeyboardSelectionEvent } from '../../util/browser';
 import { hasVehicleRentalCode } from '../../util/vehicleRentalUtils';
-import { getIdWithoutFeed } from '../../util/feedScopedIdUtils';
 import { vehicleRentalStationShape, relayShape } from '../../util/shapes';
+import { splitGtfsId } from '../../util/gtfs';
 
 const VehicleRentalStationNearYou = ({
   station,
@@ -57,7 +57,7 @@ const VehicleRentalStationNearYou = ({
                 id="citybike-station"
                 values={{
                   stationId: hasVehicleRentalCode(station.stationId)
-                    ? getIdWithoutFeed(station.stationId)
+                    ? splitGtfsId(station.stationId).entityId
                     : '',
                 }}
               />

--- a/app/component/routepage/RouteControlPanel.js
+++ b/app/component/routepage/RouteControlPanel.js
@@ -34,6 +34,7 @@ import { unixTime, unixToYYYYMMDD } from '../../util/timeUtils';
 import { saveSearch } from '../../action/SearchActions';
 import Icon from '../Icon';
 import Notification from './Notification';
+import { splitGtfsId } from '../../util/gtfs';
 
 const Tab = {
   Disruptions: PREFIX_DISRUPTION,
@@ -192,8 +193,7 @@ function RouteControlPanel(
 
         const { realTime } = config;
         if (realTime && process.env.NODE_ENV !== 'test') {
-          const routeParts = route.gtfsId.split(':');
-          const feedId = routeParts[0];
+          const { feedId, entityId } = splitGtfsId(route.gtfsId);
           const source = realTime[feedId];
           if (source?.active && isActiveDate(selectedPattern)) {
             const id = source.routeSelector({ route, match, tripStartTime });
@@ -207,7 +207,7 @@ function RouteControlPanel(
                   route: id,
                   feedId,
                   mode: route.mode.toLowerCase(),
-                  gtfsId: routeParts[1],
+                  gtfsId: entityId,
                   headsign: selectedPattern?.headsign,
                   direction,
                   tripStartTime,
@@ -246,8 +246,7 @@ function RouteControlPanel(
         : route.patterns.filter(x => x.code === newPattern);
     const isActivePattern = isActiveDate(pattern[0]);
 
-    const routeParts = route.gtfsId.split(':');
-    const feedId = routeParts[0];
+    const { feedId, entityId: routeId } = splitGtfsId(route.gtfsId);
     // if config contains mqtt feed and old client has not been removed
     if (client) {
       const { realTime } = config;
@@ -263,7 +262,7 @@ function RouteControlPanel(
               route: id,
               feedId,
               mode: route.mode.toLowerCase(),
-              gtfsId: routeParts[1],
+              gtfsId: routeId,
               headsign: pattern[0].headsign,
             },
           ],
@@ -281,7 +280,7 @@ function RouteControlPanel(
         if (source?.active) {
           const id =
             pattern[0].code !== patternId
-              ? routeParts[1]
+              ? routeId
               : source.routeSelector({ route, match, tripStartTime });
           const patternIdSplit = patternId.split(':');
           const direction = patternIdSplit[patternIdSplit.length - 2];
@@ -293,7 +292,7 @@ function RouteControlPanel(
                 route: id,
                 feedId,
                 mode: route.mode.toLowerCase(),
-                gtfsId: routeParts[1],
+                gtfsId: routeId,
                 headsign: pattern[0].headsign,
                 direction,
                 tripStartTime,

--- a/app/component/routepage/RouteStop.js
+++ b/app/component/routepage/RouteStop.js
@@ -23,6 +23,7 @@ import { estimateItineraryDistance } from '../../util/geo-utils';
 import getVehicleState from '../../util/vehicleStateUtils';
 import Icon from '../Icon';
 import { ensureColorAccessibleOnWhite } from '../../util/colorUtils';
+import { splitGtfsId } from '../../util/gtfs';
 
 function getDepartureTime(stoptime) {
   return (
@@ -194,13 +195,12 @@ const RouteStop = (
         first,
         last,
       );
+      const { feedId } = splitGtfsId(vehicle.route);
       const vehicleWithParsedShortname = {
         ...vehicle,
         shortName:
           vehicle.shortName &&
-          config.realTime[vehicle.route?.split(':')[0]].vehicleNumberParser(
-            vehicle.shortName,
-          ),
+          config.realTime[feedId].vehicleNumberParser(vehicle.shortName),
       };
       vehicleTripLink = vehicle.tripId ? (
         <TripLink

--- a/app/component/routepage/TripRouteStop.js
+++ b/app/component/routepage/TripRouteStop.js
@@ -16,6 +16,7 @@ import ZoneIcon from '../ZoneIcon';
 import { getZoneLabel } from '../../util/legUtils';
 import getVehicleState from '../../util/vehicleStateUtils';
 import { ensureColorAccessibleOnWhite } from '../../util/colorUtils';
+import { splitGtfsId } from '../../util/gtfs';
 
 const TripRouteStop = (props, { config }) => {
   const {
@@ -55,13 +56,12 @@ const TripRouteStop = (props, { config }) => {
       first,
       last,
     );
+    const { feedId } = splitGtfsId(vehicle.route);
     const vehicleWithParsedShortname = {
       ...vehicle,
       shortName:
         vehicle.shortName &&
-        config.realTime[vehicle.route?.split(':')[0]].vehicleNumberParser(
-          vehicle.shortName,
-        ),
+        config.realTime[feedId].vehicleNumberParser(vehicle.shortName),
     };
     const linkProps = {
       stopName: vehicleState === 'arriving' ? prevStop?.name : stop.name,

--- a/app/component/routepage/schedule/ScheduleContainer.js
+++ b/app/component/routepage/schedule/ScheduleContainer.js
@@ -23,6 +23,7 @@ import { getTripsList } from './scheduleTripsUtils';
 import { routeShape, patternShape } from '../../../util/shapes';
 import { calculateRedirectDecision } from './scheduleParamUtils';
 import { buildAvailableDates } from './scheduleDataUtils';
+import { splitGtfsId } from '../../../util/gtfs';
 
 /**
  * Open a route timetable PDF in a new window.
@@ -189,7 +190,7 @@ const ScheduleContainer = ({
   };
 
   const formattedServiceDate = wantedDay.toFormat(DATE_FORMAT);
-  const agencyId = routeId?.split(':')?.[0];
+  const { feedId: agencyId } = splitGtfsId(routeId);
   const hasRouteTimetableUrl = !!(
     agencyId &&
     formattedServiceDate &&

--- a/app/component/stop/Timetable.js
+++ b/app/component/stop/Timetable.js
@@ -22,6 +22,7 @@ import { replaceQueryParams } from '../../util/queryUtils';
 import { PREFIX_STOPS } from '../../util/path';
 import { TimetableFragment } from './queries/TimetableFragment';
 import { useConfigContext } from '../../configurations/ConfigContext';
+import { splitGtfsId } from '../../util/gtfs';
 
 const mapStopTimes = stoptimesObject =>
   stoptimesObject
@@ -250,16 +251,15 @@ export default function Timetable({
   );
   const timetableMap = groupArrayByHour(routesWithDetails);
   const { locationType } = stop;
-  const stopIdSplitted = stop.gtfsId.split(':');
-  const stopTimetableHandler =
-    config.timetables && config.timetables[stopIdSplitted[0]];
+  const { feedId } = splitGtfsId(stop.gtfsId);
+  const stopTimetableHandler = config.timetables && config.timetables[feedId];
   const stopPDFURL =
     stopTimetableHandler &&
-    config.URL.STOP_TIMETABLES[stopIdSplitted[0]] &&
+    config.URL.STOP_TIMETABLES[feedId] &&
     locationType !== 'STATION' &&
     date
       ? stopTimetableHandler.stopTimetableUrlResolver(
-          config.URL.STOP_TIMETABLES[stopIdSplitted[0]],
+          config.URL.STOP_TIMETABLES[feedId],
           stop,
           date,
           config.language,

--- a/app/configurations/realtimeUtils.js
+++ b/app/configurations/realtimeUtils.js
@@ -2,8 +2,9 @@ import { IS_DEV } from '../util/envUtils';
 
 /* eslint-disable prefer-template */
 function defaultRouteSelector(routePageProps) {
-  const route = routePageProps.route.gtfsId.split(':');
-  return route[1];
+  const { gtfsId } = routePageProps.route;
+  const i = gtfsId.indexOf(':');
+  return gtfsId.slice(i + 1, gtfsId.length);
 }
 
 function defaulVehicleNumberParser(vehicleNumber) {
@@ -193,7 +194,6 @@ function hslTopicResolver(
 const mqttAddress = IS_DEV
   ? 'wss://dev-mqtt.digitransit.fi'
   : 'wss://mqtt.digitransit.fi';
-
 const baseMqtt = {
   mqtt: mqttAddress,
   routeSelector: defaultRouteSelector,
@@ -240,6 +240,7 @@ export default {
   Rauma: walttiMqtt,
   Pori: walttiMqtt,
   VARELY: walttiMqtt,
+  WalttiTest: walttiMqtt,
   PohjolanMatka: elyMqtt(true),
   Harma: elyMqtt(false),
   Korsisaari: elyMqtt(true),

--- a/app/configurations/realtimeUtils.js
+++ b/app/configurations/realtimeUtils.js
@@ -240,7 +240,6 @@ export default {
   Rauma: walttiMqtt,
   Pori: walttiMqtt,
   VARELY: walttiMqtt,
-  WalttiTest: walttiMqtt,
   PohjolanMatka: elyMqtt(true),
   Harma: elyMqtt(false),
   Korsisaari: elyMqtt(true),

--- a/app/configurations/timetableConfigUtils.js
+++ b/app/configurations/timetableConfigUtils.js
@@ -1,3 +1,5 @@
+import { splitGtfsId } from '../util/gtfs';
+
 /* eslint-disable no-unused-vars */
 export default {
   HSL: {
@@ -7,7 +9,7 @@ export default {
       date,
       lang,
     ) {
-      const routeId = route.gtfsId.split(':')[1];
+      const { entityId: routeId } = splitGtfsId(route.gtfsId);
 
       // From YYYYMMDD to YYYY-MM-DD
       const formattedDate = date.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3');
@@ -27,7 +29,7 @@ export default {
       date,
       lang,
     ) {
-      const stopId = stop.gtfsId.split(':')[1];
+      const { entityId: stopId } = splitGtfsId(stop.gtfsId);
       const formattedDate = date.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3');
       const defaultSearchParams =
         'props[isSummerTimetable]=false&props[printTimetablesAsA4]=true&props[printTimetablesAsGreyscale]=false&props[template]=default&props[showAddressInfo]=false&props[showPrintButton]=true&props[redirect]=false&template=default';
@@ -54,8 +56,8 @@ export default {
       date,
       lang,
     ) {
-      const stopIdSplitted = stop.gtfsId.split(':');
-      return new URL(`${baseURL}${parseInt(stopIdSplitted[1], 10)}.pdf`);
+      const { entityId: stopId } = splitGtfsId(stop.gtfsId);
+      return new URL(`${baseURL}${parseInt(stopId, 10)}.pdf`);
     },
   },
 };

--- a/app/configurations/timetableConfigUtils.js
+++ b/app/configurations/timetableConfigUtils.js
@@ -1,5 +1,3 @@
-import { splitGtfsId } from '../util/gtfs';
-
 /* eslint-disable no-unused-vars */
 export default {
   HSL: {
@@ -9,7 +7,10 @@ export default {
       date,
       lang,
     ) {
-      const { entityId: routeId } = splitGtfsId(route.gtfsId);
+      const routeId = route.gtfsId.slice(
+        route.gtfsId.indexOf(':') + 1,
+        route.gtfsId.length,
+      );
 
       // From YYYYMMDD to YYYY-MM-DD
       const formattedDate = date.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3');
@@ -29,7 +30,10 @@ export default {
       date,
       lang,
     ) {
-      const { entityId: stopId } = splitGtfsId(stop.gtfsId);
+      const stopId = stop.gtfsId.slice(
+        stop.gtfsId.indexOf(':') + 1,
+        stop.gtfsId.length,
+      );
       const formattedDate = date.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3');
       const defaultSearchParams =
         'props[isSummerTimetable]=false&props[printTimetablesAsA4]=true&props[printTimetablesAsGreyscale]=false&props[template]=default&props[showAddressInfo]=false&props[showPrintButton]=true&props[redirect]=false&template=default';
@@ -56,7 +60,10 @@ export default {
       date,
       lang,
     ) {
-      const { entityId: stopId } = splitGtfsId(stop.gtfsId);
+      const stopId = stop.gtfsId.slice(
+        stop.gtfsId.indexOf(':') + 1,
+        stop.gtfsId.length,
+      );
       return new URL(`${baseURL}${parseInt(stopId, 10)}.pdf`);
     },
   },

--- a/app/store/RealTimeInformationStore.js
+++ b/app/store/RealTimeInformationStore.js
@@ -1,6 +1,7 @@
 import Store from 'fluxible/addons/BaseStore';
 import events from '../util/events';
 import { unixTime } from '../util/timeUtils';
+import { splitGtfsId } from '../util/gtfs';
 
 class RealTimeInformationStore extends Store {
   static storeName = 'RealTimeInformationStore';
@@ -66,7 +67,7 @@ class RealTimeInformationStore extends Store {
         message.forEach(msg => {
           if (
             !this.topicsByRoute ||
-            this.topicsByRoute[msg.route.split(':')[1]]
+            this.topicsByRoute[splitGtfsId(msg.route).entityId]
           ) {
             // Filter out old messages
             this.vehicles[msg.id] = { ...msg, receivedAt };
@@ -74,7 +75,7 @@ class RealTimeInformationStore extends Store {
         });
       } else if (
         !this.topicsByRoute ||
-        this.topicsByRoute[message.route.split(':')[1]]
+        this.topicsByRoute[splitGtfsId(message.route).entityId]
       ) {
         this.vehicles[message.id] = { ...message, receivedAt };
       }
@@ -89,15 +90,15 @@ class RealTimeInformationStore extends Store {
     if (topicsByRoute && Object.keys(topicsByRoute).length > 0) {
       this.vehicles = Object.fromEntries(
         Object.entries(this.vehicles).filter(([, vehicle]) => {
-          const routeId = vehicle.route?.split(':')[1];
+          const { entityId: routeId } = splitGtfsId(vehicle.route);
           return routeId && topicsByRoute[routeId];
         }),
       );
     } else if (Array.isArray(topics) && topics.length > 0) {
       this.vehicles = Object.fromEntries(
         Object.entries(this.vehicles).filter(([, vehicle]) => {
-          const tripId = vehicle.tripId?.split(':')[1];
-          const routeId = vehicle.route?.split(':')[1];
+          const { entityId: tripId } = splitGtfsId(vehicle.tripId);
+          const { entityId: routeId } = splitGtfsId(vehicle.route);
 
           if (tripId) {
             return topics.some(topic => topic.includes(tripId));

--- a/app/util/feedScopedIdUtils.js
+++ b/app/util/feedScopedIdUtils.js
@@ -1,34 +1,4 @@
 /**
- * Returns id without the feedId prefix.
- *
- * @param {String} feedScopedId should be in feedId:objectId format.
- */
-export const getIdWithoutFeed = feedScopedId => {
-  if (!feedScopedId) {
-    return undefined;
-  }
-  if (feedScopedId.indexOf(':') === -1) {
-    return feedScopedId;
-  }
-  return feedScopedId.split(':')[1];
-};
-
-/**
- * Returns feedId without the objectId.
- *
- * @param {String} feedScopedId should be in feedId:objectId format.
- */
-export const getFeedWithoutId = feedScopedId => {
-  if (!feedScopedId) {
-    return undefined;
-  }
-  if (feedScopedId.indexOf(':') === -1) {
-    return feedScopedId;
-  }
-  return feedScopedId.split(':')[0];
-};
-
-/**
  * Returns boolean indicating whether the feed is external or not.
  */
 export const isExternalFeed = (feedId, config) => {

--- a/app/util/gtfs.js
+++ b/app/util/gtfs.js
@@ -7,3 +7,16 @@ export const typeToName = {
   7: 'funicular',
   109: 'rail',
 };
+
+/**
+ * Splits a gtfsId into feedId and entityId, feedId cannot contain a colon
+ * @param {string} gtfsId gtfsId of the entity in format FeedId:EntityId
+ * @returns {{feedId: string, entityId: string}}
+ */
+export function splitGtfsId(gtfsId) {
+  const i = gtfsId.indexOf(':');
+  return {
+    feedId: gtfsId.slice(0, i),
+    entityId: gtfsId.slice(i + 1, gtfsId.length),
+  };
+}

--- a/app/util/gtfs.js
+++ b/app/util/gtfs.js
@@ -9,12 +9,19 @@ export const typeToName = {
 };
 
 /**
- * Splits a gtfsId into feedId and entityId, feedId cannot contain a colon
- * @param {string} gtfsId gtfsId of the entity in format FeedId:EntityId
- * @returns {{feedId: string, entityId: string}}
+ * Splits a gtfsId string into feedId and entityId, feedId cannot contain a colon
+ * @param {string} [gtfsId] gtfsId of the entity in format FeedId:EntityId
+ * @returns {{feedId?: string, entityId?: string}}
+ * @throws Will throw an error if the gtfsId is not valid
  */
 export function splitGtfsId(gtfsId) {
+  if (!gtfsId) {
+    return {};
+  }
   const i = gtfsId.indexOf(':');
+  if (i === -1) {
+    throw new Error('GtfsId needs to be formatted as feedId:entityId');
+  }
   return {
     feedId: gtfsId.slice(0, i),
     entityId: gtfsId.slice(i + 1, gtfsId.length),

--- a/app/util/modeUtils.js
+++ b/app/util/modeUtils.js
@@ -7,8 +7,9 @@ import { isInBoundingBox } from './geo-utils';
 import { addAnalyticsEvent } from './analyticsUtils';
 import { ExtendedRouteTypes, TransportMode } from '../constants';
 import { IS_DEV } from './envUtils';
-import { getFeedWithoutId, isExternalFeed } from './feedScopedIdUtils';
+import { isExternalFeed } from './feedScopedIdUtils';
 import { dateOrEmpty, durationToString } from './timeUtils';
+import { splitGtfsId } from './gtfs';
 
 function seasonMs(ddmmyyyy) {
   const parts = ddmmyyyy.split('.');
@@ -149,7 +150,7 @@ export function getRouteMode(route, config) {
     case ExtendedRouteTypes.ReplacementBus:
       return 'replacement-bus';
     default:
-      return isExternalFeed(getFeedWithoutId(route?.gtfsId), config)
+      return isExternalFeed(splitGtfsId(route?.gtfsId).feedId, config)
         ? `${route.mode?.toLowerCase()}-external`
         : route.mode?.toLowerCase();
   }
@@ -209,7 +210,7 @@ export function getStopMode(vehicleMode, routes, code, config, isTerminal) {
           }
           const arr = typeof routes === 'string' ? JSON.parse(routes) : routes;
           if (
-            arr.some(r => isExternalFeed(getFeedWithoutId(r.gtfsId), config))
+            arr.some(r => isExternalFeed(splitGtfsId(r.gtfsId).feedId, config))
           ) {
             return 'ferry-external';
           }

--- a/app/util/vehicleRentalUtils.js
+++ b/app/util/vehicleRentalUtils.js
@@ -3,8 +3,8 @@ import without from 'lodash/without';
 import { getCustomizedSettings } from '../store/localStorage';
 import { addAnalyticsEvent } from './analyticsUtils';
 import { networkIsActive } from './modeUtils';
-import { getIdWithoutFeed } from './feedScopedIdUtils';
 import { isAndroid, isIOS } from './browser';
+import { splitGtfsId } from './gtfs';
 
 export const BIKEAVL_UNKNOWN = 'No availability';
 export const BIKEAVL_BIKES = 'Bikes on station';
@@ -202,7 +202,7 @@ export const mapVehicleRentalToStore = vehicleRentalStation => {
   const newStation = {
     ...vehicleRentalStation,
     networks: [network],
-    stationId: getIdWithoutFeed(vehicleRentalStation.stationId),
+    stationId: splitGtfsId(vehicleRentalStation.stationId).entityId,
   };
   delete newStation.network;
   return newStation;

--- a/app/util/zoneIconUtils.js
+++ b/app/util/zoneIconUtils.js
@@ -1,8 +1,10 @@
+import { splitGtfsId } from './gtfs';
+
 export default function getZoneId(config, propertiesZones, dataZones) {
   function zoneFilter(zones) {
     return Array.isArray(zones)
       ? zones.filter(
-          zone => zone && config.feedIds.includes(zone.split(':')[0]),
+          zone => zone && config.feedIds.includes(splitGtfsId(zone).entityId),
         )
       : [];
   }
@@ -10,6 +12,5 @@ export default function getZoneId(config, propertiesZones, dataZones) {
   const filteredZones = propertiesZones
     ? zoneFilter(propertiesZones)
     : zoneFilter(dataZones);
-  const zone = filteredZones.length > 0 ? filteredZones[0] : undefined;
-  return zone ? zone.split(':')[1] : undefined;
+  return splitGtfsId(filteredZones.at(0)).entityId;
 }

--- a/app/util/zoneIconUtils.js
+++ b/app/util/zoneIconUtils.js
@@ -4,7 +4,7 @@ export default function getZoneId(config, propertiesZones, dataZones) {
   function zoneFilter(zones) {
     return Array.isArray(zones)
       ? zones.filter(
-          zone => zone && config.feedIds.includes(splitGtfsId(zone).entityId),
+          zone => zone && config.feedIds.includes(splitGtfsId(zone).feedId),
         )
       : [];
   }

--- a/server/server.js
+++ b/server/server.js
@@ -34,6 +34,7 @@ const { CosmosClient } = require('@azure/cosmos');
 const { getJson } = require('../app/util/xhrPromise');
 const { retryFetch } = require('../app/util/fetchUtils');
 const configTools = require('../app/config');
+const { splitGtfsId } = require('../app/util/gtfs');
 
 const config = configTools.getConfiguration();
 
@@ -161,7 +162,7 @@ function processTicketTypeResult(result) {
   if (config.availableTickets) {
     if (resultData && Array.isArray(resultData.ticketTypes)) {
       resultData.ticketTypes.forEach(ticket => {
-        const ticketFeed = ticket.fareId.split(':')[0];
+        const { feedId: ticketFeed } = splitGtfsId(ticket.fareId);
         if (config.availableTickets[ticketFeed] === undefined) {
           config.availableTickets[ticketFeed] = {};
         }

--- a/test/unit/component/TransitLeg.test.js
+++ b/test/unit/component/TransitLeg.test.js
@@ -306,14 +306,14 @@ describe('<TransitLeg />', () => {
         from: {
           name: 'Testilahti',
           stop: {
-            gtfsId: 'A',
+            gtfsId: 'A:123',
             alerts: [
               {
                 alertSeverityLevel: AlertSeverityLevelType.Warning,
                 entities: [
                   {
                     __typename: AlertEntityType.Stop,
-                    gtfsId: 'A',
+                    gtfsId: 'A:123',
                   },
                 ],
               },
@@ -323,7 +323,7 @@ describe('<TransitLeg />', () => {
         duration: 10000,
         intermediatePlaces: [],
         route: {
-          gtfsId: 'A',
+          gtfsId: 'A:2',
         },
         start: { scheduledTime: new Date(1553856180000).toISOString() },
         to: {
@@ -333,7 +333,7 @@ describe('<TransitLeg />', () => {
         trip: {
           gtfsId: 'A12345',
           pattern: {
-            code: 'A',
+            code: 'A:2:01',
           },
           tripHeadsign: 'foo - bar',
         },
@@ -577,7 +577,7 @@ describe('<TransitLeg />', () => {
         from: {
           name: 'Test',
           stop: {
-            gtfsId: 'A',
+            gtfsId: 'A:123',
             alerts: [
               {
                 alertSeverityLevel: AlertSeverityLevelType.Info,
@@ -586,7 +586,7 @@ describe('<TransitLeg />', () => {
                 entities: [
                   {
                     __typename: AlertEntityType.Stop,
-                    gtfsId: 'A',
+                    gtfsId: 'A:123',
                   },
                 ],
               },
@@ -596,7 +596,7 @@ describe('<TransitLeg />', () => {
         duration: 1000,
         intermediatePlaces: [],
         route: {
-          gtfsId: 'A1234',
+          gtfsId: 'FOO:A1234',
         },
         start: { scheduledTime: new Date(startTime * 1000).toISOString() },
         to: {
@@ -604,7 +604,7 @@ describe('<TransitLeg />', () => {
           stop: {},
         },
         trip: {
-          gtfsId: 'A1234:01',
+          gtfsId: 'FOO:A1234:01',
           pattern: {
             code: 'A',
           },

--- a/test/unit/component/TripStopListContainer.test.js
+++ b/test/unit/component/TripStopListContainer.test.js
@@ -19,7 +19,7 @@ describe('<TripStopListContainer />', () => {
           directionId: 1,
         },
         route: {
-          gtfsId: 'foobar-1',
+          gtfsId: 'foobar:1',
           mode: 'BUS',
         },
         stoptimesForDate: [
@@ -28,7 +28,7 @@ describe('<TripStopListContainer />', () => {
             realtimeDeparture: 1000,
             serviceDay,
             stop: {
-              gtfsId: 'stop-1',
+              gtfsId: 'stop:1',
             },
           },
           {
@@ -36,7 +36,7 @@ describe('<TripStopListContainer />', () => {
             realtimeDeparture: 3000,
             serviceDay,
             stop: {
-              gtfsId: 'stop-2',
+              gtfsId: 'stop:2',
             },
           },
         ],

--- a/test/unit/util/gtfs.test.js
+++ b/test/unit/util/gtfs.test.js
@@ -2,16 +2,21 @@ import { splitGtfsId } from '../../../app/util/gtfs';
 
 describe('splitGtfsId', () => {
   it('should split gtfsId into feedId and entityId', () => {
-    const gtfsId = 'FOO:1234';
-    const { feedId, entityId } = splitGtfsId(gtfsId);
-    expect(feedId).to.equal('FOO');
-    expect(entityId).to.equal('1234');
-  });
-
-  it('should gtfs work with colons in entityId', () => {
     const gtfsId = 'FOO:BAR:1234';
     const { feedId, entityId } = splitGtfsId(gtfsId);
     expect(feedId).to.equal('FOO');
     expect(entityId).to.equal('BAR:1234');
+  });
+
+  it('should return an empty object on undefined', () => {
+    const { feedId, entityId } = splitGtfsId();
+    expect(feedId).to.equal(undefined);
+    expect(entityId).to.equal(undefined);
+  });
+
+  it('should throw an error if colon is missing', () => {
+    expect(() => {
+      splitGtfsId('no colon');
+    }).to.throw(Error);
   });
 });

--- a/test/unit/util/gtfs.test.js
+++ b/test/unit/util/gtfs.test.js
@@ -1,0 +1,17 @@
+import { splitGtfsId } from '../../../app/util/gtfs';
+
+describe('splitGtfsId', () => {
+  it('should split gtfsId into feedId and entityId', () => {
+    const gtfsId = 'FOO:1234';
+    const { feedId, entityId } = splitGtfsId(gtfsId);
+    expect(feedId).to.equal('FOO');
+    expect(entityId).to.equal('1234');
+  });
+
+  it('should gtfs work with colons in entityId', () => {
+    const gtfsId = 'FOO:BAR:1234';
+    const { feedId, entityId } = splitGtfsId(gtfsId);
+    expect(feedId).to.equal('FOO');
+    expect(entityId).to.equal('BAR:1234');
+  });
+});


### PR DESCRIPTION
## Proposed Changes

  - Adds a utility function that splits a gtfsId into a feedId and entityId
    - Does so by splitting at the index of the first colon instead of splitting into array by colons
  - replaces old functionality that is prone to fail when colons are introduced in id's

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
