### PR TITLE
Ab#623 Adjustments to traffic now overview cards

### DIFF
--- a/app/component/trafficnow/DisruptionCard.js
+++ b/app/component/trafficnow/DisruptionCard.js
@@ -13,6 +13,7 @@ export default function DisruptionCard({
   alert,
   onClick = () => {},
   isMobile = false,
+  mode = undefined,
 }) {
   const {
     id,
@@ -59,7 +60,7 @@ export default function DisruptionCard({
           />
         </button>
       </header>
-      {entities && <RouteBadges entities={entities} />}
+      {entities && <RouteBadges entities={entities} mode={mode} compact />}
       <h2 className="cta-small">{alertHeaderText}</h2>
       {isMobile && (
         <DisruptionStatus
@@ -77,4 +78,5 @@ DisruptionCard.propTypes = {
   alert: alertShape.isRequired,
   onClick: PropTypes.func,
   isMobile: PropTypes.bool,
+  mode: PropTypes.string,
 };

--- a/app/component/trafficnow/Disruptions.js
+++ b/app/component/trafficnow/Disruptions.js
@@ -13,6 +13,7 @@ import { useFilterContext } from './filters/FiltersContext';
 import { filterAndSortAlerts } from './filters/filterUtils';
 import AlertsQuery from './queries/AlertsQuery';
 import CanceledTripsOverviewQuery from './queries/CanceledTripsOverviewQuery';
+import { getAlertModes } from './utils';
 import { TRAFFICNOW } from '../../util/path';
 
 const CANCELED_TRIPS_OVERVIEW_QUERY_AMOUNT = 20;
@@ -62,6 +63,24 @@ export default function Disruptions() {
     [alerts, selectedFilters],
   );
 
+  // Split each alert into one card per affected transport mode. Alerts with no
+  // recognised mode still produce a single card.
+  const disruptionCards = useMemo(
+    () =>
+      disruptions.flatMap(alert => {
+        const modes = getAlertModes(alert.entities, config);
+        if (modes.length === 0) {
+          return [{ key: alert.id, alert, mode: undefined }];
+        }
+        return modes.map(mode => ({
+          key: `${alert.id}-${mode}`,
+          alert,
+          mode,
+        }));
+      }),
+    [disruptions, config],
+  );
+
   const mobile = breakpoint !== 'large';
 
   const canceledModes = [
@@ -77,7 +96,7 @@ export default function Disruptions() {
 
   const resultAmount = canceledModes.reduce(
     (sum, mode) => (mode.totalCount > 0 ? sum + 1 : sum),
-    disruptions.length,
+    disruptionCards.length,
   );
 
   return (
@@ -111,10 +130,11 @@ export default function Disruptions() {
                   />
                 ),
             )}
-            {disruptions.map(a => (
+            {disruptionCards.map(({ key, alert, mode }) => (
               <DisruptionCard
-                key={a.id}
-                alert={a}
+                key={key}
+                alert={alert}
+                mode={mode}
                 onClick={handleCardClick}
                 isMobile={mobile}
               />

--- a/app/component/trafficnow/RouteBadges.js
+++ b/app/component/trafficnow/RouteBadges.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
 import { entityShape } from '../../util/shapes';
 import { useConfigContext } from '../../configurations/ConfigContext';
 import { AlertEntityType } from '../../constants';
@@ -8,42 +9,83 @@ import { groupEntitiesByMode } from './utils';
 import { useFilterContext } from './filters/FiltersContext';
 import RouteBadgeGroup from './components/RouteBadgeGroup';
 
-export default function RouteBadges({ entities: rawEntities }) {
+export default function RouteBadges({
+  entities: rawEntities,
+  compact = false,
+  mode = undefined,
+}) {
   const config = useConfigContext();
+  const intl = useIntl();
   const { selectedFilters } = useFilterContext();
-
-  if (rawEntities.every(e => e.__typename === AlertEntityType.Unknown)) {
-    return null;
-  }
 
   const entitiesByMode = useMemo(
     () => groupEntitiesByMode(rawEntities, config),
     [rawEntities, config],
   );
 
+  if (rawEntities.every(e => e.__typename === AlertEntityType.Unknown)) {
+    return null;
+  }
+
+  const groups = Object.entries(entitiesByMode);
+
+  // Overview cards are mode-specific.
+  const modeGroups = mode
+    ? groups.filter(([, group]) => group.mode === mode)
+    : groups;
+
+  // Do not show stops together with routes on compact overview cards.
+  // Stop-only disruptions still get their own card.
+  const routeGroups = compact
+    ? modeGroups.filter(([, group]) => group.isRoute)
+    : [];
+
+  const visibleGroups = routeGroups.length > 0 ? routeGroups : modeGroups;
+
   return (
     <div className="badges">
-      {Object.entries(entitiesByMode).map(
-        ([key, { mode, isRoute, entities }]) =>
-          mode && (
-            <RouteBadgeGroup
-              key={key}
-              mode={mode}
-              routes={entities.map(({ id, name, url, gtfsId }) => ({
-                id,
-                name,
-                url,
-                gtfsId,
-              }))}
-              isStop={!isRoute}
-              highlightedGtfsId={selectedFilters.entity?.gtfsId}
-            />
-          ),
-      )}
+      {visibleGroups.map(([key, { mode: groupMode, isRoute, entities }]) => {
+        if (!groupMode) {
+          return null;
+        }
+        const visibleEntities = compact
+          ? entities.slice(0, config.trafficNowMaxRoutesPerCard)
+          : entities;
+        const hiddenCount = entities.length - visibleEntities.length;
+        return (
+          <RouteBadgeGroup
+            key={key}
+            mode={groupMode}
+            routes={visibleEntities.map(({ id, name, url, gtfsId }) => ({
+              id,
+              name,
+              url,
+              gtfsId,
+            }))}
+            isStop={!isRoute}
+            highlightedGtfsId={selectedFilters.entity?.gtfsId}
+            renderSuffix={
+              hiddenCount > 0 ? (
+                <span
+                  className={`routes-m-narrow ${groupMode}`}
+                  aria-label={intl.formatMessage(
+                    { id: 'traffic-now_more-routes' },
+                    { count: hiddenCount },
+                  )}
+                >
+                  {`+${hiddenCount}`}
+                </span>
+              ) : null
+            }
+          />
+        );
+      })}
     </div>
   );
 }
 
 RouteBadges.propTypes = {
   entities: PropTypes.arrayOf(entityShape).isRequired,
+  compact: PropTypes.bool,
+  mode: PropTypes.string,
 };

--- a/app/component/trafficnow/utils.js
+++ b/app/component/trafficnow/utils.js
@@ -115,4 +115,29 @@ const getAvailableModes = config =>
     return acc;
   }, []);
 
-export { getAvailableModes, groupEntitiesByMode };
+// Returns the distinct transport modes that should get their own card for an
+// alert. If the alert has any route information, only the modes with routes are
+// returned (stops are shown only in the drill-down view). Stop-only modes are
+// returned only when the alert has no routes at all. Modes keep their
+// first-seen order.
+const getAlertModes = (entities, config) => {
+  if (!entities) {
+    return [];
+  }
+  const routeModes = [];
+  const stopModes = [];
+  Object.values(groupEntitiesByMode(entities, config)).forEach(
+    ({ mode, isRoute }) => {
+      if (!mode) {
+        return;
+      }
+      const target = isRoute ? routeModes : stopModes;
+      if (!target.includes(mode)) {
+        target.push(mode);
+      }
+    },
+  );
+  return routeModes.length > 0 ? routeModes : stopModes;
+};
+
+export { getAvailableModes, groupEntitiesByMode, getAlertModes };

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -731,8 +731,11 @@ export default {
   vehicles: false,
   showVehiclesOnStopPage: false,
   showVehiclesOnItineraryPage: false,
-  trafficNowLink: false,
+  trafficNowLink: true,
   trafficNowTest: TRAFFIC_NOW_TEST,
+  // Maximum number of routes shown per transport mode card in the Traffic now
+  // overview; any additional routes are collapsed into a "+N" badge.
+  trafficNowMaxRoutesPerCard: 5,
 
   timetables: {},
 

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -731,7 +731,7 @@ export default {
   vehicles: false,
   showVehiclesOnStopPage: false,
   showVehiclesOnItineraryPage: false,
-  trafficNowLink: true,
+  trafficNowLink: false,
   trafficNowTest: TRAFFIC_NOW_TEST,
   // Maximum number of routes shown per transport mode card in the Traffic now
   // overview; any additional routes are collapsed into a "+N" badge.

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -845,6 +845,7 @@ export default {
     'traffic-now_go-to-route-page': 'View route',
     'traffic-now_link': 'Services now',
     'traffic-now_link-description': 'See changes and disruptions',
+    'traffic-now_more-routes': '{count} more routes',
     trafficnow: 'Traffic now',
     'trafficnow-bread': 'Travelling',
     'trafficnow-description':

--- a/app/translations/fi.js
+++ b/app/translations/fi.js
@@ -830,6 +830,7 @@ export default {
     'traffic-now_go-to-route-page': 'Siirry linjasivulle',
     'traffic-now_link': 'Liikennetilanne nyt',
     'traffic-now_link-description': 'Katso häiriöt ja poikkeukset',
+    'traffic-now_more-routes': '{count} muuta linjaa',
     trafficnow: 'Liikenne nyt',
     'trafficnow-bread': 'Matkustaminen',
     'trafficnow-description': 'Ajantasaiset tiedot häiriöistä ja poikkeuksista',

--- a/app/translations/sv.js
+++ b/app/translations/sv.js
@@ -838,6 +838,7 @@ export default {
     'traffic-now_go-to-route-page': 'Visa linje',
     'traffic-now_link': 'Trafikläget nu',
     'traffic-now_link-description': 'Se störningar och förändringar',
+    'traffic-now_more-routes': '{count} fler linjer',
     trafficnow: 'Trafikläget nu',
     'trafficnow-bread': 'Att resa med oss',
     'trafficnow-description': 'Aktuell information om störningar och undantag',

--- a/test/unit/component/trafficnow/RouteBadges.test.js
+++ b/test/unit/component/trafficnow/RouteBadges.test.js
@@ -12,6 +12,7 @@ import { AlertEntityType } from '../../../../app/constants';
 const baseConfig = {
   CONFIG: 'default',
   colors: { primary: '#007ac9' },
+  trafficNowMaxRoutesPerCard: 5,
 };
 
 const makeEntity = (type, gtfsId, overrides = {}) => ({
@@ -33,10 +34,11 @@ const makeBusRouteGroup = entities => ({
 
 describe('<RouteBadges />', () => {
   let sandbox;
+  let stubs;
   let filterContextStub;
 
   beforeEach(() => {
-    ({ sandbox } = createShallowHookSandbox({ config: baseConfig }));
+    ({ sandbox, stubs } = createShallowHookSandbox({ config: baseConfig }));
     filterContextStub = sandbox
       .stub(FiltersContext, 'useFilterContext')
       .returns({
@@ -193,6 +195,138 @@ describe('<RouteBadges />', () => {
       expect(wrapper.find(RouteBadgeGroup).prop('highlightedGtfsId')).to.equal(
         'HSL:1',
       );
+    });
+  });
+
+  describe('compact mode', () => {
+    const makeRoutes = amount =>
+      Array.from({ length: amount }, (_, i) => ({
+        id: `e${i}`,
+        name: `${i}`,
+        url: `/route/HSL:${i}`,
+        gtfsId: `HSL:${i}`,
+      }));
+
+    it('limits routes to 5 and passes a renderSuffix for the hidden ones', () => {
+      sandbox.stub(trafficNowUtils, 'groupEntitiesByMode').returns({
+        bus_route: { mode: 'bus', isRoute: true, entities: makeRoutes(8) },
+      });
+      const wrapper = shallow(
+        <RouteBadges
+          compact
+          entities={[makeEntity(AlertEntityType.Route, 'HSL:1')]}
+        />,
+      );
+      const group = wrapper.find(RouteBadgeGroup);
+      expect(group.prop('routes')).to.have.lengthOf(5);
+      expect(group.prop('renderSuffix')).to.not.equal(null);
+    });
+
+    it('does not render a suffix when there are 5 or fewer routes', () => {
+      sandbox.stub(trafficNowUtils, 'groupEntitiesByMode').returns({
+        bus_route: { mode: 'bus', isRoute: true, entities: makeRoutes(5) },
+      });
+      const wrapper = shallow(
+        <RouteBadges
+          compact
+          entities={[makeEntity(AlertEntityType.Route, 'HSL:1')]}
+        />,
+      );
+      const group = wrapper.find(RouteBadgeGroup);
+      expect(group.prop('routes')).to.have.lengthOf(5);
+      expect(group.prop('renderSuffix')).to.equal(null);
+    });
+
+    it('uses the configurable trafficNowMaxRoutesPerCard limit', () => {
+      stubs.useConfigContext.returns({
+        ...baseConfig,
+        trafficNowMaxRoutesPerCard: 2,
+      });
+      sandbox.stub(trafficNowUtils, 'groupEntitiesByMode').returns({
+        bus_route: { mode: 'bus', isRoute: true, entities: makeRoutes(5) },
+      });
+      const wrapper = shallow(
+        <RouteBadges
+          compact
+          entities={[makeEntity(AlertEntityType.Route, 'HSL:1')]}
+        />,
+      );
+      const group = wrapper.find(RouteBadgeGroup);
+      expect(group.prop('routes')).to.have.lengthOf(2);
+      expect(group.prop('renderSuffix')).to.not.equal(null);
+    });
+
+    it('hides stop groups when a route group exists', () => {
+      sandbox.stub(trafficNowUtils, 'groupEntitiesByMode').returns({
+        bus_route: {
+          mode: 'bus',
+          isRoute: true,
+          entities: [{ id: '1', name: '1', url: '/route/1', gtfsId: 'HSL:1' }],
+        },
+        bus_stop: {
+          mode: 'bus',
+          isRoute: false,
+          entities: [
+            { id: '2', name: 'Stop A', url: '/stop/HSL:2', gtfsId: 'HSL:2' },
+          ],
+        },
+      });
+      const wrapper = shallow(
+        <RouteBadges
+          compact
+          entities={[makeEntity(AlertEntityType.Route, 'HSL:1')]}
+        />,
+      );
+      const groups = wrapper.find(RouteBadgeGroup);
+      expect(groups).to.have.lengthOf(1);
+      expect(groups.prop('isStop')).to.equal(false);
+    });
+
+    it('still shows stop groups when there are no route groups', () => {
+      sandbox.stub(trafficNowUtils, 'groupEntitiesByMode').returns({
+        bus_stop: {
+          mode: 'bus',
+          isRoute: false,
+          entities: [
+            { id: '2', name: 'Stop A', url: '/stop/HSL:2', gtfsId: 'HSL:2' },
+          ],
+        },
+      });
+      const wrapper = shallow(
+        <RouteBadges
+          compact
+          entities={[makeEntity(AlertEntityType.Stop, 'HSL:2')]}
+        />,
+      );
+      const groups = wrapper.find(RouteBadgeGroup);
+      expect(groups).to.have.lengthOf(1);
+      expect(groups.prop('isStop')).to.equal(true);
+    });
+  });
+
+  describe('mode filter', () => {
+    it('renders only the groups belonging to the given mode', () => {
+      sandbox.stub(trafficNowUtils, 'groupEntitiesByMode').returns({
+        bus_route: {
+          mode: 'bus',
+          isRoute: true,
+          entities: [{ id: '1', name: '1', url: '/route/1', gtfsId: 'HSL:1' }],
+        },
+        tram_route: {
+          mode: 'tram',
+          isRoute: true,
+          entities: [{ id: '2', name: '4', url: '/route/4', gtfsId: 'HSL:4' }],
+        },
+      });
+      const wrapper = shallow(
+        <RouteBadges
+          mode="tram"
+          entities={[makeEntity(AlertEntityType.Route, 'HSL:4')]}
+        />,
+      );
+      const groups = wrapper.find(RouteBadgeGroup);
+      expect(groups).to.have.lengthOf(1);
+      expect(groups.prop('mode')).to.equal('tram');
     });
   });
 });

--- a/test/unit/component/trafficnow/utils.test.js
+++ b/test/unit/component/trafficnow/utils.test.js
@@ -7,6 +7,7 @@ import { AlertEntityType, LocationTypes } from '../../../../app/constants';
 import {
   getAvailableModes,
   groupEntitiesByMode,
+  getAlertModes,
 } from '../../../../app/component/trafficnow/utils';
 
 describe('TrafficNow utils', () => {
@@ -146,6 +147,95 @@ describe('TrafficNow utils', () => {
       const grouped = groupEntitiesByMode(entities, {});
       const names = grouped.bus_stop.entities.map(e => e.name);
       expect(names).to.deep.equal(['Alpha stop', 'Middle stop', 'Zebra stop']);
+    });
+  });
+
+  describe('getAlertModes', () => {
+    beforeEach(() => {
+      sandbox
+        .stub(modeUtils, 'getRouteMode')
+        .callsFake(entity => entity?.mode?.toLowerCase() || null);
+      sandbox
+        .stub(pathUtils, 'stopPagePath')
+        .callsFake((isStation, gtfsId) => `/stop/${gtfsId}`);
+      sandbox
+        .stub(pathUtils, 'routePagePath')
+        .callsFake(gtfsId => `/route/${gtfsId}`);
+    });
+
+    it('returns each route mode once, ignoring stop groups of the same mode', () => {
+      const entities = [
+        {
+          __typename: AlertEntityType.Route,
+          id: 'r1',
+          gtfsId: 'HSL:r1',
+          mode: 'BUS',
+          shortName: '1',
+        },
+        {
+          __typename: AlertEntityType.Stop,
+          id: 's1',
+          gtfsId: 'HSL:s1',
+          vehicleMode: 'BUS',
+          locationType: LocationTypes.STOP,
+          name: 'Stop A',
+        },
+        {
+          __typename: AlertEntityType.Route,
+          id: 'r2',
+          gtfsId: 'HSL:r2',
+          mode: 'TRAM',
+          shortName: '4',
+        },
+      ];
+      expect(getAlertModes(entities, {})).to.deep.equal(['bus', 'tram']);
+    });
+
+    it('omits stop-only modes when the alert has any route information', () => {
+      const entities = [
+        {
+          __typename: AlertEntityType.Route,
+          id: 'r1',
+          gtfsId: 'HSL:r1',
+          mode: 'BUS',
+          shortName: '1',
+        },
+        {
+          __typename: AlertEntityType.Stop,
+          id: 's1',
+          gtfsId: 'HSL:s1',
+          vehicleMode: 'TRAM',
+          locationType: LocationTypes.STOP,
+          name: 'Stop A',
+        },
+      ];
+      expect(getAlertModes(entities, {})).to.deep.equal(['bus']);
+    });
+
+    it('returns stop modes only when the alert has no routes at all', () => {
+      const entities = [
+        {
+          __typename: AlertEntityType.Stop,
+          id: 's1',
+          gtfsId: 'HSL:s1',
+          vehicleMode: 'BUS',
+          locationType: LocationTypes.STOP,
+          name: 'Stop A',
+        },
+        {
+          __typename: AlertEntityType.Stop,
+          id: 's2',
+          gtfsId: 'HSL:s2',
+          vehicleMode: 'TRAM',
+          locationType: LocationTypes.STOP,
+          name: 'Stop B',
+        },
+      ];
+      expect(getAlertModes(entities, {})).to.deep.equal(['bus', 'tram']);
+    });
+
+    it('returns an empty array when entities are null', () => {
+      expect(getAlertModes(null, {})).to.deep.equal([]);
     });
   });
 });


### PR DESCRIPTION
## Proposed Changes

  - Each transport mode has its own card (for the same alert) to avoid cluttering the cards.
  - Max 5 routes are shown at a time, then  "+ number of additional hidden ones".
  - Only route-related icons are shown when alerts relate to routes as well as stops (stops are included in the drill-down view). 
  - Stop-only alerts have their own card.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
