### PR TITLE
AB#597 Fix alert background is always red

### DIFF
--- a/app/component/stop/stop.scss
+++ b/app/component/stop/stop.scss
@@ -12,18 +12,7 @@
   margin-right: 3px;
   border-radius: 999em;
   color: white;
-}
-
-.active-disruption-alert {
-  .alert-circle {
-    background-color: $disruption-color;
-  }
-}
-
-.active-service-alert {
-  .alert-circle {
-    background-color: rgba(136, 136, 136, 1);
-  }
+  background-color: $disruption-color;
 }
 
 .stop-page-content-wrapper {


### PR DESCRIPTION
## Proposed Changes

  - Alert number background in the tab bar should always be red (even if all alerts are only info-level)
  - Applies to route view and stop view

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
