### PR TITLE
AB#511 - Show direct and transit flex itineraries when enabled

### DIFF
--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -1143,8 +1143,8 @@ export default function ItineraryPage(props, context) {
       let plan = mergeScooterTransitPlan(
         scooterState.plan,
         mainState.plan,
-        config.vehicleRental.allowDirectScooterJourneys,
         match.location.query.arriveBy === 'true',
+        config.vehicleRental.allowDirectScooterJourneys,
       );
 
       if (externalFlexState.plan?.edges) {

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -75,7 +75,7 @@ import {
   parseCarTransitPlan,
   quitIteration,
   reportError,
-  scooterEdges,
+  filterScooterEdges,
   setCurrentTimeToURL,
   settingsLimitRouting,
   sortAndMergeExternalPlans,
@@ -508,7 +508,7 @@ export default function ItineraryPage(props, context) {
         tunedParams,
         tunedParams.maxQueryIterations,
       );
-      const scooterPlan = { edges: scooterEdges(plan.edges) };
+      const scooterPlan = { edges: filterScooterEdges(plan.edges) };
       setRelaxScooterState({ plan: scooterPlan, loading: LOADSTATE.DONE });
     } catch (error) {
       setRelaxScooterState({ plan: {}, loading: LOADSTATE.DONE });

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -1152,6 +1152,7 @@ export default function ItineraryPage(props, context) {
           externalFlexState.plan,
           plan,
           match.location.query.arriveBy === 'true',
+          config.flex.external.showBothDirectAndTransitResults,
           config.flex.external.allowedRouteTypes,
         );
       }
@@ -1161,6 +1162,7 @@ export default function ItineraryPage(props, context) {
           internalFlexState.plan,
           plan,
           match.location.query.arriveBy === 'true',
+          config.flex.internal.showBothDirectAndTransitResults,
         );
       }
       if (personalization) {

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -11,7 +11,11 @@ import {
 import { PlannerMessageType, ExtendedRouteTypes } from '../../constants';
 import { addAnalyticsEvent } from '../../util/analyticsUtils';
 import { boundWithMinimumArea } from '../../util/geo-utils';
-import { compressLegs, getTotalBikingDistance } from '../../util/legUtils';
+import {
+  compressLegs,
+  getTotalBikingDistance,
+  isDirectFlexItinerary,
+} from '../../util/legUtils';
 import { getMapLayerOptions } from '../../util/mapLayerUtils';
 import { getDefaultSettings, getSettings } from '../../util/planParamUtil';
 import { getStartTimeWithColon } from '../../util/timeUtils';
@@ -371,19 +375,23 @@ export function scooterEdges(edges, allowDirectScooterJourneys) {
     }
   });
 
-  return filteredEdges;
+  return filteredEdges.slice(0, 1);
 }
 
-/** Filters away itineraries that are not flex */
-export function flexEdges(edges) {
+/** Filters away itineraries that are not internal flex (call agency). */
+export function filterInternalFlexEdges(edges) {
   if (!edges) {
     return [];
   }
-  return edges.filter(edge =>
+  const filtered = edges.filter(edge =>
     edge.node.legs.some(
       leg => leg.route?.type === ExtendedRouteTypes.CallAgency,
     ),
   );
+  const hasDirect = filtered.some(e =>
+    isDirectFlexItinerary(e.node, [ExtendedRouteTypes.CallAgency]),
+  );
+  return filtered.slice(0, hasDirect ? 2 : 1);
 }
 
 /**
@@ -418,13 +426,15 @@ export function filterItinerariesByRouteType(
   if (!edges) {
     return [];
   }
-  return edges.filter(edge =>
+  const filtered = edges.filter(edge =>
     edge.node.legs.some(
       leg =>
         types.includes(leg.route?.type) &&
         (includeTaxiSuggestions || leg.route?.type !== 'TAXI'),
     ),
   );
+  const hasDirect = filtered.some(e => isDirectFlexItinerary(e.node, types));
+  return filtered.slice(0, hasDirect ? 2 : 1);
 }
 
 /**
@@ -514,31 +524,22 @@ export function getSortedEdges(edges, arriveBy) {
 /**
  * Combine an external edge with the main transit edges.
  */
-function sortAndMergePlans(
-  externalTransitEdges,
-  transitPlan,
-  arriveBy,
-  maxAdditionalEdges = 1,
-) {
+function sortAndMergePlans(additionalEdges, transitPlan, arriveBy) {
   const transitPlanEdges = transitPlan.edges || [];
-  const maxTransitEdges =
-    externalTransitEdges.length > 0 ? 4 : transitPlanEdges.length;
+  const maxTransitEdges = 5 - additionalEdges.length;
 
   // special case: if transitplan only has one walk itinerary, don't show external plan if it arrives later.
   if (
     transitPlanEdges.length === 1 &&
     transitPlanEdges[0].node.legs.every(leg => leg.mode === 'WALK') &&
-    transitPlanEdges[0].node.end < externalTransitEdges[0]?.node.end
+    transitPlanEdges[0].node.end < additionalEdges[0]?.node.end
   ) {
     return transitPlan;
   }
 
   return {
     edges: getSortedEdges(
-      [
-        ...externalTransitEdges.slice(0, maxAdditionalEdges),
-        ...transitPlanEdges.slice(0, maxTransitEdges),
-      ],
+      [...additionalEdges, ...transitPlanEdges.slice(0, maxTransitEdges)],
       arriveBy,
     ).map(edge => {
       return {
@@ -558,8 +559,8 @@ function sortAndMergePlans(
 export function mergeScooterTransitPlan(
   scooterPlan,
   transitPlan,
-  allowDirectScooterJourneys,
   arriveBy,
+  allowDirectScooterJourneys,
 ) {
   const scooterTransitEdges = scooterEdges(
     scooterPlan.edges,
@@ -587,14 +588,9 @@ export function mergeExternalFlexPlan(
 }
 
 /** Combine an internal flex plan with the main transit plan. */
-export function mergeInternalFlexPlan(
-  flexPlan,
-  plan,
-  arriveBy,
-  maxAdditionalEdges = 1,
-) {
-  const edges = flexEdges(flexPlan.edges);
-  return sortAndMergePlans(edges, plan, arriveBy, maxAdditionalEdges);
+export function mergeInternalFlexPlan(flexPlan, plan, arriveBy) {
+  const internalFlexEdges = filterInternalFlexEdges(flexPlan.edges);
+  return sortAndMergePlans(internalFlexEdges, plan, arriveBy);
 }
 
 /**

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -342,7 +342,7 @@ export function transitEdges(edges) {
  * 2. only use scooters (unless allowed by allowDirectScooterJourneys)
  * 3. use scooters that are not vehicles
  */
-export function scooterEdges(edges, allowDirectScooterJourneys) {
+export function filterScooterEdges(edges, allowDirectScooterJourneys) {
   if (!edges) {
     return [];
   }
@@ -375,7 +375,7 @@ export function scooterEdges(edges, allowDirectScooterJourneys) {
     }
   });
 
-  return filteredEdges.slice(0, 1);
+  return filteredEdges;
 }
 
 /**
@@ -541,11 +541,12 @@ export function mergeScooterTransitPlan(
   arriveBy,
   allowDirectScooterJourneys,
 ) {
-  const scooterTransitEdges = scooterEdges(
+  const filteredScooterEdges = filterScooterEdges(
     scooterPlan.edges,
     allowDirectScooterJourneys,
   );
-  return sortAndMergePlans(scooterTransitEdges, transitPlan, arriveBy);
+  const selectedScooterEdges = filteredScooterEdges.slice(0, 1);
+  return sortAndMergePlans(selectedScooterEdges, transitPlan, arriveBy);
 }
 
 /**

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -411,6 +411,16 @@ export function filterItinerariesByRouteType(edges, types) {
   );
 }
 
+/**
+ * Usually selects the first flex edge from a pre-filtered list.
+ * If the showBothDirectAndTransitResults flag is true and a direct flex itinerary exists,
+ * this function selects 2 edges: the direct flex itinerary and the next transit itinerary (if it exists).
+ * OTP always returns the direct flex itinerary as the first result (if one exists).
+ *
+ * @param {Array} edges - Pre-filtered flex edges (must only contain flex itineraries of the given types).
+ * @param {number[]} types - Allowed route types used to identify direct flex itineraries (e.g. ExtendedRouteTypes.CallAgency).
+ * @param {boolean} showBothDirectAndTransitResults - When true, returns both a direct and transit itinerary if both exist; otherwise returns 1.
+ */
 function selectFlexEdges(edges, types, showBothDirectAndTransitResults) {
   const hasDirect = edges.some(e => isDirectFlexItinerary(e.node, types));
   return edges.slice(0, hasDirect && showBothDirectAndTransitResults ? 2 : 1);
@@ -501,11 +511,16 @@ export function getSortedEdges(edges, arriveBy) {
 }
 
 /**
- * Combine additional edges with the main transit edges.
+ * Merges a small set of additional edges (flex or scooter) with the main
+ * transit plan edges, sorts the combined result, and caps the total at 5.
+ *
+ * @param {Array} additionalEdges - Pre-selected flex or scooter edges to prepend (amount of edges should be 1 or 2).
+ * @param {Object} transitPlan - The main transit plan object with an `edges` array.
+ * @param {boolean} arriveBy - Whether the search is arrive-by (affects sort order).
  */
 function sortAndMergePlans(additionalEdges, transitPlan, arriveBy) {
   const transitPlanEdges = transitPlan.edges || [];
-  const maxTransitEdges = 5 - additionalEdges.length;
+  const maxTransitEdges = Math.max(5 - additionalEdges.length, 0);
 
   // special case: if transitplan only has one walk itinerary, don't show external plan if it arrives later.
   if (

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -578,13 +578,14 @@ export function mergeInternalFlexPlan(
   arriveBy,
   showBothDirectAndTransitResults,
 ) {
+  const allowedInternalFlexRouteTypes = [ExtendedRouteTypes.CallAgency];
   const filteredInternalFlexEdges = filterItinerariesByRouteType(
     flexPlan.edges,
-    [ExtendedRouteTypes.CallAgency],
+    allowedInternalFlexRouteTypes,
   );
   const selectedInternalFlexEdges = selectFlexEdges(
     filteredInternalFlexEdges,
-    [ExtendedRouteTypes.CallAgency],
+    allowedInternalFlexRouteTypes,
     showBothDirectAndTransitResults,
   );
   return sortAndMergePlans(selectedInternalFlexEdges, plan, arriveBy);

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -402,22 +402,18 @@ export function filterItineraries(edges, modes) {
   );
 }
 
-export function filterItinerariesByRouteType(
-  edges,
-  types,
-  showBothDirectAndTransitResults,
-) {
+export function filterItinerariesByRouteType(edges, types) {
   if (!edges) {
     return [];
   }
-  const filtered = edges.filter(edge =>
+  return edges.filter(edge =>
     edge.node.legs.some(leg => types.includes(leg.route?.type)),
   );
-  const hasDirect = filtered.some(e => isDirectFlexItinerary(e.node, types));
-  return filtered.slice(
-    0,
-    hasDirect && showBothDirectAndTransitResults ? 2 : 1,
-  );
+}
+
+function selectFlexEdges(edges, types, showBothDirectAndTransitResults) {
+  const hasDirect = edges.some(e => isDirectFlexItinerary(e.node, types));
+  return edges.slice(0, hasDirect && showBothDirectAndTransitResults ? 2 : 1);
 }
 
 /**
@@ -505,7 +501,7 @@ export function getSortedEdges(edges, arriveBy) {
 }
 
 /**
- * Combine an external edge with the main transit edges.
+ * Combine additional edges with the main transit edges.
  */
 function sortAndMergePlans(additionalEdges, transitPlan, arriveBy) {
   const transitPlanEdges = transitPlan.edges || [];
@@ -562,12 +558,16 @@ export function mergeExternalFlexPlan(
   showBothDirectAndTransitResults,
   allowedExternalFlexRouteTypes,
 ) {
-  const externalFlexEdges = filterItinerariesByRouteType(
+  const filteredExternalFlexEdges = filterItinerariesByRouteType(
     externalPlan.edges,
+    allowedExternalFlexRouteTypes,
+  );
+  const selectedExternalFlexEdges = selectFlexEdges(
+    filteredExternalFlexEdges,
     allowedExternalFlexRouteTypes,
     showBothDirectAndTransitResults,
   );
-  return sortAndMergePlans(externalFlexEdges, transitPlan, arriveBy);
+  return sortAndMergePlans(selectedExternalFlexEdges, transitPlan, arriveBy);
 }
 
 /** Combine an internal flex plan with the main transit plan. */
@@ -577,12 +577,16 @@ export function mergeInternalFlexPlan(
   arriveBy,
   showBothDirectAndTransitResults,
 ) {
-  const internalFlexEdges = filterItinerariesByRouteType(
+  const filteredInternalFlexEdges = filterItinerariesByRouteType(
     flexPlan.edges,
+    [ExtendedRouteTypes.CallAgency],
+  );
+  const selectedInternalFlexEdges = selectFlexEdges(
+    filteredInternalFlexEdges,
     [ExtendedRouteTypes.CallAgency],
     showBothDirectAndTransitResults,
   );
-  return sortAndMergePlans(internalFlexEdges, plan, arriveBy);
+  return sortAndMergePlans(selectedInternalFlexEdges, plan, arriveBy);
 }
 
 /**

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -378,22 +378,6 @@ export function scooterEdges(edges, allowDirectScooterJourneys) {
   return filteredEdges.slice(0, 1);
 }
 
-/** Filters away itineraries that are not internal flex (call agency). */
-export function filterInternalFlexEdges(edges) {
-  if (!edges) {
-    return [];
-  }
-  const filtered = edges.filter(edge =>
-    edge.node.legs.some(
-      leg => leg.route?.type === ExtendedRouteTypes.CallAgency,
-    ),
-  );
-  const hasDirect = filtered.some(e =>
-    isDirectFlexItinerary(e.node, [ExtendedRouteTypes.CallAgency]),
-  );
-  return filtered.slice(0, hasDirect ? 2 : 1);
-}
-
 /**
  * Filters away plain walk
  */
@@ -421,20 +405,19 @@ export function filterItineraries(edges, modes) {
 export function filterItinerariesByRouteType(
   edges,
   types,
-  includeTaxiSuggestions,
+  showBothDirectAndTransitResults,
 ) {
   if (!edges) {
     return [];
   }
   const filtered = edges.filter(edge =>
-    edge.node.legs.some(
-      leg =>
-        types.includes(leg.route?.type) &&
-        (includeTaxiSuggestions || leg.route?.type !== 'TAXI'),
-    ),
+    edge.node.legs.some(leg => types.includes(leg.route?.type)),
   );
   const hasDirect = filtered.some(e => isDirectFlexItinerary(e.node, types));
-  return filtered.slice(0, hasDirect ? 2 : 1);
+  return filtered.slice(
+    0,
+    hasDirect && showBothDirectAndTransitResults ? 2 : 1,
+  );
 }
 
 /**
@@ -576,20 +559,29 @@ export function mergeExternalFlexPlan(
   externalPlan,
   transitPlan,
   arriveBy,
+  showBothDirectAndTransitResults,
   allowedExternalFlexRouteTypes,
-  includeTaxiSuggestions,
 ) {
   const externalFlexEdges = filterItinerariesByRouteType(
     externalPlan.edges,
     allowedExternalFlexRouteTypes,
-    includeTaxiSuggestions,
+    showBothDirectAndTransitResults,
   );
   return sortAndMergePlans(externalFlexEdges, transitPlan, arriveBy);
 }
 
 /** Combine an internal flex plan with the main transit plan. */
-export function mergeInternalFlexPlan(flexPlan, plan, arriveBy) {
-  const internalFlexEdges = filterInternalFlexEdges(flexPlan.edges);
+export function mergeInternalFlexPlan(
+  flexPlan,
+  plan,
+  arriveBy,
+  showBothDirectAndTransitResults,
+) {
+  const internalFlexEdges = filterItinerariesByRouteType(
+    flexPlan.edges,
+    [ExtendedRouteTypes.CallAgency],
+    showBothDirectAndTransitResults,
+  );
   return sortAndMergePlans(internalFlexEdges, plan, arriveBy);
 }
 

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -870,6 +870,7 @@ export default {
       direct: false,
       agencies: [], // "FeedId:AgencyId"
       allowedRouteTypes: [1501],
+      showBothDirectAndTransitResults: false,
     },
     internal: {
       enabled: false,
@@ -877,6 +878,7 @@ export default {
       direct: false,
       agencies: [], // "FeedId:AgencyId"
       minTransferTime: 900, // seconds
+      showBothDirectAndTransitResults: false,
     },
   },
   personalization: false,

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -450,6 +450,7 @@ export default {
       transit: true,
       direct: true,
       agencies: ['02Taksi:02_taksi'],
+      showBothDirectAndTransitResults: true,
     },
     internal: {
       enabled: true,

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -480,6 +480,14 @@ export function isCallAgencyLeg(leg) {
   return leg.route?.type === ExtendedRouteTypes.CallAgency;
 }
 
+export function isDirectFlexItinerary(itinerary, allowedTypes) {
+  const transitLegs = itinerary.legs.filter(leg => leg.transitLeg);
+  return (
+    transitLegs.length === 1 &&
+    allowedTypes.includes(transitLegs[0].route?.type)
+  );
+}
+
 export function hasTaxiLegs(itinerary) {
   return itinerary.legs.some(isTaxiLeg);
 }


### PR DESCRIPTION
## Proposed Changes

  - This PR adds the capability to flex to show both a direct and transit route. In order for this to happen both `direct`, `transit`, and the new config field `showBothDirectAndTransitResults` need to be enabled.
  - I removed a check that was always true because comparing numbers to the string TAXI doesn't make sense `(includeTaxiSuggestions || leg.route?.type !== 'TAXI'),`
  - Refactoring changes