### PR TITLE
AB#605 reactivation of personalization

### DIFF
--- a/app/component/404.js
+++ b/app/component/404.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { FormattedMessage } from 'react-intl';
 import Link from 'found/Link';
-import { configShape } from '../util/shapes';
 import Icon from './Icon';
+import { useConfigContext } from '../configurations/ConfigContext';
 
-const Error404 = (props, { config }) => {
-  const { error } = props;
+export default function Error404({ error }) {
+  const config = useConfigContext();
 
   return (
     <div className="page-not-found">
@@ -48,11 +47,7 @@ const Error404 = (props, { config }) => {
       </p>
     </div>
   );
-};
-
-Error404.contextTypes = {
-  config: configShape.isRequired,
-};
+}
 
 Error404.propTypes = {
   error: PropTypes.shape({
@@ -61,11 +56,3 @@ Error404.propTypes = {
     values: PropTypes.object,
   }),
 };
-
-Error404.defaultProps = {
-  error: undefined,
-};
-
-Error404.displayName = 'Error404';
-
-export default Error404;

--- a/app/component/AboutPage.js
+++ b/app/component/AboutPage.js
@@ -1,16 +1,13 @@
-import PropTypes from 'prop-types';
 /* eslint-disable react/no-array-index-key */
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Link from 'found/Link';
 import { FormattedMessage } from 'react-intl';
-import connectToStores from 'fluxible-addons-react/connectToStores';
-import { configShape } from '../util/shapes';
+import { useConfigContext } from '../configurations/ConfigContext';
 
-const AboutPage = ({ currentLanguage }, { config }) => {
-  const [about, setAbout] = useState([]);
-  useEffect(() => {
-    setAbout(config.aboutThisService[currentLanguage]);
-  }, []);
+export default function AboutPage() {
+  const config = useConfigContext();
+  const about = config.aboutThisService[config.language];
+
   return (
     <div className="about-page fullscreen">
       <div className="page-frame fullscreen momentum-scroll">
@@ -50,22 +47,4 @@ const AboutPage = ({ currentLanguage }, { config }) => {
       </div>
     </div>
   );
-};
-
-AboutPage.propTypes = {
-  currentLanguage: PropTypes.string.isRequired,
-};
-
-AboutPage.contextTypes = {
-  config: configShape.isRequired,
-};
-
-const connectedComponent = connectToStores(
-  AboutPage,
-  ['PreferencesStore'],
-  context => ({
-    currentLanguage: context.getStore('PreferencesStore').getLanguage(),
-  }),
-);
-
-export { connectedComponent as default, AboutPage as Component };
+}

--- a/app/component/AddressRow.js
+++ b/app/component/AddressRow.js
@@ -4,18 +4,23 @@ import { useIntl } from 'react-intl';
 import StopCode from './StopCode';
 import { getTerminalOrStationText } from '../util/modeUtils';
 
-const AddressRow = props => {
+export default function AddressRow({
+  desc,
+  code,
+  isTerminal = false,
+  vehicleMode,
+}) {
   const intl = useIntl();
   return (
     <div className="route-address-row-container">
-      <span className="route-stop-address-row">{props.desc}</span>
-      {props.code && <StopCode code={props.code} />}
-      {props.isTerminal && (
-        <StopCode code={getTerminalOrStationText(intl, props.vehicleMode)} />
+      <span className="route-stop-address-row">{desc}</span>
+      {code && <StopCode code={code} />}
+      {isTerminal && (
+        <StopCode code={getTerminalOrStationText(intl, vehicleMode)} />
       )}
     </div>
   );
-};
+}
 
 AddressRow.propTypes = {
   desc: PropTypes.string,
@@ -23,12 +28,3 @@ AddressRow.propTypes = {
   isTerminal: PropTypes.bool,
   vehicleMode: PropTypes.string,
 };
-
-AddressRow.defaultProps = {
-  desc: undefined,
-  code: undefined,
-  isTerminal: false,
-  vehicleMode: undefined,
-};
-
-export default AddressRow;

--- a/app/component/AlertBanner.js
+++ b/app/component/AlertBanner.js
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'found';
 import TruncateMarkup from 'react-truncate-markup';
-import { alertShape, configShape } from '../util/shapes';
+import { alertShape } from '../util/shapes';
 import Icon from './Icon';
 import { alertSeverityCompare } from '../util/alertUtils';
+import { useConfigContext } from '../configurations/ConfigContext';
 
-const AlertBanner = ({ alerts, linkAddress }, { config }) => {
+export default function AlertBanner({ alerts, linkAddress }) {
+  const { colors } = useConfigContext();
   const alert = [...alerts].sort(alertSeverityCompare)[0];
   const message = alert.alertDescriptionText;
   const header = alert.alertHeaderText;
@@ -18,7 +20,7 @@ const AlertBanner = ({ alerts, linkAddress }, { config }) => {
       ? 'icon_caution_white_exclamation'
       : 'icon_info';
   const iconColor =
-    alert.alertSeverityLevel !== 'INFO' ? config.colors.caution : '#888';
+    alert.alertSeverityLevel !== 'INFO' ? colors.caution : '#888';
   return (
     <Link
       className={`alert-banner-link ${alert.alertSeverityLevel.toLowerCase()}`}
@@ -35,22 +37,14 @@ const AlertBanner = ({ alerts, linkAddress }, { config }) => {
           </TruncateMarkup>
         </div>
         <div className="arrow-icon">
-          <Icon
-            img="icon_arrow-collapse--right"
-            color={config.colors.primary}
-          />
+          <Icon img="icon_arrow-collapse--right" color={colors.primary} />
         </div>
       </div>
     </Link>
   );
-};
+}
 
 AlertBanner.propTypes = {
   alerts: PropTypes.arrayOf(alertShape).isRequired,
   linkAddress: PropTypes.string.isRequired,
 };
-
-AlertBanner.contextTypes = {
-  config: configShape.isRequired,
-};
-export default AlertBanner;

--- a/app/component/DatetimepickerContainer.js
+++ b/app/component/DatetimepickerContainer.js
@@ -1,33 +1,49 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import { matchShape, routerShape } from 'found';
+import React, { useEffect, useMemo } from 'react';
+import { useRouter } from 'found';
 import debounce from 'lodash/debounce';
-import { connectToStores } from 'fluxible-addons-react';
 import Datetimepicker from '@digitransit-component/digitransit-component-datetimepicker';
-import { configShape } from '../util/shapes';
 import { replaceQueryParams } from '../util/queryUtils';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
+import { useConfigContext } from '../configurations/ConfigContext';
 
-function DatetimepickerContainer(
-  { realtime, embedWhenClosed, embedWhenOpen, lang, color },
-  context,
-) {
-  const { router, match, config } = context;
+export default function DatetimepickerContainer({
+  realtime,
+  embedWhenClosed = null,
+  embedWhenOpen = null,
+}) {
+  const config = useConfigContext();
+  const { match, router } = useRouter();
   const openPicker = !!match.location.query.setTime; // string to boolean
 
-  const setParams = debounce((time, arriveBy, setTime) => {
-    replaceQueryParams(router, match, {
-      time: time?.toString(),
-      arriveBy,
-      setTime,
-    });
-  }, 10);
+  const setParams = useMemo(
+    () =>
+      debounce((time, arriveBy, setTime) => {
+        replaceQueryParams(router, match, {
+          time: time?.toString(),
+          arriveBy,
+          setTime,
+        });
+      }, 10),
+    [router, match],
+  );
 
-  const setOpenParam = debounce(setTime => {
-    replaceQueryParams(router, match, {
-      setTime,
-    });
-  }, 10);
+  const setOpenParam = useMemo(
+    () =>
+      debounce(setTime => {
+        replaceQueryParams(router, match, {
+          setTime,
+        });
+      }, 10),
+    [router, match],
+  );
+
+  useEffect(() => {
+    return () => {
+      setParams.cancel();
+      setOpenParam.cancel();
+    };
+  }, [setParams, setOpenParam]);
 
   const onClose = () => {
     setOpenParam(undefined);
@@ -101,10 +117,10 @@ function DatetimepickerContainer(
       onArrivalClick={onArrivalClick}
       embedWhenClosed={embedWhenClosed}
       embedWhenOpen={embedWhenOpen}
-      lang={lang}
-      color={color}
+      lang={config.language}
+      color={config.colors.primary}
       timeZone={config.timeZone}
-      serviceTimeRange={context.config.itinerary.serviceTimeRange}
+      serviceTimeRange={config.itinerary.serviceTimeRange}
       fontWeights={config.fontWeights}
       onOpen={onOpen}
       onClose={onClose}
@@ -117,28 +133,4 @@ DatetimepickerContainer.propTypes = {
   realtime: PropTypes.bool.isRequired,
   embedWhenClosed: PropTypes.node,
   embedWhenOpen: PropTypes.node,
-  lang: PropTypes.string.isRequired,
-  color: PropTypes.string,
 };
-
-DatetimepickerContainer.defaultProps = {
-  embedWhenClosed: null,
-  embedWhenOpen: null,
-  color: '#007ac9',
-};
-
-DatetimepickerContainer.contextTypes = {
-  router: routerShape.isRequired,
-  match: matchShape.isRequired,
-  config: configShape.isRequired,
-};
-
-const withLang = connectToStores(
-  DatetimepickerContainer,
-  ['PreferencesStore'],
-  context => ({
-    lang: context.getStore('PreferencesStore').getLanguage(),
-  }),
-);
-
-export { withLang as default, DatetimepickerContainer as Component };

--- a/app/component/ExternalLink.js
+++ b/app/component/ExternalLink.js
@@ -6,9 +6,9 @@ export default function ExternalLink({
   name,
   children,
   href,
-  className,
+  className = '',
   onClick,
-  withArrow,
+  withArrow = false,
 }) {
   return (
     (name || children !== undefined) && (
@@ -45,14 +45,3 @@ ExternalLink.propTypes = {
   onClick: PropTypes.func,
   withArrow: PropTypes.bool,
 };
-
-ExternalLink.defaultProps = {
-  name: undefined,
-  children: undefined,
-  href: undefined,
-  onClick: undefined,
-  className: '',
-  withArrow: false,
-};
-
-ExternalLink.displayName = 'ExternalLink';

--- a/app/component/FavouriteStopContainer.js
+++ b/app/component/FavouriteStopContainer.js
@@ -29,10 +29,7 @@ function FavouriteStopContainerComponent(props, context) {
           gid += `#${stop.code}`;
         }
 
-        getJson(config.URL.PELIAS_PLACE, {
-          ids: gid,
-          // lang: context.getStore('PreferencesStore').getLanguage(), TODO enable this when OTP supports translations
-        })
+        getJson(config.URL.PELIAS_PLACE, { ids: gid })
           .then(res => {
             if (Array.isArray(res.features) && res.features.length > 0) {
               const stopOrStation = res.features[0];

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -365,11 +365,7 @@ function IndexPage(props, context) {
             />
           </span>
           <LocationSearch {...locationSearchProps} />
-          <DatetimepickerContainer
-            realtime
-            color={colors.primary}
-            lang={language}
-          />
+          <DatetimepickerContainer realtime />
           {!config.hideFavourites && (
             <>
               <FavouritesContainer
@@ -420,11 +416,7 @@ function IndexPage(props, context) {
       >
         <CtrlPanel position="bottom" fontWeights={fontWeights}>
           <LocationSearch disableAutoFocus isMobile {...locationSearchProps} />
-          <DatetimepickerContainer
-            realtime
-            color={colors.primary}
-            lang={language}
-          />
+          <DatetimepickerContainer realtime />
           <FavouritesContainer
             onClickFavourite={clickFavourite}
             lang={language}

--- a/app/component/LoginPrompt.js
+++ b/app/component/LoginPrompt.js
@@ -2,8 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Modal, ModalContent } from '@hsl-fi/dialog';
 import { useIntl } from 'react-intl';
+import { useRouter } from 'found';
 import { useConfigContext } from '../configurations/ConfigContext';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
+import { getLoginPath } from '../util/path';
 
 export default function LoginPrompt({
   open,
@@ -13,6 +15,7 @@ export default function LoginPrompt({
 }) {
   const intl = useIntl();
   const config = useConfigContext();
+  const { match } = useRouter();
 
   const login = intl.formatMessage({
     id: 'login',
@@ -34,7 +37,7 @@ export default function LoginPrompt({
       action: 'login',
       name: null,
     });
-    window.location.assign('/login');
+    window.location.assign(getLoginPath(match.location));
   };
 
   const handleSecondaryClick = () => {

--- a/app/component/MainMenuLinks.js
+++ b/app/component/MainMenuLinks.js
@@ -3,41 +3,37 @@ import React from 'react';
 import MenuItem from './MenuItem';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
 
-const MainMenuLinks = ({ closeMenu, content }) => (
-  <div>
-    {content.map(link =>
-      Object.keys(link).length === 0 ? (
-        <span key="separator" />
-      ) : (
-        <div key={link.label || link.name} className="offcanvas-section">
-          <MenuItem
-            onClick={() => {
-              if (link.label || link.name) {
-                addAnalyticsEvent({
-                  category: 'Navigation',
-                  action: 'OpenMainMenuLink',
-                  name: link.label || link.name,
-                });
-              }
-              if (link.route) {
-                closeMenu();
-              }
-            }}
-            {...link}
-          />
-        </div>
-      ),
-    )}
-  </div>
-);
+export default function MainMenuLinks({ closeMenu, content = [] }) {
+  return (
+    <div>
+      {content.map(link =>
+        Object.keys(link).length === 0 ? (
+          <span key="separator" />
+        ) : (
+          <div key={link.label || link.name} className="offcanvas-section">
+            <MenuItem
+              onClick={() => {
+                if (link.label || link.name) {
+                  addAnalyticsEvent({
+                    category: 'Navigation',
+                    action: 'OpenMainMenuLink',
+                    name: link.label || link.name,
+                  });
+                }
+                if (link.route) {
+                  closeMenu();
+                }
+              }}
+              {...link}
+            />
+          </div>
+        ),
+      )}
+    </div>
+  );
+}
 
 MainMenuLinks.propTypes = {
   content: PropTypes.arrayOf(PropTypes.shape(MenuItem.propTypes)),
   closeMenu: PropTypes.func.isRequired,
 };
-
-MainMenuLinks.defaultProps = {
-  content: [],
-};
-
-export default MainMenuLinks;

--- a/app/component/MenuItem.js
+++ b/app/component/MenuItem.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { routerShape } from 'found';
+import { useRouter } from 'found';
 
 const mapToLink = (href, children, onClick) => (
   <span className="cursor-pointer">
@@ -26,11 +26,9 @@ const mapToRoute = (router, route, children, onClick) => (
   </button>
 );
 
-export default function MenuItem(
-  { name, href, label, route, onClick },
-  { router },
-) {
+export default function MenuItem({ name, href, label, route, onClick }) {
   const intl = useIntl();
+  const { router } = useRouter();
   const displayLabel = label || (
     <FormattedMessage id={name} defaultMessage={name} />
   );
@@ -59,17 +57,3 @@ MenuItem.propTypes = {
   label: PropTypes.string,
   onClick: PropTypes.func,
 };
-
-MenuItem.defaultProps = {
-  name: undefined,
-  href: undefined,
-  route: undefined,
-  label: undefined,
-  onClick: undefined,
-};
-
-MenuItem.contextTypes = {
-  router: routerShape.isRequired,
-};
-
-MenuItem.displayName = 'MenuItem';

--- a/app/component/RentalVehicleContent.js
+++ b/app/component/RentalVehicleContent.js
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
-import connectToStores from 'fluxible-addons-react/connectToStores';
 import { FormattedMessage } from 'react-intl';
-import { routerShape } from 'found';
+import { useRouter } from 'found';
 import Icon from './Icon';
 import withBreakpoint from '../util/withBreakpoint';
 import {
@@ -14,16 +13,26 @@ import { PREFIX_RENTALVEHICLES } from '../util/path';
 import VehicleRentalLeg from './itinerary/VehicleRentalLeg';
 import BackButton from './BackButton';
 import { rentalVehicleShape } from '../util/shapes';
+import { useConfigContext } from '../configurations/ConfigContext';
 
-const RentalVehicleContent = (
-  { rentalVehicle, breakpoint, router, error, language, match },
-  { config },
-) => {
+function RentalVehicleContent({
+  rentalVehicle,
+  breakpoint,
+  error = undefined,
+}) {
   const [isClient, setClient] = useState(false);
+  const config = useConfigContext();
+  const { match, router } = useRouter();
 
   useEffect(() => {
     setClient(true);
-  });
+  }, []);
+
+  useEffect(() => {
+    if (!rentalVehicle && !error) {
+      router.replace(`/${PREFIX_RENTALVEHICLES}`);
+    }
+  }, [rentalVehicle, error, router]);
 
   const networks = match.params.networks?.split(',');
 
@@ -33,14 +42,15 @@ const RentalVehicleContent = (
   }
 
   if (!rentalVehicle && !error) {
-    router.replace(`/${PREFIX_RENTALVEHICLES}`);
     return null;
   }
+
   const networkConfig = getRentalNetworkConfig(
     rentalVehicle.rentalNetwork.networkId,
     config,
   );
   const vehicleIcon = getRentalNetworkIcon(networkConfig);
+  const { language } = config;
 
   if (networks) {
     return (
@@ -98,66 +108,39 @@ const RentalVehicleContent = (
       </div>
     </div>
   );
-};
+}
 
 RentalVehicleContent.propTypes = {
-  rentalVehicle: rentalVehicleShape.isRequired,
+  rentalVehicle: rentalVehicleShape,
   breakpoint: PropTypes.string.isRequired,
-  router: routerShape.isRequired,
   error: PropTypes.shape({
     message: PropTypes.string,
   }),
-  language: PropTypes.string.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      networks: PropTypes.string,
-    }),
-  }),
-};
-
-RentalVehicleContent.defaultProps = {
-  error: undefined,
-  match: undefined,
-};
-
-RentalVehicleContent.contextTypes = {
-  config: PropTypes.shape({
-    text: PropTypes.string,
-  }).isRequired,
 };
 
 const RentalVehicleContentWithBreakpoint = withBreakpoint(RentalVehicleContent);
 
-const connectedComponent = connectToStores(
+const containerComponent = createFragmentContainer(
   RentalVehicleContentWithBreakpoint,
-  ['PreferencesStore'],
-  ({ getStore }) => {
-    const language = getStore('PreferencesStore').getLanguage();
-    return { language };
+  {
+    rentalVehicle: graphql`
+      fragment RentalVehicleContent_rentalVehicle on RentalVehicle {
+        lat
+        lon
+        name
+        vehicleId
+        rentalUris {
+          android
+          ios
+          web
+        }
+        rentalNetwork {
+          networkId
+          url
+        }
+      }
+    `,
   },
 );
 
-const containerComponent = createFragmentContainer(connectedComponent, {
-  rentalVehicle: graphql`
-    fragment RentalVehicleContent_rentalVehicle on RentalVehicle {
-      lat
-      lon
-      name
-      vehicleId
-      rentalUris {
-        android
-        ios
-        web
-      }
-      rentalNetwork {
-        networkId
-        url
-      }
-    }
-  `,
-});
-
-export {
-  containerComponent as default,
-  RentalVehicleContentWithBreakpoint as Component,
-};
+export default containerComponent;

--- a/app/component/Toggle.js
+++ b/app/component/Toggle.js
@@ -1,11 +1,15 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
-export default function Toggle({ toggled, title, onToggle, id }) {
+const Toggle = forwardRef(function Toggle(
+  { toggled = true, title, onToggle, id },
+  ref,
+) {
   return (
     <div className="option-toggle-container" title={title}>
       <div className="toggle">
         <input
+          ref={ref}
           type="checkbox"
           id={id}
           checked={toggled}
@@ -21,7 +25,7 @@ export default function Toggle({ toggled, title, onToggle, id }) {
       </div>
     </div>
   );
-}
+});
 
 Toggle.propTypes = {
   toggled: PropTypes.bool,
@@ -30,7 +34,4 @@ Toggle.propTypes = {
   id: PropTypes.string.isRequired,
 };
 
-Toggle.defaultProps = {
-  toggled: true,
-  title: undefined,
-};
+export default Toggle;

--- a/app/component/itinerary/Feedback.js
+++ b/app/component/itinerary/Feedback.js
@@ -124,18 +124,16 @@ export default function Feedback({
   }, []);
 
   const handleGiveFeedback = value => {
-    if (giveFeedback) {
-      if (isAnimating) {
-        return;
-      }
-
-      setIsAnimating(true);
-      timerRef.current = setTimeout(() => {
-        setIsAnimating(false);
-        panelRef.current?.focus();
-      }, ANIMATION_MS);
-      giveFeedback(value);
+    if (!giveFeedback || isAnimating) {
+      return;
     }
+
+    setIsAnimating(true);
+    timerRef.current = setTimeout(() => {
+      setIsAnimating(false);
+      panelRef.current?.focus();
+    }, ANIMATION_MS);
+    giveFeedback(value);
   };
 
   let status;

--- a/app/component/itinerary/Feedback.js
+++ b/app/component/itinerary/Feedback.js
@@ -2,14 +2,19 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import React, { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useRouter } from 'found';
+import ExternalLink from '../ExternalLink';
 import Icon from '../Icon';
 import { useConfigContext } from '../../configurations/ConfigContext';
+import { getLoginPath } from '../../util/path';
 
 const ANIMATION_MS = 1200;
 
 function FeedbackLayer({ recommended, status, giveFeedback, animationClass }) {
-  const { colors } = useConfigContext();
+  const config = useConfigContext();
+  const { colors } = config;
   const intl = useIntl();
+  const { match } = useRouter();
 
   const favIcon = recommended
     ? 'icon_star-with-circle'
@@ -27,6 +32,22 @@ function FeedbackLayer({ recommended, status, giveFeedback, animationClass }) {
     },
   };
   const iconProps = iconMap[status];
+  const loginNeeded = config.allowLogin && !config.user.sub;
+  const thumbColor = loginNeeded ? '#CCC' : colors.primary;
+
+  const middleTexts = loginNeeded ? (
+    <div>
+      <FormattedMessage id={status} />
+      <ExternalLink
+        onClick={() => window.location.assign(getLoginPath(match.location))}
+        withArrow
+      >
+        <FormattedMessage id="personalization-login-for-voting" />
+      </ExternalLink>
+    </div>
+  ) : (
+    <FormattedMessage id={status} />
+  );
 
   return (
     <div className={cx('feedback-layer', animationClass)}>
@@ -38,28 +59,27 @@ function FeedbackLayer({ recommended, status, giveFeedback, animationClass }) {
         >
           <Icon {...iconProps} height={1.4} width={1.4} />
           <span>&nbsp;&nbsp;&nbsp;</span>
-          <FormattedMessage id={status} />
+          {middleTexts}
         </div>
         {status === 'personalization-ask' && (
           <div className="feedback-section">
             <button
               type="button"
-              className="thumb-button"
+              className={cx('thumb-button', {
+                'thumb-button-disabled': loginNeeded,
+              })}
               onClick={() => giveFeedback(true)}
               aria-label={intl.formatMessage({
                 id: 'personalization-aria-like',
               })}
             >
-              <Icon
-                img="icon_thumb"
-                color={colors.primary}
-                height={1}
-                width={1}
-              />
+              <Icon img="icon_thumb" color={thumbColor} height={1} width={1} />
             </button>
             <button
               type="button"
-              className="thumb-button"
+              className={cx('thumb-button', {
+                'thumb-button-disabled': loginNeeded,
+              })}
               onClick={() => giveFeedback(false)}
               aria-label={intl.formatMessage({
                 id: 'personalization-aria-dislike',
@@ -67,7 +87,7 @@ function FeedbackLayer({ recommended, status, giveFeedback, animationClass }) {
             >
               <Icon
                 img="icon_thumb-down"
-                color={colors.primary}
+                color={thumbColor}
                 height={1}
                 width={1}
               />
@@ -104,16 +124,18 @@ export default function Feedback({
   }, []);
 
   const handleGiveFeedback = value => {
-    if (isAnimating) {
-      return;
-    }
+    if (giveFeedback) {
+      if (isAnimating) {
+        return;
+      }
 
-    setIsAnimating(true);
-    timerRef.current = setTimeout(() => {
-      setIsAnimating(false);
-      panelRef.current?.focus();
-    }, ANIMATION_MS);
-    giveFeedback(value);
+      setIsAnimating(true);
+      timerRef.current = setTimeout(() => {
+        setIsAnimating(false);
+        panelRef.current?.focus();
+      }, ANIMATION_MS);
+      giveFeedback(value);
+    }
   };
 
   let status;
@@ -160,5 +182,5 @@ export default function Feedback({
 Feedback.propTypes = {
   recommended: PropTypes.bool,
   feedback: PropTypes.bool,
-  giveFeedback: PropTypes.func.isRequired,
+  giveFeedback: PropTypes.func,
 };

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -32,6 +32,7 @@ import { streetHash } from '../../util/path';
 import { itineraryShape, relayShape } from '../../util/shapes';
 import { getFutureText } from '../../util/timeUtils';
 import { BreakpointConsumer } from '../../util/withBreakpoint';
+import { getSettings } from '../../util/planParamUtil';
 import BackButton from '../BackButton';
 import Emissions from './Emissions';
 import EmissionsInfo from './EmissionsInfo';
@@ -113,8 +114,11 @@ function ItineraryDetails({
     match.params.hash !== streetHash.walk &&
     match.params.hash !== streetHash.bike;
 
+  const settings = getSettings(config);
   const shouldShowFeedback =
-    config.personalization && itinerary.legs.some(l => l.transitLeg);
+    itinerary.legs.some(l => l.transitLeg) &&
+    config.personalization &&
+    settings.personalization; // user has not turned it off
 
   const fares = getFaresFromLegs(itinerary.legs, config);
   const extraProps = getExtraProps(itinerary, intl);

--- a/app/component/itinerary/ItineraryDetails.js
+++ b/app/component/itinerary/ItineraryDetails.js
@@ -114,7 +114,7 @@ function ItineraryDetails({
     match.params.hash !== streetHash.bike;
 
   const shouldShowFeedback =
-    giveFeedback && itinerary.legs.some(l => l.transitLeg);
+    config.personalization && itinerary.legs.some(l => l.transitLeg);
 
   const fares = getFaresFromLegs(itinerary.legs, config);
   const extraProps = getExtraProps(itinerary, intl);

--- a/app/component/itinerary/SearchSettings.js
+++ b/app/component/itinerary/SearchSettings.js
@@ -27,7 +27,6 @@ export default function SearchSettings({ toggleSettings }) {
             </div>
           </div>
         }
-        color={config.colors.primary}
       />
     </div>
   );

--- a/app/component/itinerary/TransitLeg.js
+++ b/app/component/itinerary/TransitLeg.js
@@ -70,7 +70,7 @@ const filterNextLegs = l => {
 
 export default function TransitLeg({
   leg,
-  interliningLegs,
+  interliningLegs = [],
   index,
   mode,
   focusAction,

--- a/app/component/itinerary/customizesearch/Personalization.js
+++ b/app/component/itinerary/customizesearch/Personalization.js
@@ -23,6 +23,7 @@ export default function Personalization({ settings, updateSettings }) {
   const [snackbarLiveRegionMessage, setSnackBarLiveRegionMessage] =
     useState('');
   const snackbarTimeout = useRef(null);
+  const settingsToggleRef = useRef(null);
   const personalization = isPersonalizationEnabled(config, settings);
 
   useEffect(() => {
@@ -30,6 +31,14 @@ export default function Personalization({ settings, updateSettings }) {
       clearTimeout(snackbarTimeout.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (!modalOpen && !loginPromptOpen && !againModalOpen) {
+      requestAnimationFrame(() => {
+        settingsToggleRef.current?.focus?.();
+      });
+    }
+  }, [modalOpen, loginPromptOpen, againModalOpen]);
 
   const changePersonalization = newState => {
     addAnalyticsEvent({
@@ -70,6 +79,7 @@ export default function Personalization({ settings, updateSettings }) {
     setShowSnackbar(false);
   };
 
+  // prevent line wrapping to one short word only
   const linkText = intl.formatMessage({ id: 'personalization-open-info' });
   const words = linkText.split(' ');
   const lastWord = words.pop();
@@ -87,6 +97,7 @@ export default function Personalization({ settings, updateSettings }) {
         <FormattedMessage id="personalization" />
       </div>
       <SettingsToggle
+        ref={settingsToggleRef}
         id="settings-toggle-personalization"
         labelId="personal-itineraries"
         labelStyle="mode-label-upper"

--- a/app/component/itinerary/customizesearch/Personalization.js
+++ b/app/component/itinerary/customizesearch/Personalization.js
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import SettingsToggle from './SettingsToggle';
 import PrModal from './PrModal';
+import PersonalizeAgainModal from './PersonalizeAgainModal';
 import Snackbar from '../../Snackbar';
 import LoginPrompt from '../../LoginPrompt';
 import Icon from '../../Icon';
@@ -10,12 +11,14 @@ import { addAnalyticsEvent } from '../../../util/analyticsUtils';
 import { isPersonalizationEnabled } from '../../../util/modeUtils';
 import { settingsShape } from '../../../util/shapes';
 import { useConfigContext } from '../../../configurations/ConfigContext';
+import { getPersonalization } from '../../../store/localStorage';
 
 export default function Personalization({ settings, updateSettings }) {
   const intl = useIntl();
   const config = useConfigContext();
   const [modalOpen, setModalOpen] = useState(false);
   const [loginPromptOpen, setLoginPromptOpen] = useState(false);
+  const [againModalOpen, setAgainModalOpen] = useState(false);
   const [showSnackbar, setShowSnackbar] = useState(null);
   const [snackbarLiveRegionMessage, setSnackBarLiveRegionMessage] =
     useState('');
@@ -28,27 +31,35 @@ export default function Personalization({ settings, updateSettings }) {
     };
   }, []);
 
+  const changePersonalization = newState => {
+    addAnalyticsEvent({
+      category: 'ItinerarySettings',
+      action: `Settings${newState ? 'Enable' : 'Disable'}Personalization`,
+      name: null,
+    });
+    updateSettings({ personalization: newState });
+    if (newState) {
+      setShowSnackbar(true);
+      setSnackBarLiveRegionMessage(
+        intl.formatMessage({ id: 'personalization-activated' }),
+      );
+      snackbarTimeout.current = setTimeout(() => {
+        setSnackBarLiveRegionMessage('');
+        setShowSnackbar(false);
+      }, 4000);
+    }
+  };
+
   const onToggle = () => {
     const loginNeeded = config.allowLogin && !config.user.sub;
     if (loginNeeded) {
       setLoginPromptOpen(true);
     } else {
       const newState = !personalization;
-      addAnalyticsEvent({
-        category: 'ItinerarySettings',
-        action: `Settings${newState ? 'Enable' : 'Disable'}Personalization`,
-        name: null,
-      });
-      updateSettings({ personalization: newState });
-      if (newState) {
-        setShowSnackbar(true);
-        setSnackBarLiveRegionMessage(
-          intl.formatMessage({ id: 'personalization-activated' }),
-        );
-        snackbarTimeout.current = setTimeout(() => {
-          setSnackBarLiveRegionMessage('');
-          setShowSnackbar(false);
-        }, 4000);
+      if (newState && Object.keys(getPersonalization().weights || []).length) {
+        setAgainModalOpen(true);
+      } else {
+        changePersonalization(newState);
       }
     }
   };
@@ -114,6 +125,14 @@ export default function Personalization({ settings, updateSettings }) {
         onClose={() => setLoginPromptOpen(false)}
         titleId="personalization-login-title"
         descriptionId="personalization-login-description"
+      />
+      <PersonalizeAgainModal
+        open={againModalOpen}
+        onClose={() => setAgainModalOpen(false)}
+        onContinue={() => {
+          setAgainModalOpen(false);
+          changePersonalization(true);
+        }}
       />
     </>
   );

--- a/app/component/itinerary/customizesearch/Personalization.js
+++ b/app/component/itinerary/customizesearch/Personalization.js
@@ -24,6 +24,7 @@ export default function Personalization({ settings, updateSettings }) {
     useState('');
   const snackbarTimeout = useRef(null);
   const settingsToggleRef = useRef(null);
+  const wasAnyModalOpenRef = useRef(null);
   const personalization = isPersonalizationEnabled(config, settings);
 
   useEffect(() => {
@@ -33,11 +34,13 @@ export default function Personalization({ settings, updateSettings }) {
   }, []);
 
   useEffect(() => {
-    if (!modalOpen && !loginPromptOpen && !againModalOpen) {
+    const anyModalOpen = modalOpen || loginPromptOpen || againModalOpen;
+    if (wasAnyModalOpenRef.current && !anyModalOpen) {
       requestAnimationFrame(() => {
         settingsToggleRef.current?.focus?.();
       });
     }
+    wasAnyModalOpenRef.current = anyModalOpen;
   }, [modalOpen, loginPromptOpen, againModalOpen]);
 
   const changePersonalization = newState => {

--- a/app/component/itinerary/customizesearch/PersonalizeAgainModal.js
+++ b/app/component/itinerary/customizesearch/PersonalizeAgainModal.js
@@ -19,8 +19,8 @@ export default function PersonalizeAgainModal({ open, onClose, onContinue }) {
     id: 'personalization-continue-choices',
   });
   const select = intl.formatMessage({ id: 'choose' });
-  const keep = intl.formatMessage({ id: 'personalization-keep-history' });
-  const remove = intl.formatMessage({ id: 'personalization-remove-history' });
+  const keep = intl.formatMessage({ id: 'personalization-history-keep' });
+  const remove = intl.formatMessage({ id: 'personalization-history-remove' });
 
   const handlePrimaryClick = () => {
     // if (!action) return;
@@ -32,7 +32,7 @@ export default function PersonalizeAgainModal({ open, onClose, onContinue }) {
     if (action === 'remove') {
       setPersonalization({});
     }
-    onContinue(action === 1);
+    onContinue();
   };
 
   const handleSecondaryClick = () => {
@@ -73,13 +73,15 @@ export default function PersonalizeAgainModal({ open, onClose, onContinue }) {
           label={select}
           items={[
             {
-              isChecked: false,
+              isChecked: action === 'keep',
+              id: 'keep',
               key: 'keep',
               label: keep,
               onChange: () => setAction('keep'),
             },
             {
-              isChecked: false,
+              isChecked: action === 'remove',
+              id: 'remove',
               key: 'remove',
               label: remove,
               onChange: () => setAction('remove'),
@@ -91,7 +93,7 @@ export default function PersonalizeAgainModal({ open, onClose, onContinue }) {
   );
 }
 
-PersonalizeAgainModal.js.propTypes = {
+PersonalizeAgainModal.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onContinue: PropTypes.func.isRequired,

--- a/app/component/itinerary/customizesearch/PersonalizeAgainModal.js
+++ b/app/component/itinerary/customizesearch/PersonalizeAgainModal.js
@@ -1,0 +1,98 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { Modal, ModalContent } from '@hsl-fi/dialog';
+import { RadioGroup } from '@hsl-fi/form';
+import { useIntl } from 'react-intl';
+import { useConfigContext } from '../../../configurations/ConfigContext';
+import { addAnalyticsEvent } from '../../../util/analyticsUtils';
+import { setPersonalization } from '../../../store/localStorage';
+
+export default function PersonalizeAgainModal({ open, onClose, onContinue }) {
+  const intl = useIntl();
+  const config = useConfigContext();
+  const [action, setAction] = useState();
+
+  const ok = intl.formatMessage({ id: 'continue' });
+  const cancel = intl.formatMessage({ id: 'cancel' });
+  const title = intl.formatMessage({ id: 'personalization-continue-query' });
+  const description = intl.formatMessage({
+    id: 'personalization-continue-choices',
+  });
+  const select = intl.formatMessage({ id: 'choose' });
+  const keep = intl.formatMessage({ id: 'personalization-keep-history' });
+  const remove = intl.formatMessage({ id: 'personalization-remove-history' });
+
+  const handlePrimaryClick = () => {
+    // if (!action) return;
+    addAnalyticsEvent({
+      category: 'Personalization',
+      action: 'continue',
+      name: action,
+    });
+    if (action === 'remove') {
+      setPersonalization({});
+    }
+    onContinue(action === 1);
+  };
+
+  const handleSecondaryClick = () => {
+    addAnalyticsEvent({
+      category: 'Personalization',
+      action: 'cancel',
+      name: null,
+    });
+    onClose();
+  };
+
+  return (
+    <Modal
+      lang={config.language}
+      onOpenChange={handleSecondaryClick}
+      open={open}
+    >
+      <ModalContent
+        title={title}
+        description={description}
+        lang={config.language}
+        buttons={[
+          {
+            children: ok,
+            disabled: !action,
+            onClick: handlePrimaryClick,
+          },
+          {
+            children: cancel,
+            onClick: handleSecondaryClick,
+            variant: 'secondary',
+          },
+        ]}
+      >
+        <RadioGroup
+          backgroundColor="primary"
+          borderVariant="weak"
+          label={select}
+          items={[
+            {
+              isChecked: false,
+              key: 'keep',
+              label: keep,
+              onChange: () => setAction('keep'),
+            },
+            {
+              isChecked: false,
+              key: 'remove',
+              label: remove,
+              onChange: () => setAction('remove'),
+            },
+          ]}
+        />
+      </ModalContent>
+    </Modal>
+  );
+}
+
+PersonalizeAgainModal.js.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onContinue: PropTypes.func.isRequired,
+};

--- a/app/component/itinerary/customizesearch/SettingsToggle.js
+++ b/app/component/itinerary/customizesearch/SettingsToggle.js
@@ -1,18 +1,21 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import Toggle from '../../Toggle';
 
-export default function SettingsToggle({
-  id,
-  label = '',
-  labelId,
-  labelStyle = '',
-  toggled,
-  onToggle,
-  leftElement, // e.g. icon
-  borderStyle = '',
-}) {
+const SettingsToggle = forwardRef(function SettingsToggle(
+  {
+    id,
+    label = '',
+    labelId,
+    labelStyle = '',
+    toggled,
+    onToggle,
+    leftElement, // e.g. icon
+    borderStyle = '',
+  },
+  ref,
+) {
   return (
     <label htmlFor={id} className={`toggle-container ${borderStyle}`}>
       <div className="toggle-left">
@@ -22,10 +25,10 @@ export default function SettingsToggle({
           {label}
         </span>
       </div>
-      <Toggle id={id} toggled={toggled} onToggle={onToggle} />
+      <Toggle ref={ref} id={id} toggled={toggled} onToggle={onToggle} />
     </label>
   );
-}
+});
 
 SettingsToggle.propTypes = {
   id: PropTypes.string.isRequired,
@@ -37,3 +40,5 @@ SettingsToggle.propTypes = {
   leftElement: PropTypes.node,
   borderStyle: PropTypes.string,
 };
+
+export default SettingsToggle;

--- a/app/component/itinerary/personalisation.scss
+++ b/app/component/itinerary/personalisation.scss
@@ -168,8 +168,31 @@
   font-size: $font-size-xsmall;
   overflow: hidden;
 
+  .icon-container {
+    display: flex;
+    flex-direction: row;
+    width: auto;
+    align-items: center;
+  }
+
   .feedback-text-posted {
     font-weight: $font-weight-book;
+  }
+
+  .external-link-container {
+    border: 0;
+    padding: 0;
+    width: 100%;
+
+    a {
+      font-size: $font-size-small;
+      font-weight: $font-weight-medium;
+      color: $link-color;
+    }
+
+    .icon-container {
+      display: inline-block;
+    }
   }
 
   .feedback-section {
@@ -191,6 +214,10 @@
       align-items: center;
     }
 
+    .thumb-button-disabled {
+      background-color: var(--color-surface-disabled);
+    }
+
     .thumb-button svg {
       transition: transform 0.2s ease;
     }
@@ -206,13 +233,6 @@
         stroke: transparent;
         fill: $attention-color;
       }
-    }
-
-    .icon-container {
-      display: flex;
-      flex-direction: row;
-      width: auto;
-      align-items: center;
     }
   }
 }

--- a/app/component/itinerary/search-settings.scss
+++ b/app/component/itinerary/search-settings.scss
@@ -206,7 +206,7 @@
   display: inline-flex;
   align-items: center;
   padding: 6px;
-  border-radius: 999px;
+  border-radius: 8px;
   background: #fff;
   position: relative;
   z-index: 1004;

--- a/app/component/popover.scss
+++ b/app/component/popover.scss
@@ -1,7 +1,7 @@
 .popover-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.1);
   z-index: 1000;
   animation: fadeInOverlay 1s forwards;
 }

--- a/app/component/popover.scss
+++ b/app/component/popover.scss
@@ -1,7 +1,7 @@
 .popover-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.4);
   z-index: 1000;
   animation: fadeInOverlay 1s forwards;
 }
@@ -13,9 +13,9 @@
 .popover-highlight {
   position: fixed;
   border-radius: 999px;
-  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
   z-index: 1001;
   pointer-events: none;
+  box-shadow: 0 0 50px white;
   animation: fadeInHighlight 1s forwards;
 }
 

--- a/app/component/routepage/PatternStopsContainer.js
+++ b/app/component/routepage/PatternStopsContainer.js
@@ -37,7 +37,7 @@ function PatternStopsContainer({ pattern, match, breakpoint, route }) {
         'bp-large': breakpoint === 'large',
       })}
     >
-      {route && route.patterns && (
+      {route?.patterns && (
         <RouteControlPanel
           match={match}
           route={route}
@@ -60,7 +60,7 @@ function PatternStopsContainer({ pattern, match, breakpoint, route }) {
           </div>
         </div>
       )}
-      {route.type !== ExtendedRouteTypes.CallAgency && (
+      {route?.type !== ExtendedRouteTypes.CallAgency && (
         <RouteStopListContainer
           key="list"
           pattern={pattern}

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -766,7 +766,7 @@ export default {
   }, */
 
   showRouteDescNotification: IS_DEV,
-  personalization: IS_DEV,
+  personalization: false,
   showNewRoutePage: true,
   staticCrisisBanners: [
     {

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -766,7 +766,7 @@ export default {
   }, */
 
   showRouteDescNotification: IS_DEV,
-  personalization: false,
+  personalization: IS_DEV,
   showNewRoutePage: true,
   staticCrisisBanners: [
     {

--- a/app/configurations/config.matka.js
+++ b/app/configurations/config.matka.js
@@ -135,7 +135,7 @@ export default {
     copyright: { label: `© Matka.fintraffic.fi ${YEAR}` },
     content: [
       {
-        name: 'Fintraffic',
+        label: 'Fintraffic',
         href: 'https://www.fintraffic.fi',
       },
       {

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -588,6 +588,7 @@ export default {
       'You will receive similar recommendations in the future.',
     'personalization-login-description':
       'You can enable personalized route recommendations when you are logged in.',
+    'personalization-login-for-voting': 'Log in and give feedback',
     'personalization-login-title': 'Sign in to get recommendations',
     'personalization-modal-feedback': 'We learn from your feedback',
     'personalization-modal-feedback-details':

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -120,10 +120,11 @@ export default {
     'car-park-disclaimer':
       'You can park your car near a station or stop and continue your journey by public transport',
     'car-park-disclaimer-header': 'Park your car',
+    choose: 'Select',
     'choose-freely': 'Optional',
     'choose-stop': 'Select stop',
-    'choose-stop-or-vehicle': 'Select vehicle or stop',
-    'choose-vehicle': 'Select vehicle',
+    'choose-stop-or-vehicle': 'Select route or stop',
+    'choose-vehicle': 'Select route',
     citybike: 'City bike',
     'citybike-duration-general-header':
       'Extra charge applies to several sections of route to be completed by a city bike.',
@@ -571,9 +572,16 @@ export default {
     'personalization-ask': 'Do you like this route recommendation?',
     'personalization-beta':
       'Personalization is still in the testing phase, meaning we are trying out the service. We would love to hear about your experience. The survey will open in a new tab.',
+    'personalization-continue-choices':
+      'Choose whether we use your usage history for personalization or start over by deleting your usage history.',
+    'personalization-continue-query':
+      'How do you want to continue personalization?',
     'personalization-disliked':
       'You will receive fewer recommendations like this in the future.',
     'personalization-feedback': 'Give feedback',
+    'personalization-history-keep': 'Take advantage of usage history',
+    'personalization-history-remove':
+      'Delete personalization history and start over',
     'personalization-info':
       'Find your favorite routes and travel according to your habits',
     'personalization-liked':

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -569,7 +569,7 @@ export default {
     'personalization-activated': 'Personalization has been enabled',
     'personalization-aria-dislike': 'I do not like this itinerary',
     'personalization-aria-like': 'I like this itinerary',
-    'personalization-ask': 'Do you like this route recommendation?',
+    'personalization-ask': 'Do you like this route suggestion?',
     'personalization-beta':
       'Personalization is still in the testing phase, meaning we are trying out the service. We would love to hear about your experience. The survey will open in a new tab.',
     'personalization-continue-choices':

--- a/app/translations/fi.js
+++ b/app/translations/fi.js
@@ -573,6 +573,7 @@ export default {
     'personalization-liked': 'Saat jatkossa samankaltaisia suosituksia.',
     'personalization-login-description':
       'Voit ottaa yksilölliset reittisuositukset käyttöön, kun olet kirjautunut sisään.',
+    'personalization-login-for-voting': 'Kirjaudu ja anna palautetta',
     'personalization-login-title': 'Kirjaudu saadaksesi suosituksia',
     'personalization-modal-feedback': 'Opimme palautteestasi',
     'personalization-modal-feedback-details':

--- a/app/translations/fi.js
+++ b/app/translations/fi.js
@@ -555,9 +555,9 @@ export default {
     'personal-itineraries': 'Yksilölliset reittiehdotukset',
     personalization: 'Personointi',
     'personalization-activated': 'Personointi on otettu käyttöön',
-    'personalization-aria-dislike': 'En pidä tästä reittisuosituksesta',
-    'personalization-aria-like': 'Pidän tästä reittisuosituksesta',
-    'personalization-ask': 'Pidätkö tästä reittisuosituksesta?',
+    'personalization-aria-dislike': 'En pidä tästä reittiehdotuksesta',
+    'personalization-aria-like': 'Pidän tästä reittiehdotuksesta',
+    'personalization-ask': 'Pidätkö tästä reittiehdotuksesta?',
     'personalization-beta':
       'Personointi on vielä testausvaiheessa, eli kokeilemme palvelua. Haluaisimme kuulla kokemuksestasi. Kysely avautuu uuteen välilehteen.',
     'personalization-continue-choices':

--- a/app/translations/fi.js
+++ b/app/translations/fi.js
@@ -113,6 +113,7 @@ export default {
     'car-park-disclaimer':
       'Voit jättää auton parkkiin aseman tai pysäkin tuntumaan ja jatkaa matkaasi kätevästi julkisilla',
     'car-park-disclaimer-header': 'Jätä auto parkkiin',
+    choose: 'Valitse',
     'choose-freely': 'Vapaasti valittavat',
     'choose-stop': 'Valitse pysäkki',
     'choose-stop-or-vehicle': 'Valitse linja tai pysäkki',
@@ -559,9 +560,14 @@ export default {
     'personalization-ask': 'Pidätkö tästä reittisuosituksesta?',
     'personalization-beta':
       'Personointi on vielä testausvaiheessa, eli kokeilemme palvelua. Haluaisimme kuulla kokemuksestasi. Kysely avautuu uuteen välilehteen.',
+    'personalization-continue-choices':
+      'Valitse, käytämmekö personointiin käyttöhistoriaasi vai aloitammeko alusta, jolloin käyttöhistoria poistetaan.',
+    'personalization-continue-query': 'Miten haluat jatkaa personointia?',
     'personalization-disliked':
       'Saat jatkossa vähemmän tämänkaltaisia suosituksia.',
     'personalization-feedback': 'Anna palautetta',
+    'personalization-history-keep': 'Hyödynnä käyttöhistoriaa',
+    'personalization-history-remove': 'Poista käyttöhistoria ja aloita alusta',
     'personalization-info':
       'Löydä mieleiset reitit ja matkusta tottumustesi mukaan.',
     'personalization-liked': 'Saat jatkossa samankaltaisia suosituksia.',

--- a/app/translations/sv.js
+++ b/app/translations/sv.js
@@ -117,10 +117,11 @@ export default {
     'car-park-disclaimer':
       'Du kan lämna bilen på parkeringen vid stationen eller hållplatsen och fortsätta din resa enkel med kollektivtrafiken',
     'car-park-disclaimer-header': 'Lämna din bil i parkeringen',
+    choose: 'Välj',
     'choose-freely': 'Valfria',
     'choose-stop': 'Välj hållplats',
-    'choose-stop-or-vehicle': 'Select vehicle or stop',
-    'choose-vehicle': 'Select vehicle',
+    'choose-stop-or-vehicle': 'Välj en linje eller hållplats',
+    'choose-vehicle': 'Välj en linje',
     citybike: 'Stadscykel',
     'citybike-duration-general-header':
       'Rutten har flera sträckor med stadscykel som inkluderar tilläggsavgifter.',
@@ -563,9 +564,16 @@ export default {
     'personalization-ask': 'Gillar du den här ruttrekommendationen?',
     'personalization-beta':
       'Personaliseringen är fortfarande i testfasen, vilket innebär att vi testar tjänsten. Vi vill gärna höra om din upplevelse. Undersökningen öppnas i en ny flik.',
+    'personalization-continue-choices':
+      'Välj om vi använder din användningshistorik för personalisering eller om vi ska börja om genom att radera din användningshistorik.',
+    'personalization-continue-query':
+      'Hur vill du fortsätta med personaliseringen?',
     'personalization-disliked':
       'Du kommer att få färre rekommendationer som denna i framtiden.',
     'personalization-feedback': 'Ge feedback',
+    'personalization-history-keep': 'Dra nytta av användningshistoriken',
+    'personalization-history-remove':
+      'Rensa personaliseringshistoriken och börja om',
     'personalization-info':
       'Hitta dina favoritrutter och res utifrån dina vanor.',
     'personalization-liked':

--- a/app/translations/sv.js
+++ b/app/translations/sv.js
@@ -573,7 +573,7 @@ export default {
     'personalization-feedback': 'Ge feedback',
     'personalization-history-keep': 'Dra nytta av användningshistoriken',
     'personalization-history-remove':
-      'Rensa personaliseringshistoriken och börja om',
+      'Rensa användningshistoriken och börja om',
     'personalization-info':
       'Hitta dina favoritrutter och res utifrån dina vanor.',
     'personalization-liked':

--- a/app/translations/sv.js
+++ b/app/translations/sv.js
@@ -559,9 +559,9 @@ export default {
     'personal-itineraries': 'Individuella ruttförslag',
     personalization: 'Personalisering',
     'personalization-activated': 'Personalisering har aktiverats',
-    'personalization-aria-dislike': 'Jag gillar den här ruttrekommendationen',
-    'personalization-aria-like': 'Jag gillar inte den här ruttrekommendationen',
-    'personalization-ask': 'Gillar du den här ruttrekommendationen?',
+    'personalization-aria-dislike': 'Jag gillar den här ruttförslaget',
+    'personalization-aria-like': 'Jag gillar inte den här ruttförslaget',
+    'personalization-ask': 'Gillar du den här ruttförslaget?',
     'personalization-beta':
       'Personaliseringen är fortfarande i testfasen, vilket innebär att vi testar tjänsten. Vi vill gärna höra om din upplevelse. Undersökningen öppnas i en ny flik.',
     'personalization-continue-choices':

--- a/app/translations/sv.js
+++ b/app/translations/sv.js
@@ -580,6 +580,7 @@ export default {
       'Du kommer att få liknande rekommendationer i framtiden.',
     'personalization-login-description':
       'Du kan aktivera personliga ruttrekommendationer när du är inloggad.',
+    'personalization-login-for-voting': 'Logga in och ge feedback',
     'personalization-login-title': 'Logga in för att få rekommendationer',
     'personalization-modal-feedback': 'Vi lär oss av er feedback',
     'personalization-modal-feedback-details':

--- a/app/util/path.js
+++ b/app/util/path.js
@@ -62,6 +62,11 @@ export const buildURL = (pathSegments = []) => {
   return url;
 };
 
+export function getLoginPath(location) {
+  const returnTo = `${location.pathname}${location.search || ''}`;
+  return `/login?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
 export const createReturnPath = (
   path,
   origin,

--- a/test/unit/ItineraryDetails.test.js
+++ b/test/unit/ItineraryDetails.test.js
@@ -24,7 +24,8 @@ describe('<ItineraryDetails />', () => {
       tabIndex: 0,
     };
     const wrapper = shallowWithIntl(<ItineraryDetails {...props} />, {
-      context: { ...mockContext },
+      context: mockContext,
+      config: mockContext.config,
     });
     expect(wrapper.find('.itinerary-tab').length).to.equal(1);
   });

--- a/test/unit/component/AboutPage.test.js
+++ b/test/unit/component/AboutPage.test.js
@@ -1,46 +1,39 @@
 import React from 'react';
-import { Component as AboutPage } from '../../../app/component/AboutPage';
+import AboutPage from '../../../app/component/AboutPage';
 import { mountWithIntl } from '../helpers/mock-intl-enzyme';
-import { mockChildContextTypes } from '../helpers/mock-context';
 
 describe('<AboutPage />', () => {
-  const context = {
-    config: {
-      CONFIG: 'default',
-      aboutThisService: {
-        fi: [
-          {
-            header: 'header1',
-            paragraphs: ['foo1'],
-            link: 'foo1.com',
-          },
-          {
-            header: 'header2',
-            paragraphs: ['foo2'],
-          },
-        ],
-        sv: [
-          {
-            header: 'sv_header1',
-            paragraphs: ['sv_foo1'],
-            link: 'sv_foo1.com',
-          },
-          {
-            header: 'sv_header2',
-            paragraphs: ['sv_foo2'],
-          },
-        ],
-      },
+  const config = {
+    CONFIG: 'default',
+    aboutThisService: {
+      fi: [
+        {
+          header: 'header1',
+          paragraphs: ['foo1'],
+          link: 'foo1.com',
+        },
+        {
+          header: 'header2',
+          paragraphs: ['foo2'],
+        },
+      ],
+      sv: [
+        {
+          header: 'sv_header1',
+          paragraphs: ['sv_foo1'],
+          link: 'sv_foo1.com',
+        },
+        {
+          header: 'sv_header2',
+          paragraphs: ['sv_foo2'],
+        },
+      ],
     },
   };
 
-  const props = { currentLanguage: 'fi' };
-  const svprops = { currentLanguage: 'sv' };
-
   it('should render all defined headers and paragraph texts in given order', () => {
-    const wrapper = mountWithIntl(<AboutPage {...props} />, {
-      context,
-      childContextTypes: { ...mockChildContextTypes },
+    const wrapper = mountWithIntl(<AboutPage />, {
+      config: { ...config, language: 'fi' },
     });
     expect(wrapper.find('p').first().text()).to.equal('foo1'); //eslint-disable-line
     expect(wrapper.find('p').last().text()).to.equal('foo2'); //eslint-disable-line
@@ -49,17 +42,15 @@ describe('<AboutPage />', () => {
   });
 
   it('should render external links', () => {
-    const wrapper = mountWithIntl(<AboutPage {...props} />, {
-      context,
-      childContextTypes: { ...mockChildContextTypes },
+    const wrapper = mountWithIntl(<AboutPage />, {
+      config: { ...config, language: 'fi' },
     });
     expect(wrapper.find('a').first().prop('href')).to.equal('foo1.com'); //eslint-disable-line
   });
 
   it('should obey language selection', () => {
-    const wrapper = mountWithIntl(<AboutPage {...svprops} />, {
-      context,
-      childContextTypes: { ...mockChildContextTypes },
+    const wrapper = mountWithIntl(<AboutPage />, {
+      config: { ...config, language: 'sv' },
     });
     expect(wrapper.find('.about-header').first().text()).to.equal('sv_header1'); //eslint-disable-line
     expect(wrapper.find('p').first().text()).to.equal('sv_foo1'); //eslint-disable-line

--- a/test/unit/helpers/mock-context.js
+++ b/test/unit/helpers/mock-context.js
@@ -4,6 +4,7 @@ import { matchShape, routerShape } from 'found';
 
 import { mockRouter, mockMatch } from './mock-router';
 import PositionStore from '../../../app/store/PositionStore';
+import config from '../../../app/configurations/config.default';
 
 const noop = () => {};
 
@@ -13,11 +14,7 @@ const noop = () => {};
  * their propType requirements.
  */
 export const mockContext = {
-  config: {
-    CONFIG: 'default',
-    timeZone: 'Europe/Helsinki',
-    colors: { primary: '#3fa', accessiblePrimary: '#333' },
-  },
+  config,
   executeAction: noop,
   getStore: () => ({
     on: noop,


### PR DESCRIPTION
A modal asks if personalization history should be kept or emptied. Opens only if there is existing history. 

This PR also adds feedback element as a teaser to itinerary detail view of non-logged users which have not yet turned personalization off. 
 
Some components modernized as well.