### PR TITLE
AB#579 Traffic now footer

### DIFF
--- a/app/component/trafficnow/TrafficNow.js
+++ b/app/component/trafficnow/TrafficNow.js
@@ -10,6 +10,7 @@ import Loading from '../Loading';
 import CanceledTripsContainer from './CanceledTripsContainer';
 import DisruptionDetailsContainer from './DisruptionDetailsContainer';
 import Disruptions from './Disruptions';
+import TrafficNowFooter from './TrafficNowFooter';
 import TrafficNowHeader from './TrafficNowHeader';
 import Filters from './filters/Filters';
 import { FilterContextProvider } from './filters/FiltersContext';
@@ -104,6 +105,7 @@ const TrafficNow = () => {
           </FilterContextProvider>
         </div>
       </Gutterer>
+      <TrafficNowFooter />
     </div>
   );
 };

--- a/app/component/trafficnow/TrafficNow.js
+++ b/app/component/trafficnow/TrafficNow.js
@@ -5,6 +5,7 @@ import Button from '@hsl-fi/button';
 import { useRouter } from 'found';
 import ReactModal from 'react-modal';
 import { useBreakpoint } from '../../util/withBreakpoint';
+import scrollTop from '../../util/scroll';
 import Gutterer from '../Gutterer';
 import Loading from '../Loading';
 import CanceledTripsContainer from './CanceledTripsContainer';
@@ -29,6 +30,10 @@ const TrafficNow = () => {
   const mobile = breakpoint !== 'large';
 
   useEffect(() => ReactModal.setAppElement(document.querySelector('#app')), []);
+
+  useEffect(() => {
+    scrollTop();
+  }, [mode, alertId]);
 
   const isMobileCanceledTripsView = !!mode && mobile;
   const isDetailsView = !!alertId;

--- a/app/component/trafficnow/TrafficNowFooter.js
+++ b/app/component/trafficnow/TrafficNowFooter.js
@@ -1,0 +1,242 @@
+import React from 'react';
+import { SiteFooter } from '@hsl-fi/site-footer';
+import { useConfigContext } from '../../configurations/ConfigContext';
+
+const SUPPORTED_LANGS = ['fi', 'sv', 'en'];
+
+const langPrefix = lang => (lang === 'fi' ? '' : `/${lang}`);
+
+const href = (rootLink, lang, paths) =>
+  `${rootLink}${langPrefix(lang)}${paths[lang]}`;
+
+const buildFooterData = (rootLink, lang) => ({
+  column1: {
+    title: {
+      fi: 'Liput ja hinnat',
+      sv: 'Biljetter och priser',
+      en: 'Tickets and fares',
+    }[lang],
+    links: [
+      {
+        label: {
+          fi: 'Kausiliput',
+          sv: 'Periodbiljetter',
+          en: 'Season tickets',
+        }[lang],
+        href: href(rootLink, lang, {
+          fi: '/liput-ja-hinnat/kausiliput',
+          sv: '/biljetter-och-priser/periodbiljetter',
+          en: '/tickets-and-fares/season-tickets',
+        }),
+      },
+      {
+        label: { fi: 'Kertaliput', sv: 'Enkelbiljetter', en: 'Single tickets' }[
+          lang
+        ],
+        href: href(rootLink, lang, {
+          fi: '/liput-ja-hinnat/kertaliput',
+          sv: '/biljetter-och-priser/enkelbiljetter',
+          en: '/tickets-and-fares/single-tickets',
+        }),
+      },
+      {
+        label: { fi: 'Vyöhykkeet', sv: 'Zoner', en: 'Zones' }[lang],
+        href: href(rootLink, lang, {
+          fi: '/liput-ja-hinnat/vyohykkeet',
+          sv: '/biljetter-och-priser/zoner',
+          en: '/tickets-and-fares/zones',
+        }),
+      },
+    ],
+  },
+  column2: {
+    title: { fi: 'Matkustaminen', sv: 'Att resa', en: 'Travelling' }[lang],
+    links: [
+      {
+        label: {
+          fi: 'Reitit ja aikataulut',
+          sv: 'Rutter och tidtabeller',
+          en: 'Routes and timetables',
+        }[lang],
+        href: href(rootLink, lang, {
+          fi: '/reitit-ja-aikataulut',
+          sv: '/rutter-och-tidtabeller',
+          en: '/routes-and-timetables',
+        }),
+      },
+      {
+        label: {
+          fi: 'Juhlapyhät ja poikkeusaikataulut',
+          sv: 'Helger och avvikande tidtabeller',
+          en: 'Bank holidays and changes',
+        }[lang],
+        href: href(rootLink, lang, {
+          fi: '/matkustaminen/juhlapyhat-ja-poikkeusaikataulut',
+          sv: '/att-resa/helger-och-avvikande-tidtabeller',
+          en: '/travelling/bank-holidays-and-changes-to-public-transport-services',
+        }),
+      },
+      {
+        label: {
+          fi: 'Esteettömyys',
+          sv: 'Tillgänglighet',
+          en: 'Accessibility',
+        }[lang],
+        href: href(rootLink, lang, {
+          fi: '/matkustaminen/esteettomyys',
+          sv: '/att-resa/tillganglighet',
+          en: '/travelling/accessibility',
+        }),
+      },
+    ],
+  },
+  column3: {
+    title: { fi: 'HSL', sv: 'HRT', en: 'HSL' }[lang],
+    links: [
+      {
+        label: {
+          fi: 'Tietoa HSL:stä',
+          sv: 'Information om HRT',
+          en: 'About HSL',
+        }[lang],
+        href: href(rootLink, lang, {
+          fi: '/hsl',
+          sv: '/hrt',
+          en: '/hsl',
+        }),
+      },
+      {
+        label: { fi: 'Uutiset', sv: 'Nyheter', en: 'News' }[lang],
+        href: href(rootLink, lang, {
+          fi: '/hsl/uutiset',
+          sv: '/hrt/nyheter',
+          en: '/hsl/news',
+        }),
+      },
+      {
+        label: { fi: 'Avoimet työpaikat', sv: 'Lediga jobb', en: 'Open jobs' }[
+          lang
+        ],
+        href: href(rootLink, lang, {
+          fi: '/hsl/avoimet-tyopaikat',
+          sv: '/hrt/lediga-jobb',
+          en: '/hsl/open-jobs',
+        }),
+      },
+    ],
+  },
+  column4: {
+    title: { fi: 'Asiakaspalvelu', sv: 'Kundtjänst', en: 'Customer service' }[
+      lang
+    ],
+    links: [
+      {
+        label: { fi: 'Ota yhteyttä', sv: 'Kontakta oss', en: 'Contact us' }[
+          lang
+        ],
+        href: href(rootLink, lang, {
+          fi: '/asiakaspalvelu',
+          sv: '/kundtjanst',
+          en: '/customer-service',
+        }),
+      },
+      {
+        label: {
+          fi: 'Anna palautetta',
+          sv: 'Ge respons',
+          en: 'Give feedback',
+        }[lang],
+        href: href(rootLink, lang, {
+          fi: '/asiakaspalvelu/palaute',
+          sv: '/kundtjanst/respons',
+          en: '/customer-service/feedback',
+        }),
+      },
+      {
+        label: {
+          fi: 'Löytötavarat',
+          sv: 'Hittegods',
+          en: 'Lost and found',
+        }[lang],
+        href: href(rootLink, lang, {
+          fi: '/asiakaspalvelu/loytotavarat',
+          sv: '/kundtjanst/hittegods',
+          en: '/customer-service/lost-and-found',
+        }),
+      },
+    ],
+  },
+  secondaryLinks: {
+    contantInfoLink: {
+      href: href(rootLink, lang, {
+        fi: '/yhteystiedot',
+        sv: '/kontaktuppgifter',
+        en: '/contact-information',
+      }),
+    },
+    paymentMethodsLink: {
+      href: href(rootLink, lang, {
+        fi: '/liput-ja-hinnat/maksutavat',
+        sv: '/biljetter-och-priser/betalningssatt',
+        en: '/tickets-and-fares/payment-methods',
+      }),
+    },
+    privacyLink: {
+      href: href(rootLink, lang, {
+        fi: '/hsl/tietosuoja',
+        sv: '/hrt/dataskydd',
+        en: '/hsl/privacy-policy',
+      }),
+    },
+    cookieSettingsLink: {
+      href: href(rootLink, lang, {
+        fi: '/hsl/tietosuoja',
+        sv: '/hrt/dataskydd',
+        en: '/hsl/privacy-policy',
+      }),
+    },
+    termsOfUseLink: {
+      href: href(rootLink, lang, {
+        fi: '/kayttoehdot',
+        sv: '/anvandarvillkor',
+        en: '/terms-of-use',
+      }),
+    },
+    accessibilityStatementLink: {
+      href: href(rootLink, lang, {
+        fi: '/saavutettavuusseloste',
+        sv: '/tillganglighetsutlatande',
+        en: '/accessibility-statement',
+      }),
+    },
+  },
+});
+
+const TrafficNowFooter = () => {
+  const {
+    CONFIG,
+    language,
+    URL: { ROOTLINK },
+  } = useConfigContext();
+
+  if (CONFIG !== 'hsl') {
+    return null;
+  }
+
+  const lang = SUPPORTED_LANGS.includes(language) ? language : 'fi';
+
+  return (
+    <SiteFooter
+      baseUrl={ROOTLINK}
+      lang={lang}
+      data={buildFooterData(ROOTLINK, lang)}
+      cookieSettingsButtonProps={{
+        type: 'button',
+        onClick: () => window.CookieConsent?.renew?.(),
+      }}
+      // variant="compact" // use the simple bottom bar footer without link columns and app promotion
+    />
+  );
+};
+
+export default TrafficNowFooter;

--- a/app/component/trafficnow/styles/layout.scss
+++ b/app/component/trafficnow/styles/layout.scss
@@ -137,6 +137,7 @@
     gap: var(--space-m);
     padding-top: var(--space-xl);
     padding-right: var(--space-xl);
+    padding-bottom: var(--space-xl);
     position: sticky;
     top: 0;
 

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "@hsl-fi/modal": " ^0.3.2",
     "@hsl-fi/sass": " 1.0.0",
     "@hsl-fi/shimmer": "0.1.2",
+    "@hsl-fi/site-footer": "^5.1.1",
     "@hsl-fi/site-header": "6.4.0",
     "@mapbox/sphericalmercator": "1.1.0",
     "@mapbox/vector-tile": "1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,6 +3449,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hsl-fi/site-footer@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@hsl-fi/site-footer@npm:5.1.1"
+  dependencies:
+    "@hsl-fi/assets": "npm:^2.1.0"
+    "@hsl-fi/i18n": "npm:^1.5.1"
+    "@hsl-fi/icons": "npm:^2.2.4"
+    "@hsl-fi/navigation": "npm:^3.0.0"
+    classnames: "npm:^2.3.2"
+  peerDependencies:
+    "@hsl-fi/design-tokens": ^1.20.0
+    "@hsl-fi/layout-primitives": ^4.4.0
+    react: ">=16"
+  checksum: 10/644324bd5015b06d784b7d013f184ec68bd2ccb506281585fd20bf3155e9b46c3ed7a3329a55adc054f808961870c05d5554707373ae5ea93d946ad27c4b452b
+  languageName: node
+  linkType: hard
+
 "@hsl-fi/site-header@npm:6.4.0":
   version: 6.4.0
   resolution: "@hsl-fi/site-header@npm:6.4.0"
@@ -12389,6 +12406,7 @@ __metadata:
     "@hsl-fi/modal": "npm: ^0.3.2"
     "@hsl-fi/sass": "npm: 1.0.0"
     "@hsl-fi/shimmer": "npm:0.1.2"
+    "@hsl-fi/site-footer": "npm:^5.1.1"
     "@hsl-fi/site-header": "npm:6.4.0"
     "@lerna/batch-packages": "npm:3.16.0"
     "@lerna/filter-packages": "npm:3.18.0"


### PR DESCRIPTION
## Proposed Changes

  - Added HSL footer for traffic now. Extensive default content visible for now. To opt for the compact, just uncomment the SiteFooter variant parameter.
  - Added padding under the filters to avoid the filter component touching the footer, and the scroll looking uneven between the filters and the alert contents.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
