### PR TITLE
AB#639 Inherit font-family in shared components

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "8.3.7",
+  "version": "8.3.8",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,7 +28,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^7.1.12",
+    "@digitransit-component/digitransit-component-autosuggest": "^7.1.13",
     "@digitransit-component/digitransit-component-icon": "^2.0.2",
     "@hsl-fi/sass": "1.0.0",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "7.1.12",
+  "version": "7.1.13",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [
@@ -35,7 +35,7 @@
     "@hsl-fi/hooks": "^1.2.4"
   },
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-dialog-modal": "^3.0.3",
+    "@digitransit-component/digitransit-component-dialog-modal": "^3.0.4",
     "@digitransit-component/digitransit-component-icon": "^2.0.2",
     "@digitransit-component/digitransit-component-suggestion-item": "^3.0.3",
     "@hsl-fi/sass": "1.0.0",

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/components/MobileSearch.scss
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/components/MobileSearch.scss
@@ -72,7 +72,7 @@ input[type='text'] {
   width: 100%;
 
   .input {
-    font-family: var(--font-family);
+    font-family: inherit;
     width: 100%;
     position: relative;
     padding-bottom: 7px;
@@ -179,7 +179,7 @@ button.clear-input {
 
 .clear-search-history {
   display: flex;
-  font-family: var(--font-family);
+  font-family: inherit;
   margin-top: auto;
   align-items: center;
   justify-content: center;

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/components/styles.scss
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/components/styles.scss
@@ -36,7 +36,7 @@ input[type='text'] {
     }
 
     font-size: 16px;
-    font-family: var(--font-family);
+    font-family: inherit;
     display: flex;
     width: 100%;
     height: 44px;

--- a/digitransit-component/packages/digitransit-component-control-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-control-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-control-panel",
-  "version": "7.1.3",
+  "version": "7.1.4",
   "description": "digitransit-component control-panel module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-control-panel/src/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-control-panel/src/helpers/styles.scss
@@ -119,7 +119,7 @@
   }
 
   .near-you-title {
-    font-family: var(--font-family);
+    font-family: inherit;
     font-weight: var(--font-weight);
     line-height: normal;
     letter-spacing: -0.67px;

--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/styles.scss
@@ -41,7 +41,7 @@ $zindex: base, map-container, map-gradient, map-fullscreen-toggle, map-buttons,
 
   label button {
     cursor: pointer;
-    font-family: var(--font-family);
+    font-family: inherit;
   }
 
   .hidden {
@@ -378,7 +378,7 @@ $zindex: base, map-container, map-gradient, map-fullscreen-toggle, map-buttons,
 }
 
 .mobile-modal-content {
-  font-family: var(--font-family);
+  font-family: inherit;
   background: white;
   width: 89%;
   position: absolute;

--- a/digitransit-component/packages/digitransit-component-dialog-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-dialog-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-dialog-modal",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "digitransit-component dialog-modal module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-dialog-modal/src/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-dialog-modal/src/helpers/styles.scss
@@ -40,7 +40,7 @@
     width: 100%;
     height: 50px;
     font-size: 18px;
-    font-family: var(--font-family);
+    font-family: inherit;
     font-weight: var(--font-weight-medium);
     letter-spacing: -0.5px;
     background: var(--color);

--- a/digitransit-component/packages/digitransit-component-favourite-bar/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-bar",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "digitransit-component favourite-bar module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-favourite-bar/src/helpers/styles.scss
+++ b/digitransit-component/packages/digitransit-component-favourite-bar/src/helpers/styles.scss
@@ -114,7 +114,7 @@ $favourite-highlight-background-color: #f2f5f7;
       flex-direction: row;
 
       .name {
-        font-family: var(--font-family);
+        font-family: inherit;
         font-size: 15px;
         margin-right: 6px;
         font-weight: var(--font-weight-medium);
@@ -132,7 +132,7 @@ $favourite-highlight-background-color: #f2f5f7;
       }
 
       .address {
-        font-family: var(--font-family);
+        font-family: inherit;
         font-size: 12px;
         margin-right: 6px;
         font-weight: normal;

--- a/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-editing-modal",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "digitransit-component favourite-editing-modal module",
   "main": "index.js",
   "files": [
@@ -32,7 +32,7 @@
     "@digitransit-search-util/digitransit-search-util-uniq-by-label": "^2.1.2"
   },
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-dialog-modal": "^3.0.3",
+    "@digitransit-component/digitransit-component-dialog-modal": "^3.0.4",
     "@digitransit-component/digitransit-component-icon": "^2.0.2",
     "@hsl-fi/container-spinner": "0.3.2",
     "@hsl-fi/modal": "^0.3.2",

--- a/digitransit-component/packages/digitransit-component-favourite-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-modal",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "digitransit-component favourite-modal module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-favourite-modal/src/helpers/desktop.scss
+++ b/digitransit-component/packages/digitransit-component-favourite-modal/src/helpers/desktop.scss
@@ -32,7 +32,7 @@
         position: relative;
         width: 100%;
         height: 44px;
-        font-family: var(--font-family);
+        font-family: inherit;
         border-radius: 5px;
         border: solid 1px #888;
         background-color: #fff;
@@ -90,7 +90,7 @@
       width: 100%;
       height: 50px;
       font-size: 18px;
-      font-family: var(--font-family);
+      font-family: inherit;
       font-weight: var(--font-weight-medium);
       letter-spacing: -0.5px;
       background: var(--color);

--- a/digitransit-component/packages/digitransit-component-favourite-modal/src/helpers/mobile.scss
+++ b/digitransit-component/packages/digitransit-component-favourite-modal/src/helpers/mobile.scss
@@ -37,7 +37,7 @@
       position: relative;
       width: 100%;
       height: 44px;
-      font-family: var(--font-family);
+      font-family: inherit;
       border-radius: 5px;
       border: solid 1px #888;
       background-color: #fff;
@@ -84,7 +84,7 @@
       width: 100%;
       height: 50px;
       font-size: 18px;
-      font-family: var(--font-family);
+      font-family: inherit;
       font-weight: var(--font-weight-medium);
       letter-spacing: -0.5px;
       background: var(--color);

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component",
-  "version": "5.0.15",
+  "version": "5.0.16",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-component",
   "module": "digitransit-component.mjs",
@@ -18,18 +18,18 @@
     "url": "git://github.com/HSLdevcom/digitransit-ui.git"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^7.1.12",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^8.3.7",
-    "@digitransit-component/digitransit-component-control-panel": "^7.1.3",
-    "@digitransit-component/digitransit-component-favourite-bar": "^5.0.5",
-    "@digitransit-component/digitransit-component-favourite-editing-modal": "^5.0.4",
-    "@digitransit-component/digitransit-component-favourite-modal": "^4.0.4",
+    "@digitransit-component/digitransit-component-autosuggest": "^7.1.13",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^8.3.8",
+    "@digitransit-component/digitransit-component-control-panel": "^7.1.4",
+    "@digitransit-component/digitransit-component-favourite-bar": "^5.0.6",
+    "@digitransit-component/digitransit-component-favourite-editing-modal": "^5.0.5",
+    "@digitransit-component/digitransit-component-favourite-modal": "^4.0.5",
     "@digitransit-component/digitransit-component-icon": "^2.0.2",
     "@digitransit-component/digitransit-component-suggestion-item": "^3.0.3",
     "@digitransit-component/digitransit-component-with-breakpoint": "^1.0.1"
   },
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-dialog-modal": "^3.0.3",
+    "@digitransit-component/digitransit-component-dialog-modal": "^3.0.4",
     "@hsl-fi/container-spinner": "0.3.2",
     "@hsl-fi/modal": "^0.3.2",
     "@hsl-fi/sass": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2077,11 +2077,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@npm:^8.3.7, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@npm:^8.3.8, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^7.1.12
+    "@digitransit-component/digitransit-component-autosuggest": ^7.1.13
     "@digitransit-component/digitransit-component-icon": ^2.0.2
     "@hsl-fi/sass": 1.0.0
     classnames: 2.5.1
@@ -2096,7 +2096,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@npm:^7.1.12, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@npm:^7.1.13, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
@@ -2105,7 +2105,7 @@ __metadata:
     "@digitransit-search-util/digitransit-search-util-uniq-by-label": "npm:^2.1.2"
     "@hsl-fi/hooks": "npm:^1.2.4"
   peerDependencies:
-    "@digitransit-component/digitransit-component-dialog-modal": ^3.0.3
+    "@digitransit-component/digitransit-component-dialog-modal": ^3.0.4
     "@digitransit-component/digitransit-component-icon": ^2.0.2
     "@digitransit-component/digitransit-component-suggestion-item": ^3.0.3
     "@hsl-fi/sass": 1.0.0
@@ -2122,7 +2122,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-control-panel@npm:^7.1.3, @digitransit-component/digitransit-component-control-panel@workspace:digitransit-component/packages/digitransit-component-control-panel":
+"@digitransit-component/digitransit-component-control-panel@npm:^7.1.4, @digitransit-component/digitransit-component-control-panel@workspace:digitransit-component/packages/digitransit-component-control-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-control-panel@workspace:digitransit-component/packages/digitransit-component-control-panel"
   peerDependencies:
@@ -2173,7 +2173,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-favourite-bar@npm:^5.0.5, @digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar":
+"@digitransit-component/digitransit-component-favourite-bar@npm:^5.0.6, @digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar"
   dependencies:
@@ -2193,13 +2193,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-favourite-editing-modal@npm:^5.0.4, @digitransit-component/digitransit-component-favourite-editing-modal@workspace:digitransit-component/packages/digitransit-component-favourite-editing-modal":
+"@digitransit-component/digitransit-component-favourite-editing-modal@npm:^5.0.5, @digitransit-component/digitransit-component-favourite-editing-modal@workspace:digitransit-component/packages/digitransit-component-favourite-editing-modal":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-favourite-editing-modal@workspace:digitransit-component/packages/digitransit-component-favourite-editing-modal"
   dependencies:
     "@digitransit-search-util/digitransit-search-util-uniq-by-label": "npm:^2.1.2"
   peerDependencies:
-    "@digitransit-component/digitransit-component-dialog-modal": ^3.0.3
+    "@digitransit-component/digitransit-component-dialog-modal": ^3.0.4
     "@digitransit-component/digitransit-component-icon": ^2.0.2
     "@hsl-fi/container-spinner": 0.3.2
     "@hsl-fi/modal": ^0.3.2
@@ -2212,7 +2212,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-favourite-modal@npm:^4.0.4, @digitransit-component/digitransit-component-favourite-modal@workspace:digitransit-component/packages/digitransit-component-favourite-modal":
+"@digitransit-component/digitransit-component-favourite-modal@npm:^4.0.5, @digitransit-component/digitransit-component-favourite-modal@workspace:digitransit-component/packages/digitransit-component-favourite-modal":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-favourite-modal@workspace:digitransit-component/packages/digitransit-component-favourite-modal"
   peerDependencies:
@@ -2278,17 +2278,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": "npm:^7.1.12"
-    "@digitransit-component/digitransit-component-autosuggest-panel": "npm:^8.3.7"
-    "@digitransit-component/digitransit-component-control-panel": "npm:^7.1.3"
-    "@digitransit-component/digitransit-component-favourite-bar": "npm:^5.0.5"
-    "@digitransit-component/digitransit-component-favourite-editing-modal": "npm:^5.0.4"
-    "@digitransit-component/digitransit-component-favourite-modal": "npm:^4.0.4"
+    "@digitransit-component/digitransit-component-autosuggest": "npm:^7.1.13"
+    "@digitransit-component/digitransit-component-autosuggest-panel": "npm:^8.3.8"
+    "@digitransit-component/digitransit-component-control-panel": "npm:^7.1.4"
+    "@digitransit-component/digitransit-component-favourite-bar": "npm:^5.0.6"
+    "@digitransit-component/digitransit-component-favourite-editing-modal": "npm:^5.0.5"
+    "@digitransit-component/digitransit-component-favourite-modal": "npm:^4.0.5"
     "@digitransit-component/digitransit-component-icon": "npm:^2.0.2"
     "@digitransit-component/digitransit-component-suggestion-item": "npm:^3.0.3"
     "@digitransit-component/digitransit-component-with-breakpoint": "npm:^1.0.1"
   peerDependencies:
-    "@digitransit-component/digitransit-component-dialog-modal": ^3.0.3
+    "@digitransit-component/digitransit-component-dialog-modal": ^3.0.4
     "@hsl-fi/container-spinner": 0.3.2
     "@hsl-fi/modal": ^0.3.2
     "@hsl-fi/sass": 1.0.0


### PR DESCRIPTION
## Proposed Changes

  - This pr removes var(--font-family) usage in shared components as it caused hsl themed fonts to appear everywhere
  - Inheriting the font from body keeps it consistent with the rest of the theme

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
