### PR TITLE
Fix trafficnow filtering

### DIFF
--- a/app/component/trafficnow/Disruptions.js
+++ b/app/component/trafficnow/Disruptions.js
@@ -64,8 +64,7 @@ export default function Disruptions() {
   );
 
   const disruptionCards = useMemo(
-    () =>
-      buildDisruptionCards(disruptions, selectedFilters.vehicleModes, config),
+    () => buildDisruptionCards(disruptions, selectedFilters, config),
     [disruptions, selectedFilters.vehicleModes, config],
   );
 

--- a/app/component/trafficnow/Disruptions.js
+++ b/app/component/trafficnow/Disruptions.js
@@ -65,21 +65,24 @@ export default function Disruptions() {
 
   // Split each alert into one card per affected transport mode. Alerts with no
   // recognised mode still produce a single card.
-  const disruptionCards = useMemo(
-    () =>
-      disruptions.flatMap(alert => {
-        const modes = getAlertModes(alert.entities, config);
-        if (modes.length === 0) {
-          return [{ key: alert.id, alert, mode: undefined }];
-        }
-        return modes.map(mode => ({
-          key: `${alert.id}-${mode}`,
-          alert,
-          mode,
-        }));
-      }),
-    [disruptions, config],
-  );
+  const disruptionCards = useMemo(() => {
+    const selectedModes = selectedFilters.vehicleModes;
+    return disruptions.flatMap(alert => {
+      const allModes = getAlertModes(alert.entities, config);
+      if (allModes.length === 0) {
+        return [{ key: alert.id, alert, mode: undefined }];
+      }
+      const modes =
+        selectedModes.length > 0
+          ? allModes.filter(m => selectedModes.includes(m.toLowerCase()))
+          : allModes;
+      return modes.map(mode => ({
+        key: `${alert.id}-${mode}`,
+        alert,
+        mode,
+      }));
+    });
+  }, [disruptions, config, selectedFilters.vehicleModes]);
 
   const mobile = breakpoint !== 'large';
 

--- a/app/component/trafficnow/Disruptions.js
+++ b/app/component/trafficnow/Disruptions.js
@@ -13,7 +13,7 @@ import { useFilterContext } from './filters/FiltersContext';
 import { filterAndSortAlerts } from './filters/filterUtils';
 import AlertsQuery from './queries/AlertsQuery';
 import CanceledTripsOverviewQuery from './queries/CanceledTripsOverviewQuery';
-import { getAlertModes } from './utils';
+import { buildDisruptionCards } from './utils';
 import { TRAFFICNOW } from '../../util/path';
 
 const CANCELED_TRIPS_OVERVIEW_QUERY_AMOUNT = 20;
@@ -63,26 +63,11 @@ export default function Disruptions() {
     [alerts, selectedFilters],
   );
 
-  // Split each alert into one card per affected transport mode. Alerts with no
-  // recognised mode still produce a single card.
-  const disruptionCards = useMemo(() => {
-    const selectedModes = selectedFilters.vehicleModes;
-    return disruptions.flatMap(alert => {
-      const allModes = getAlertModes(alert.entities, config);
-      if (allModes.length === 0) {
-        return [{ key: alert.id, alert, mode: undefined }];
-      }
-      const modes =
-        selectedModes.length > 0
-          ? allModes.filter(m => selectedModes.includes(m.toLowerCase()))
-          : allModes;
-      return modes.map(mode => ({
-        key: `${alert.id}-${mode}`,
-        alert,
-        mode,
-      }));
-    });
-  }, [disruptions, config, selectedFilters.vehicleModes]);
+  const disruptionCards = useMemo(
+    () =>
+      buildDisruptionCards(disruptions, selectedFilters.vehicleModes, config),
+    [disruptions, selectedFilters.vehicleModes, config],
+  );
 
   const mobile = breakpoint !== 'large';
 

--- a/app/component/trafficnow/utils.js
+++ b/app/component/trafficnow/utils.js
@@ -120,15 +120,24 @@ const getAvailableModes = config =>
 // returned (stops are shown only in the drill-down view). Stop-only modes are
 // returned only when the alert has no routes at all. Modes keep their
 // first-seen order.
-const getAlertModes = (entities, config) => {
+// selectedFilters.entity / selectedFilters.favourites narrow modes to only
+// those whose entity group contains the relevant route or stop.
+const getAlertModes = (entities, config, selectedFilters = {}) => {
   if (!entities) {
     return [];
   }
+  const { entity, favourites } = selectedFilters;
   const routeModes = [];
   const stopModes = [];
   Object.values(groupEntitiesByMode(entities, config)).forEach(
-    ({ mode, isRoute }) => {
+    ({ mode, isRoute, entities: groupEntities }) => {
       if (!mode) {
+        return;
+      }
+      if (entity && !groupEntities.some(e => e.gtfsId === entity.gtfsId)) {
+        return;
+      }
+      if (favourites && !groupEntities.some(e => favourites.has(e.gtfsId))) {
         return;
       }
       const target = isRoute ? routeModes : stopModes;
@@ -140,18 +149,19 @@ const getAlertModes = (entities, config) => {
   return routeModes.length > 0 ? routeModes : stopModes;
 };
 
-// Splits each alert into one card per affected transport mode, optionally
-// filtered to the caller's selectedModes list. Alerts with no recognised mode
-// produce a single card with mode=undefined.
-const buildDisruptionCards = (disruptions, selectedModes, config) =>
+// Splits each alert into one card per affected transport mode, respecting
+// active filters (vehicleModes, entity, favourites). Alerts with no recognised
+// mode produce a single card with mode=undefined.
+const buildDisruptionCards = (disruptions, selectedFilters, config) =>
   disruptions.flatMap(alert => {
-    const allModes = getAlertModes(alert.entities, config);
+    const allModes = getAlertModes(alert.entities, config, selectedFilters);
     if (allModes.length === 0) {
       return [{ key: alert.id, alert, mode: undefined }];
     }
+    const vehicleModes = selectedFilters.vehicleModes ?? [];
     const modes =
-      selectedModes.length > 0
-        ? allModes.filter(m => selectedModes.includes(m.toLowerCase()))
+      vehicleModes.length > 0
+        ? allModes.filter(m => vehicleModes.includes(m.toLowerCase()))
         : allModes;
     return modes.map(mode => ({
       key: `${alert.id}-${mode}`,

--- a/app/component/trafficnow/utils.js
+++ b/app/component/trafficnow/utils.js
@@ -140,4 +140,29 @@ const getAlertModes = (entities, config) => {
   return routeModes.length > 0 ? routeModes : stopModes;
 };
 
-export { getAvailableModes, groupEntitiesByMode, getAlertModes };
+// Splits each alert into one card per affected transport mode, optionally
+// filtered to the caller's selectedModes list. Alerts with no recognised mode
+// produce a single card with mode=undefined.
+const buildDisruptionCards = (disruptions, selectedModes, config) =>
+  disruptions.flatMap(alert => {
+    const allModes = getAlertModes(alert.entities, config);
+    if (allModes.length === 0) {
+      return [{ key: alert.id, alert, mode: undefined }];
+    }
+    const modes =
+      selectedModes.length > 0
+        ? allModes.filter(m => selectedModes.includes(m.toLowerCase()))
+        : allModes;
+    return modes.map(mode => ({
+      key: `${alert.id}-${mode}`,
+      alert,
+      mode,
+    }));
+  });
+
+export {
+  getAvailableModes,
+  groupEntitiesByMode,
+  getAlertModes,
+  buildDisruptionCards,
+};

--- a/app/component/trafficnow/utils.js
+++ b/app/component/trafficnow/utils.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-underscore-dangle */
-import { getTransportModes, getRouteMode } from '../../util/modeUtils';
+import {
+  getTransportModes,
+  getRouteMode,
+  getBaseTransportMode,
+} from '../../util/modeUtils';
 import {
   AlertEntityType,
   LocationTypes,
@@ -161,7 +165,9 @@ const buildDisruptionCards = (disruptions, selectedFilters, config) =>
     const vehicleModes = selectedFilters.vehicleModes ?? [];
     const modes =
       vehicleModes.length > 0
-        ? allModes.filter(m => vehicleModes.includes(m.toLowerCase()))
+        ? allModes.filter(m =>
+            vehicleModes.includes(getBaseTransportMode(m.toLowerCase())),
+          )
         : allModes;
     return modes.map(mode => ({
       key: `${alert.id}-${mode}`,

--- a/app/util/modeUtils.js
+++ b/app/util/modeUtils.js
@@ -223,6 +223,23 @@ export function getStopMode(vehicleMode, routes, code, config, isTerminal) {
 }
 
 /**
+ * Maps an extended route mode string back to its base transport mode.
+ */
+export function getBaseTransportMode(mode) {
+  if (
+    mode === 'bus-local' ||
+    mode === 'bus-express' ||
+    mode === 'replacement-bus'
+  ) {
+    return 'bus';
+  }
+  if (mode === 'speedtram') {
+    return 'tram';
+  }
+  return mode;
+}
+
+/**
  * @returns icon name
  */
 export function transitIconName(mode, lollipop) {

--- a/test/unit/component/trafficnow/FiltersContext.test.js
+++ b/test/unit/component/trafficnow/FiltersContext.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { describe, it, afterEach } from 'mocha';
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
@@ -47,10 +47,19 @@ const OutsideConsumer = () => {
 };
 
 describe('FiltersContext', () => {
+  let wrapper;
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = null;
+    }
+  });
+
   describe('Default filter state', () => {
     it('initialises noEffect to NO_EFFECT', () => {
       const controlRef = React.createRef();
-      mount(
+      wrapper = mount(
         <FilterContextProvider>
           <FilterConsumer controlRef={controlRef} />
         </FilterContextProvider>,
@@ -60,7 +69,7 @@ describe('FiltersContext', () => {
 
     it('initialises validityPeriod to ALL', () => {
       const controlRef = React.createRef();
-      mount(
+      wrapper = mount(
         <FilterContextProvider>
           <FilterConsumer controlRef={controlRef} />
         </FilterContextProvider>,
@@ -70,7 +79,7 @@ describe('FiltersContext', () => {
 
     it('initialises vehicleModes to an empty array', () => {
       const controlRef = React.createRef();
-      mount(
+      wrapper = mount(
         <FilterContextProvider>
           <FilterConsumer controlRef={controlRef} />
         </FilterContextProvider>,
@@ -80,7 +89,7 @@ describe('FiltersContext', () => {
 
     it('initialises now as a number', () => {
       const controlRef = React.createRef();
-      mount(
+      wrapper = mount(
         <FilterContextProvider>
           <FilterConsumer controlRef={controlRef} />
         </FilterContextProvider>,
@@ -92,7 +101,7 @@ describe('FiltersContext', () => {
   describe('setFilter', () => {
     it('updates vehicleModes when setFilter is called', () => {
       const controlRef = React.createRef();
-      mount(
+      wrapper = mount(
         <FilterContextProvider>
           <FilterConsumer controlRef={controlRef} />
         </FilterContextProvider>,
@@ -109,7 +118,7 @@ describe('FiltersContext', () => {
 
     it('does not affect other filter keys when only one is updated', () => {
       const controlRef = React.createRef();
-      mount(
+      wrapper = mount(
         <FilterContextProvider>
           <FilterConsumer controlRef={controlRef} />
         </FilterContextProvider>,
@@ -127,7 +136,7 @@ describe('FiltersContext', () => {
   describe('removeFilter', () => {
     it('removes the specified key from selectedFilters', () => {
       const controlRef = React.createRef();
-      mount(
+      wrapper = mount(
         <FilterContextProvider>
           <FilterConsumer controlRef={controlRef} />
         </FilterContextProvider>,
@@ -145,7 +154,7 @@ describe('FiltersContext', () => {
 
     it('leaves other keys intact after removing one', () => {
       const controlRef = React.createRef();
-      mount(
+      wrapper = mount(
         <FilterContextProvider>
           <FilterConsumer controlRef={controlRef} />
         </FilterContextProvider>,
@@ -162,7 +171,7 @@ describe('FiltersContext', () => {
   describe('resetFilters', () => {
     it('restores all filters to their default values', () => {
       const controlRef = React.createRef();
-      mount(
+      wrapper = mount(
         <FilterContextProvider>
           <FilterConsumer controlRef={controlRef} />
         </FilterContextProvider>,
@@ -184,6 +193,7 @@ describe('FiltersContext', () => {
 
   describe('useFilterContext outside provider', () => {
     it('throws when used outside a FilterContextProvider', () => {
+      // wrapper intentionally not assigned; component throws on mount
       expect(() => mount(<OutsideConsumer />)).to.throw(
         'useFilterContext must be used within a FilterContextProvider',
       );

--- a/test/unit/component/trafficnow/utils.test.js
+++ b/test/unit/component/trafficnow/utils.test.js
@@ -288,36 +288,102 @@ describe('TrafficNow utils', () => {
           },
         ],
       };
-      const cards = buildDisruptionCards([alert], [], {});
+      const cards = buildDisruptionCards([alert], {}, {});
       expect(cards).to.have.length(2);
       expect(cards.map(c => c.mode)).to.deep.equal(['bus', 'tram']);
       expect(cards.map(c => c.key)).to.deep.equal(['a1-bus', 'a1-tram']);
     });
 
-    it('keeps only the selected modes when a filter is active', () => {
+    it('keeps only the selected modes when vehicleModes filter is active', () => {
       const busAlert = makeAlert('a1', 'BUS');
       const tramAlert = makeAlert('a2', 'TRAM');
-      const cards = buildDisruptionCards([busAlert, tramAlert], ['bus'], {});
+      const cards = buildDisruptionCards(
+        [busAlert, tramAlert],
+        { vehicleModes: ['bus'] },
+        {},
+      );
       expect(cards).to.have.length(1);
       expect(cards[0].mode).to.equal('bus');
     });
 
+    it('limits cards to the mode containing the selected entity', () => {
+      const alert = {
+        id: 'a1',
+        entities: [
+          {
+            __typename: AlertEntityType.Route,
+            id: 'r1',
+            gtfsId: 'HSL:r1',
+            mode: 'BUS',
+            shortName: '1',
+          },
+          {
+            __typename: AlertEntityType.Route,
+            id: 'r2',
+            gtfsId: 'HSL:r2',
+            mode: 'TRAM',
+            shortName: '4',
+          },
+        ],
+      };
+      const cards = buildDisruptionCards(
+        [alert],
+        { entity: { gtfsId: 'HSL:r1' } },
+        {},
+      );
+      expect(cards).to.have.length(1);
+      expect(cards[0].mode).to.equal('bus');
+    });
+
+    it('limits cards to modes containing at least one favourite', () => {
+      const alert = {
+        id: 'a1',
+        entities: [
+          {
+            __typename: AlertEntityType.Route,
+            id: 'r1',
+            gtfsId: 'HSL:r1',
+            mode: 'BUS',
+            shortName: '1',
+          },
+          {
+            __typename: AlertEntityType.Route,
+            id: 'r2',
+            gtfsId: 'HSL:r2',
+            mode: 'TRAM',
+            shortName: '4',
+          },
+        ],
+      };
+      const cards = buildDisruptionCards(
+        [alert],
+        { favourites: new Set(['HSL:r2']) },
+        {},
+      );
+      expect(cards).to.have.length(1);
+      expect(cards[0].mode).to.equal('tram');
+    });
+
     it('produces a single card with mode=undefined for an alert with no recognised mode', () => {
       const alert = { id: 'a1', entities: [] };
-      const cards = buildDisruptionCards([alert], [], {});
+      const cards = buildDisruptionCards([alert], {}, {});
       expect(cards).to.have.length(1);
       expect(cards[0]).to.deep.include({ key: 'a1', mode: undefined, alert });
     });
 
     it('still produces a no-mode card even when a mode filter is active', () => {
       const alert = { id: 'a1', entities: [] };
-      const cards = buildDisruptionCards([alert], ['bus'], {});
+      const cards = buildDisruptionCards(
+        [alert],
+        { vehicleModes: ['bus'] },
+        {},
+      );
       expect(cards).to.have.length(1);
       expect(cards[0].mode).to.equal(undefined);
     });
 
     it('returns an empty array when disruptions is empty', () => {
-      expect(buildDisruptionCards([], [], {})).to.deep.equal([]);
+      expect(buildDisruptionCards([], {}, {})).to.deep.equal([]);
     });
   });
 });

--- a/test/unit/component/trafficnow/utils.test.js
+++ b/test/unit/component/trafficnow/utils.test.js
@@ -8,6 +8,7 @@ import {
   getAvailableModes,
   groupEntitiesByMode,
   getAlertModes,
+  buildDisruptionCards,
 } from '../../../../app/component/trafficnow/utils';
 
 describe('TrafficNow utils', () => {
@@ -236,6 +237,87 @@ describe('TrafficNow utils', () => {
 
     it('returns an empty array when entities are null', () => {
       expect(getAlertModes(null, {})).to.deep.equal([]);
+    });
+  });
+
+  describe('buildDisruptionCards', () => {
+    beforeEach(() => {
+      sandbox
+        .stub(modeUtils, 'getRouteMode')
+        .callsFake(entity => entity?.mode?.toLowerCase() || null);
+      sandbox
+        .stub(pathUtils, 'stopPagePath')
+        .callsFake((isStation, gtfsId) => `/stop/${gtfsId}`);
+      sandbox
+        .stub(pathUtils, 'routePagePath')
+        .callsFake(gtfsId => `/route/${gtfsId}`);
+    });
+
+    const makeAlert = (id, entityMode) => ({
+      id,
+      entities: entityMode
+        ? [
+            {
+              __typename: AlertEntityType.Route,
+              id: `r-${id}`,
+              gtfsId: `HSL:r-${id}`,
+              mode: entityMode,
+              shortName: id,
+            },
+          ]
+        : [],
+    });
+
+    it('produces one card per mode when no filter is active', () => {
+      const alert = {
+        id: 'a1',
+        entities: [
+          {
+            __typename: AlertEntityType.Route,
+            id: 'r1',
+            gtfsId: 'HSL:r1',
+            mode: 'BUS',
+            shortName: '1',
+          },
+          {
+            __typename: AlertEntityType.Route,
+            id: 'r2',
+            gtfsId: 'HSL:r2',
+            mode: 'TRAM',
+            shortName: '4',
+          },
+        ],
+      };
+      const cards = buildDisruptionCards([alert], [], {});
+      expect(cards).to.have.length(2);
+      expect(cards.map(c => c.mode)).to.deep.equal(['bus', 'tram']);
+      expect(cards.map(c => c.key)).to.deep.equal(['a1-bus', 'a1-tram']);
+    });
+
+    it('keeps only the selected modes when a filter is active', () => {
+      const busAlert = makeAlert('a1', 'BUS');
+      const tramAlert = makeAlert('a2', 'TRAM');
+      const cards = buildDisruptionCards([busAlert, tramAlert], ['bus'], {});
+      expect(cards).to.have.length(1);
+      expect(cards[0].mode).to.equal('bus');
+    });
+
+    it('produces a single card with mode=undefined for an alert with no recognised mode', () => {
+      const alert = { id: 'a1', entities: [] };
+      const cards = buildDisruptionCards([alert], [], {});
+      expect(cards).to.have.length(1);
+      expect(cards[0]).to.deep.include({ key: 'a1', mode: undefined, alert });
+    });
+
+    it('still produces a no-mode card even when a mode filter is active', () => {
+      const alert = { id: 'a1', entities: [] };
+      const cards = buildDisruptionCards([alert], ['bus'], {});
+      expect(cards).to.have.length(1);
+      expect(cards[0].mode).to.equal(undefined);
+    });
+
+    it('returns an empty array when disruptions is empty', () => {
+      expect(buildDisruptionCards([], [], {})).to.deep.equal([]);
     });
   });
 });

--- a/test/unit/util/trafficNowUtil.test.js
+++ b/test/unit/util/trafficNowUtil.test.js
@@ -1,4 +1,7 @@
-import { groupEntitiesByMode } from '../../../app/component/trafficnow/utils';
+import {
+  groupEntitiesByMode,
+  buildDisruptionCards,
+} from '../../../app/component/trafficnow/utils';
 import { stopPagePath, routePagePath } from '../../../app/util/path';
 
 const mocks = {
@@ -241,5 +244,88 @@ describe('trafficNowUtil', () => {
       useExtendedRouteTypes: false,
     });
     expect(grouped).to.be.an('object');
+  });
+});
+
+describe('buildDisruptionCards vehicleModes filter with extended route types', () => {
+  const extendedConfig = { useExtendedRouteTypes: true };
+
+  const makeAlert = (id, routeType) => ({
+    id,
+    entities: [
+      {
+        __typename: 'Route',
+        gtfsId: `MATKA:${id}`,
+        id: `ROUTE_${id}`,
+        mode: 'BUS',
+        type: routeType,
+        shortName: id,
+        __isNode: 'Route',
+      },
+    ],
+  });
+
+  const speedTramAlert = {
+    id: 'SPEEDTRAM_ALERT',
+    entities: [
+      {
+        __typename: 'Route',
+        gtfsId: 'MATKA:900',
+        id: 'ROUTE_ST',
+        mode: 'TRAM',
+        type: 900, // ExtendedRouteTypes.SpeedTram
+        shortName: 'ST',
+        __isNode: 'Route',
+      },
+    ],
+  };
+
+  it('includes bus-local cards when bus filter is active', () => {
+    const cards = buildDisruptionCards(
+      [makeAlert('LOCAL', 704)],
+      { vehicleModes: ['bus'] },
+      extendedConfig,
+    );
+    expect(cards).to.have.lengthOf(1);
+    expect(cards[0].mode).to.equal('bus-local');
+  });
+
+  it('includes bus-express cards when bus filter is active', () => {
+    const cards = buildDisruptionCards(
+      [makeAlert('EXPRESS', 702)],
+      { vehicleModes: ['bus'] },
+      extendedConfig,
+    );
+    expect(cards).to.have.lengthOf(1);
+    expect(cards[0].mode).to.equal('bus-express');
+  });
+
+  it('includes replacement-bus cards when bus filter is active', () => {
+    const cards = buildDisruptionCards(
+      [makeAlert('REPL', 714)],
+      { vehicleModes: ['bus'] },
+      extendedConfig,
+    );
+    expect(cards).to.have.lengthOf(1);
+    expect(cards[0].mode).to.equal('replacement-bus');
+  });
+
+  it('includes speedtram cards when tram filter is active', () => {
+    const cards = buildDisruptionCards(
+      [speedTramAlert],
+      { vehicleModes: ['tram'] },
+      extendedConfig,
+    );
+    expect(cards).to.have.lengthOf(1);
+    expect(cards[0].mode).to.equal('speedtram');
+  });
+
+  it('excludes bus-local cards when only tram filter is active', () => {
+    const cards = buildDisruptionCards(
+      [makeAlert('LOCAL', 704)],
+      { vehicleModes: ['tram'] },
+      extendedConfig,
+    );
+    expect(cards).to.have.lengthOf(0);
   });
 });


### PR DESCRIPTION
## Proposed Changes

  - When single alerts are split into mode specific cards the mode filtering was not applied correctly and unwanted mode cards were shown. Splitting now takes into account the selected filters.
  - Also did some refactoring and added tests

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
