### PR TITLE
AB#468 Add translations and fix styles of stop and route page disruption view

### DIFF
--- a/app/component/Disruption.js
+++ b/app/component/Disruption.js
@@ -9,7 +9,7 @@ import DisruptionBadge from './trafficnow/DisruptionBadge';
 import { useConfigContext } from '../configurations/ConfigContext';
 import { routePagePath, stopPagePath } from '../util/path';
 import IconBackground from './icon/IconBackground';
-import { getRouteMode } from '../util/modeUtils';
+import { getRouteMode, transitIconName } from '../util/modeUtils';
 import { getStartTimeWithColon } from '../util/timeUtils';
 import { entityShape, stopTimeShape } from '../util/shapes';
 import {
@@ -86,7 +86,7 @@ export default function Disruption({
       <div
         className="alert-row"
         role="button"
-        aria-label={alertDescriptionText}
+        aria-label={`${alertHeaderText} ${buttonLabel}`}
         onClick={toggleDetails}
         tabIndex={0}
         onKeyDown={e => {
@@ -99,22 +99,12 @@ export default function Disruption({
         }}
       >
         {toggleDetails && (
-          <button
-            type="button"
-            onClick={e => {
-              if (toggleDetails) {
-                toggleDetails();
-              }
-              e.stopPropagation();
-            }}
-            className="alert-row-arrow"
-            aria-label={buttonLabel}
-          >
+          <div className="alert-row-arrow">
             <Icon
               img="icon_arrow-collapse--right"
               color={config.colors.primary}
             />
-          </button>
+          </div>
         )}
         <div className="alert-row-top">
           <DisruptionBadge
@@ -132,12 +122,8 @@ export default function Disruption({
                 return (
                   <Fragment key={key}>
                     <Icon
-                      img={`icon_${
-                        mode.toLowerCase() === 'bus-express'
-                          ? 'bus'
-                          : mode.toLowerCase()
-                      }`}
-                      className={`${mode.toLowerCase()}`}
+                      img={transitIconName(mode)}
+                      className={mode.toLowerCase()}
                       height={2.15}
                       width={2.15}
                       iconScale={isStop ? 0.5 : 1}

--- a/app/component/Disruption.js
+++ b/app/component/Disruption.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useRouter } from 'found';
 import { useIntl } from 'react-intl';
 import { DateTime } from 'luxon';
+import cx from 'classnames';
 import Icon from './Icon';
 import DisruptionBadge from './trafficnow/DisruptionBadge';
 import { useConfigContext } from '../configurations/ConfigContext';
@@ -81,97 +82,120 @@ export default function Disruption({
         defaultMessage: 'View details',
       });
   return (
-    <div
-      className="alert-row"
-      role="listitem"
-      aria-label={alertDescriptionText}
-    >
-      {toggleDetails && (
-        <button
-          type="button"
-          onClick={() => toggleDetails()}
-          className="alert-row-arrow"
-          aria-label={buttonLabel}
-        >
-          <Icon
-            img="icon_arrow-collapse--right"
-            color={config.colors.primary}
+    <div className="alert-row-container" role="listitem">
+      <div
+        className="alert-row"
+        role="button"
+        aria-label={alertDescriptionText}
+        onClick={toggleDetails}
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === ' ' || e.key === 'Enter') {
+            if (toggleDetails) {
+              toggleDetails();
+            }
+            e.stopPropagation();
+          }
+        }}
+      >
+        {toggleDetails && (
+          <button
+            type="button"
+            onClick={e => {
+              if (toggleDetails) {
+                toggleDetails();
+              }
+              e.stopPropagation();
+            }}
+            className="alert-row-arrow"
+            aria-label={buttonLabel}
+          >
+            <Icon
+              img="icon_arrow-collapse--right"
+              color={config.colors.primary}
+            />
+          </button>
+        )}
+        <div className="alert-row-top">
+          <DisruptionBadge
+            showIcon
+            variant={alertSeverityLevel}
+            label={alertEffect || 'no_service'}
           />
-        </button>
-      )}
-      <div className="alert-row-top">
-        <DisruptionBadge
-          showIcon
-          variant={alertSeverityLevel}
-          label={alertEffect || 'no_service'}
-        />
-        {status}
-      </div>
-      <div className="alert-row-badges">
-        {groupedEntities &&
-          Object.entries(groupedEntities).map(
-            ([key, { typename, mode, items }]) => {
-              const isStop = typename === AlertEntityType.Stop;
-              return (
-                <Fragment key={key}>
-                  <Icon
-                    img={`icon_${
-                      mode.toLowerCase() === 'bus-express'
-                        ? 'bus'
-                        : mode.toLowerCase()
-                    }`}
-                    className={`${mode.toLowerCase()}`}
-                    height={2}
-                    width={2}
-                    iconScale={isStop ? 0.5 : 1}
-                    background={
-                      isStop && (
-                        <IconBackground shape="stopsign" color="currentcolor" />
-                      )
-                    }
-                  />
-                  {items.map(({ gtfsId, shortName, name, locationType }) => {
-                    const isStation = locationType === LocationTypes.STATION;
-                    return (
-                      <span key={gtfsId} className="mode-badge">
-                        <a
-                          href={
-                            isStop
-                              ? stopPagePath(isStation, gtfsId)
-                              : routePagePath(gtfsId)
-                          }
-                          onClick={e => {
-                            e.preventDefault();
-                            match.router.push(
+          {status}
+        </div>
+        <div className="alert-row-badges">
+          {groupedEntities &&
+            Object.entries(groupedEntities).map(
+              ([key, { typename, mode, items }]) => {
+                const isStop = typename === AlertEntityType.Stop;
+                return (
+                  <Fragment key={key}>
+                    <Icon
+                      img={`icon_${
+                        mode.toLowerCase() === 'bus-express'
+                          ? 'bus'
+                          : mode.toLowerCase()
+                      }`}
+                      className={`${mode.toLowerCase()}`}
+                      height={2.15}
+                      width={2.15}
+                      iconScale={isStop ? 0.5 : 1}
+                      background={
+                        isStop && (
+                          <IconBackground
+                            shape="stopsign"
+                            color="currentcolor"
+                          />
+                        )
+                      }
+                    />
+                    {items.map(({ gtfsId, shortName, name, locationType }) => {
+                      const isStation = locationType === LocationTypes.STATION;
+                      return (
+                        <span
+                          key={gtfsId}
+                          className={cx('mode-badge', mode.toLowerCase())}
+                        >
+                          <a
+                            href={
                               isStop
                                 ? stopPagePath(isStation, gtfsId)
-                                : routePagePath(gtfsId),
-                            );
-                          }}
-                        >
-                          <span>{isStop ? name : shortName}</span>
-                        </a>
-                      </span>
-                    );
-                  })}
-                </Fragment>
-              );
-            },
-          )}
-      </div>
-      <div className="alert-row-bottom">
-        <span className="alert-row-title">{alertHeaderText}</span>
-        {canceledDepartures.length > 0 && (
-          <div className="canceled-departures">
-            {canceledDepartures.map(st => (
-              <span key={st.scheduledDeparture} className="cancelation-badge">
-                <span className="canceled">
-                  {getStartTimeWithColon(st.scheduledDeparture)}
+                                : routePagePath(gtfsId)
+                            }
+                            onClick={e => {
+                              e.preventDefault();
+                              match.router.push(
+                                isStop
+                                  ? stopPagePath(isStation, gtfsId)
+                                  : routePagePath(gtfsId),
+                              );
+                            }}
+                          >
+                            <span>{isStop ? name : shortName}</span>
+                          </a>
+                        </span>
+                      );
+                    })}
+                  </Fragment>
+                );
+              },
+            )}
+        </div>
+        <div className="alert-row-bottom">
+          <span className="alert-row-title">{alertHeaderText}</span>
+          {canceledDepartures.length > 0 && (
+            <div className="canceled-departures">
+              {canceledDepartures.map(st => (
+                <span key={st.scheduledDeparture} className="cancelation-badge">
+                  <span className="canceled">
+                    {getStartTimeWithColon(st.scheduledDeparture)}
+                  </span>
                 </span>
-              </span>
-            ))}
-          </div>
-        )}
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/app/component/Disruption.js
+++ b/app/component/Disruption.js
@@ -153,28 +153,28 @@ export default function Disruption({
                     {items.map(({ gtfsId, shortName, name, locationType }) => {
                       const isStation = locationType === LocationTypes.STATION;
                       return (
-                        <span
+                        <a
                           key={gtfsId}
                           className={cx('mode-badge', mode.toLowerCase())}
-                        >
-                          <a
-                            href={
+                          href={
+                            isStop
+                              ? stopPagePath(isStation, gtfsId)
+                              : routePagePath(gtfsId)
+                          }
+                          onClick={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            match.router.push(
                               isStop
                                 ? stopPagePath(isStation, gtfsId)
-                                : routePagePath(gtfsId)
-                            }
-                            onClick={e => {
-                              e.preventDefault();
-                              match.router.push(
-                                isStop
-                                  ? stopPagePath(isStation, gtfsId)
-                                  : routePagePath(gtfsId),
-                              );
-                            }}
-                          >
+                                : routePagePath(gtfsId),
+                            );
+                          }}
+                        >
+                          <div>
                             <span>{isStop ? name : shortName}</span>
-                          </a>
-                        </span>
+                          </div>
+                        </a>
                       );
                     })}
                   </Fragment>

--- a/app/component/Disruption.js
+++ b/app/component/Disruption.js
@@ -81,12 +81,13 @@ export default function Disruption({
         id: 'disruption-view-details',
         defaultMessage: 'View details',
       });
+  const ariaLabel = hasCancelations ? alertDescriptionText : alertHeaderText;
   return (
     <div className="alert-row-container" role="listitem">
       <div
         className="alert-row"
         role="button"
-        aria-label={`${alertHeaderText} ${buttonLabel}`}
+        aria-label={`${ariaLabel} ${buttonLabel}`}
         onClick={toggleDetails}
         tabIndex={0}
         onKeyDown={e => {

--- a/app/component/DisruptionDetails.js
+++ b/app/component/DisruptionDetails.js
@@ -33,7 +33,7 @@ const DisruptionDetails = ({
           />
         </span>
         <span className="validity">
-          <Icon className="clock-icon" img="icon_clock" />
+          <Icon className="status-icon" img="icon_status" />
           <FormattedMessage id={validityLabelId} />
         </span>
       </div>

--- a/app/component/DisruptionList.js
+++ b/app/component/DisruptionList.js
@@ -161,7 +161,7 @@ const DisruptionList = ({
             <div role="list">
               {futureAlerts.map(disruption => (
                 <Disruption
-                  toggleDetails={toggleDetails}
+                  toggleDetails={() => toggleDetails(disruption.id)}
                   key={disruption.id}
                   {...disruption}
                 />

--- a/app/component/DisruptionList.js
+++ b/app/component/DisruptionList.js
@@ -59,6 +59,7 @@ const DisruptionList = ({
 }) => {
   const { match, router } = useRouter();
   const breakpoint = useBreakpoint();
+  const intl = useIntl();
 
   // if a valid alertId is present in url query, show alert details
   const activeAlert =
@@ -167,12 +168,13 @@ const DisruptionList = ({
               ))}
             </div>
           ) : (
-            <p className="alerts-list-section-no-alerts">
-              <FormattedMessage
-                id="disruption-list-no-upcoming-alerts"
-                defaultMessage="No known upcoming disruptions or diversions"
-              />
-            </p>
+            <div className="alerts-list-section-no-alerts">
+              <Icon img="icon_info" />
+              {intl.formatMessage({
+                id: 'disruption-list-no-upcoming-alerts',
+                defaultMessage: 'No known upcoming disruptions or diversions',
+              })}
+            </div>
           )}
         </div>
       </div>

--- a/app/component/disruption.scss
+++ b/app/component/disruption.scss
@@ -21,8 +21,6 @@
 }
 
 .alerts-list-wrapper {
-  margin-top: 14px;
-
   &.bp-large {
     flex: 1;
     display: flex;
@@ -36,6 +34,8 @@
 }
 
 .alert-details {
+  margin-top: 16px;
+
   .alert-details-header {
     min-height: 56px;
     display: flex;
@@ -60,21 +60,27 @@
 
       .icon-container {
         padding-right: 8px;
+        display: flex;
+        align-items: center;
+        color: $theme-primary-color;
       }
     }
   }
 
   .alert-details-content {
     padding: 24px 64px 24px 64px;
+
+    h2 {
+      font-size: 18px;
+    }
   }
 
   .alert-url {
     color: $theme-primary-color;
-    margin-left: 5px;
 
     .external-link-container {
       border-radius: 999em;
-      padding: 0 24px 0 24px;
+      padding: 0 var(--space-m);
     }
 
     .external-link {
@@ -84,7 +90,7 @@
 }
 
 .alerts-list {
-  padding: 24px 48px 24px 48px;
+  padding: var(--space-m) var(--space-xl);
   background: $background-color-lighter;
   padding-bottom: 0.7em;
   flex: 1;
@@ -105,16 +111,37 @@
   }
 
   .alerts-list-section-no-alerts {
+    padding: var(--space-xs) var(--space-s);
     text-align: center;
+    border-radius: var(--radius-s);
+    border: 1px solid var(--color-border-weak);
+    background: var(--color-surface-default);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-xs);
+    font-weight: $font-weight-book;
+    font-size: 14px;
+
+    .icon-container {
+      color: $theme-primary-color;
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  .alert-row:hover {
+    border: 1px solid #0074bf;
+    cursor: pointer;
   }
 
   .alert-row {
     background-color: $white;
-    padding: 24px 24px 24px 24px;
+    padding: var(--space-m);
     position: relative;
     border-radius: 8px;
     margin-bottom: 16px;
-    box-shadow: 0 2px 4px 0 #3333;
+    border: 1px solid $light-gray;
 
     .alert-row-arrow {
       position: absolute;
@@ -179,7 +206,7 @@
     .cancelation-badge {
       border-radius: 4px;
       margin-right: 2px;
-      padding: var(--space-xxs) var(--space-xs) var(--space-xxs) var(--space-xs);
+      padding: var(--space-xxs) var(--space-xs);
       border: 1px solid $light-gray;
       font-weight: $font-weight-book;
       color: $gray;
@@ -201,7 +228,7 @@
 
       .mode-badge {
         max-height: 32px;
-        background-color: $info-background-color;
+        background-color: color-mix(in srgb, currentcolor, white 90%);
         border-radius: 4px;
         padding: 4px 8px 4px 8px;
         min-width: 30px;
@@ -211,13 +238,17 @@
           color: black;
         }
       }
+
+      .mode-badge:hover {
+        background-color: color-mix(in srgb, currentcolor, white 90%);
+      }
     }
   }
 }
 
 .mobile {
   .alerts-list {
-    padding: 0 16px 0 16px;
+    padding: 16px;
   }
 
   .alert-details {

--- a/app/component/disruption.scss
+++ b/app/component/disruption.scss
@@ -240,7 +240,7 @@
       }
 
       .mode-badge:hover {
-        background-color: color-mix(in srgb, currentcolor, white 90%);
+        background-color: color-mix(in srgb, currentcolor, white 80%);
       }
     }
   }

--- a/app/component/disruption.scss
+++ b/app/component/disruption.scss
@@ -131,7 +131,7 @@
   }
 
   .alert-row:hover {
-    border: 1px solid #0074bf;
+    border: 1px solid $theme-primary-color;
     cursor: pointer;
   }
 

--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -100,6 +100,7 @@ div.map {
       .content-container {
         position: relative;
         top: -15px;
+        margin-bottom: -15px;
         box-shadow: 0 -10px 10px -10px rgba(0, 0, 0, 0.3);
         border-radius: 15px 15px 0 0;
         padding-top: 15px;

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -191,11 +191,11 @@ export default {
     'disruption-info-no-alerts': 'No known disruptions or diversions.',
     'disruption-info-route-no-alerts':
       'No known disruptions or diversions to the route.',
-    'disruption-list-active': 'Active',
-    'disruption-list-no-active-alerts': 'No known active disruptions',
+    'disruption-list-active': 'Ongoing',
+    'disruption-list-no-active-alerts': 'No known ongoing disruptions',
     'disruption-list-no-upcoming-alerts':
       'No known upcoming disruptions or diversions',
-    'disruption-list-traffic-normal': 'Traffic normal',
+    'disruption-list-traffic-normal': 'Services normal',
     'disruption-list-upcoming': 'Upcoming',
     'disruption-view-details': 'View details',
     'disruption-view-timetable': 'View timetable',

--- a/app/translations/sv.js
+++ b/app/translations/sv.js
@@ -189,14 +189,14 @@ export default {
     'disruption-info-no-alerts': 'Inga kända störningar eller avvikelser.',
     'disruption-info-route-no-alerts':
       'Linjen har för tillfället inga kända störningar eller avvikelser.',
-    'disruption-list-active': 'Aktiva',
-    'disruption-list-no-active-alerts': 'Inga kända aktiva störningar',
+    'disruption-list-active': 'Aktuella',
+    'disruption-list-no-active-alerts': 'Inga kända störningar',
     'disruption-list-no-upcoming-alerts':
       'Inga kända kommande störningar eller avvikelser',
-    'disruption-list-traffic-normal': 'Trafik normal',
+    'disruption-list-traffic-normal': 'Normal trafik',
     'disruption-list-upcoming': 'Kommande',
-    'disruption-view-details': 'View details',
-    'disruption-view-timetable': 'View timetable',
+    'disruption-view-details': 'Mer information',
+    'disruption-view-timetable': 'Öppna tidtabell',
     disruptions: 'Störningar',
     'disruptions-and-diversions': 'Störningar och avvikelser',
     'disruptions-change-filters': 'Försök igen genom att ändra dina val.',
@@ -242,7 +242,8 @@ export default {
     'from-tram': 'spårvagnen',
     frontpage: 'Framsidan',
     funicular: 'Bergbanan',
-    'generic-cancelation': '{mode} {route} {headsign} ställs in kl. {times} .',
+    'generic-cancelation':
+      '{mode} {route} {headsign} har ställs in kl. {times}',
     'generic-error': 'Det hände ett fel',
     'geolocation-denied-heading': 'Delning av platsinformation är förbjudet',
     'geolocation-denied-text':

--- a/test/unit/component/Disruption.test.js
+++ b/test/unit/component/Disruption.test.js
@@ -119,7 +119,7 @@ describe('<Disruption />', () => {
     expect(
       wrapper.find(Icon).findWhere(n => n.prop('className') === 'bus'),
     ).to.have.lengthOf(1);
-    const link = wrapper.find('.mode-badge a');
+    const link = wrapper.find('.mode-badge');
     expect(link).to.have.lengthOf(1);
     expect(link.prop('href')).to.equal(routePagePath('HSL:2097N'));
     expect(link.find('span').text()).to.equal('97N');
@@ -135,7 +135,7 @@ describe('<Disruption />', () => {
     const wrapper = shallowWithIntl(<Disruption {...props} />, {
       context: mockContext,
     });
-    const link = wrapper.find('.mode-badge a');
+    const link = wrapper.find('.mode-badge');
     expect(link).to.have.lengthOf(1);
     expect(link.prop('href')).to.equal(
       `/${PREFIX_STOPS}/${encodeURIComponent('HSL:1234')}`,
@@ -153,7 +153,7 @@ describe('<Disruption />', () => {
     const wrapper = shallowWithIntl(<Disruption {...props} />, {
       context: mockContext,
     });
-    const link = wrapper.find('.mode-badge a');
+    const link = wrapper.find('.mode-badge');
     expect(link.prop('href')).to.equal(
       `/${PREFIX_TERMINALS}/${encodeURIComponent('HSL:5678')}`,
     );


### PR DESCRIPTION
## Proposed Changes

  - Replaces placeholder translations with proper ones
  - fix minor spacing issues
  - route badge background corresponds to the mode
  - remove shadow from disruption card, adds a border and a hover effect, make the whole item clickable

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
