### PR TITLE
AB#511 - Flex translations

### DIFF
--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -83,7 +83,7 @@ export default {
     'bike-station-disabled': 'The bike station is out of service.',
     'bikes-available': '{amount} bikes at the station ',
     'biking-speed': 'Biking speed',
-    'book-a-lift': 'Use an app to book a ride',
+    'book-a-lift': 'Use taxis via the app',
     'booking-method': 'Booking method',
     bus: 'Bus',
     'bus-express': 'Trunk bus',
@@ -202,6 +202,8 @@ export default {
     'e-scooter': 'Electric scooter',
     'e-scooter-alternative':
       'How about using an electric scooter for part of your journey? {paymentInfo}',
+    'e-scooter-or-taxi-alternative':
+      'How about traveling part of the way by an e-scooter, a taxi or a ride-hailing service? {paymentInfo}',
     'e-scooters': 'Electric scooters',
     'e-scooters-available':
       'There are electric scooters available in the area. Use an app to unlock the electric scooter.',
@@ -227,7 +229,7 @@ export default {
     'from-bus': 'bus',
     'from-ferry': 'ferry',
     'from-ferrypier': 'ferry pier',
-    'from-place': 'location',
+    'from-place': ' ',
     'from-rail': 'train',
     'from-scooter-location': 'the scooter location',
     'from-station': 'station',
@@ -402,7 +404,7 @@ export default {
     'modes.to-scooter': 'to scooter',
     'modes.to-stop': 'stop',
     'modes.to-subway': 'subway station',
-    'modes.to-taxi': 'destination',
+    'modes.to-taxi': ' ',
     'modes.to-tram': 'tram stop',
     'more-departures': 'More departures',
     'move-on-map': 'Move on the map',
@@ -560,9 +562,9 @@ export default {
     'payment-info-e-scooter':
       'Please note that you need to use the app of the operator in question in order to use and pay for the scooters.',
     'payment-info-e-scooter-or-taxi':
-      'Please note that you need to use the app of the operator in question in order to use and pay for the taxis or scooters.',
+      'Please note that you use and pay for scooters, taxis and ride-hailing services in the service providers’ own apps.',
     'payment-info-taxi':
-      'Please note that you need to use the app of the operator in question in order to use and pay for the taxis.',
+      'Please note that you use and pay for taxis and ride‑hailing services in the service providers’ own apps.',
     'personal-itineraries': 'Personal itineraries',
     personalization: 'Personalization',
     'personalization-activated': 'Personalization has been enabled',
@@ -728,6 +730,10 @@ export default {
       'Some selections in the settings exclude certain route alternatives.',
     'settings-missing-itineraries-header':
       'Are some route alternatives missing?',
+    'settings-taxi':
+      'You can choose your preferred taxi and ride‑hailing services to include them in route planning.',
+    'settings-taxi-routes':
+      'Include taxi and ride‑hailing services in your routes!',
     'show-departures': 'Show departures',
     'show-more': 'Show more',
     'show-more-stops-near-you': 'Show more stops near you',
@@ -793,8 +799,8 @@ export default {
     'swipe-summary-page-tab': 'Itinerary swipe result tabs',
     taxi: 'Taxi',
     'taxi-alternative':
-      'How about using a taxi for part of your journey? {paymentInfo}',
-    'taxi-distance-duration': 'Travel for {duration} ({distance})',
+      'How about traveling part of the way by a taxi? {paymentInfo}',
+    'taxi-distance-duration': 'Travel {duration} ({distance})',
     'taxi-external': 'Taxi',
     'taxi-with-route-number': 'Taxi {routeNumber}',
     'taxis-and-ride-hailing': 'Taxis and ride-hailing services',

--- a/app/translations/fi.js
+++ b/app/translations/fi.js
@@ -197,6 +197,8 @@ export default {
     'e-scooter': 'Sähköpotkulauta',
     'e-scooter-alternative':
       'Entä jos kulkisit osan matkasta sähköpotkulaudalla? {paymentInfo}',
+    'e-scooter-or-taxi-alternative':
+      'Entä jos kulkisit osan matkasta sähköpotkulaudalla, taksilla tai kyytipalvelulla? {paymentInfo}',
     'e-scooters': 'Sähköpotkulaudat',
     'e-scooters-available':
       'Alueella sähköpotkulautoja vapaana. Ota sähköpotkulauta käyttöön sovelluksella.',
@@ -710,6 +712,9 @@ export default {
     'settings-missing-itineraries-body':
       'Asetuksissa on päällä valintoja, jotka rajaavat pois joitain reittivaihtoehtoja.',
     'settings-missing-itineraries-header': 'Puuttuuko reittivaihtoehtoja?',
+    'settings-taxi':
+      'Voit valita haluamasi taksi- ja kyytipalvelut, jolloin ne ovat osana reititystä',
+    'settings-taxi-routes': 'Taksi- ja kyytipalvelut osaksi reittejäsi!',
     'show-departures': 'Näytä lähdöt',
     'show-more': 'Näytä lisää',
     'show-more-stops-near-you': 'Näytä lisää pysäkkejä lähelläsi',

--- a/app/translations/sv.js
+++ b/app/translations/sv.js
@@ -83,7 +83,7 @@ export default {
     'bike-station-disabled': 'Stadscykelstationen är ur bruk.',
     'bikes-available': '{amount} cyklar vid stationen',
     'biking-speed': 'Cykling hastighet',
-    'book-a-lift': 'Beställ resa i appen',
+    'book-a-lift': 'Beställ skjuts med appen',
     'booking-method': 'Beställningssätt',
     bus: 'Buss',
     'bus-express': 'Stombuss',
@@ -200,6 +200,8 @@ export default {
     'e-scooter': 'Elsparkcykel',
     'e-scooter-alternative':
       'Och om du skulle åka elsparkcykel en del av din resa? {paymentInfo}',
+    'e-scooter-or-taxi-alternative':
+      'Vad sägs om att resa en del av sträckan med elsparkcykel, taxi eller skjutstjänst? {paymentInfo}',
     'e-scooters': 'Elsparkcyklar',
     'e-scooters-available':
       'Det finns lediga elsparkcyklar i området. Ta en elsparkcykel i bruk med en app.',
@@ -225,7 +227,7 @@ export default {
     'from-bus': 'bussen',
     'from-ferry': 'färjan',
     'from-ferrypier': 'färjerkajen',
-    'from-place': 'plats',
+    'from-place': ' ',
     'from-rail': 'tåget',
     'from-scooter-location': 'platsen för sparkcykel',
     'from-station': 'stationen',
@@ -246,7 +248,7 @@ export default {
       'Det tar längre tid än väntat att hitta din plats.',
     'geolocation-timeout-text':
       'Har du godkänt att webbläsaren får använda din plats?',
-    'get-off-the-ride': 'Stig ur',
+    'get-off-the-ride': 'Stig av',
     hour: 'Timme',
     hsl_ticket: 'HRT-biljetten',
     hsl_travel_card: 'HRT-kortet',
@@ -286,7 +288,7 @@ export default {
     'itinerary-details.scooter-leg':
       '{time} åk elsparkcykel {distance} från {origin} till destinationen {destination}. Restid {duration}',
     'itinerary-details.taxi-leg':
-      '{time} åk taxi {distance} från {origin} till {to} {destination}. Restid {duration}',
+      '{time} res med taxi {distance} från {origin} till {to} {destination}. Restid {duration}',
     'itinerary-details.transit-leg-part-1': '{time} {realtime} ta',
     'itinerary-details.transit-leg-part-2':
       'från hållplats {startStop} {startZoneInfo} {trackInfo} till hållplats {endStop} {endZoneInfo}. Beräknad restid {duration}. ',
@@ -321,7 +323,7 @@ export default {
     'itinerary-summary-row.first-leg-start-time-scooter':
       'Avgång kl {firstDepartureTime} med en sparkcykel',
     'itinerary-summary-row.first-leg-start-time-taxi':
-      'Avgång kl {firstDepartureTime} med taxi från {firstDepartureStop}',
+      'Taxi avgår från {firstDepartureStop} kl. {firstDepartureTime}',
     'itinerary-summary-row.no-transit-legs': 'Avgå när det passar för dig',
     'itinerary-summary-row.transfers':
       'Byte {vehicle} vid hållplats {stopName}',
@@ -397,7 +399,7 @@ export default {
     'modes.to-scooter': 'elsparkcykel',
     'modes.to-stop': 'hållplats',
     'modes.to-subway': 'metrostation',
-    'modes.to-taxi': 'destination',
+    'modes.to-taxi': ' ',
     'modes.to-tram': 'spårvagnshållplats',
     'more-departures': 'Fler avgångar',
     'move-on-map': 'Flytta på kartan',
@@ -552,9 +554,9 @@ export default {
     'payment-info-e-scooter':
       'Vänligen observera att användning och betalning av elsparkcyklar görs via operatörernas egna appar.',
     'payment-info-e-scooter-or-taxi':
-      'Vänligen observera att användning och betalning av elsparkcyklar och taxi görs via operatörernas egna appar.',
+      'Vänligen observera att du använder och betalar för elsparkcyklar, taxi och skjutstjänster med aktörernas egna appar.',
     'payment-info-taxi':
-      'Vänligen observera att användning och betalning av taxi görs via operatörernas egna appar.',
+      'Vänligen observera att du använder och betalar för taxi och skjutstjänster med aktörernas egna appar.',
     'personal-itineraries': 'Individuella ruttförslag',
     personalization: 'Personalisering',
     'personalization-activated': 'Personalisering har aktiverats',
@@ -717,6 +719,10 @@ export default {
     'settings-missing-itineraries-body':
       'Dina val i inställningar utesluter vissa ruttalternativ.',
     'settings-missing-itineraries-header': 'Saknas det några ruttförslag?',
+    'settings-taxi':
+      'Du kan själv välja vilka taxi- och skjutstjänster som ska ingå i din rutt',
+    'settings-taxi-routes':
+      'Använd taxi- och skjutstjänster som en del av din resa!',
     'show-departures': 'Visa avgångarna',
     'show-more': 'Visa mer',
     'show-more-stops-near-you': 'Visa flera hållplatser nära dig',
@@ -785,7 +791,7 @@ export default {
       'Navigeringsknapp för att kunna bläddra ruttförslag.',
     taxi: 'Taxi',
     'taxi-alternative':
-      'Och om du skulle åka taxi en del av din resa? {paymentInfo}',
+      'Vad sägs om att resa en del av sträckan med taxi? {paymentInfo}',
     'taxi-distance-duration': 'Res {duration} ({distance})',
     'taxi-external': 'Taxi',
     'taxi-with-route-number': 'Taxi {routeNumber}',


### PR DESCRIPTION
## Proposed Changes

  - Contains a hack with blank translations (react-intl does not accept empty translations). Multiple spaces are displayed as one in the displayed html