### PR TITLE
AB#671 - Traffic now theme fixes

### DIFF
--- a/app/component/trafficnow/DisruptionDetailsContainer.js
+++ b/app/component/trafficnow/DisruptionDetailsContainer.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { ButtonLink } from '@hsl-fi/layout-primitives';
 import Link from 'found/Link';
+import { useRouter } from 'found';
 import { useLazyLoadQuery } from 'react-relay/hooks';
 import { useConfigContext } from '../../configurations/ConfigContext';
 import Card from '../Card';
@@ -16,29 +17,21 @@ import { AlertSeverityLevelType } from '../../constants';
 const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
   const config = useConfigContext();
   const intl = useIntl();
+  const { router } = useRouter();
   const { alerts } = useLazyLoadQuery(AlertsQuery, {
     feedIds: config.feedIds,
   });
 
   const alert = alerts?.find(a => a.id === alertId);
 
+  useEffect(() => {
+    if (!alert) {
+      router.replace('/liikenne');
+    }
+  }, [alert, router]);
+
   if (!alert) {
-    return (
-      <>
-        <div className="detail-view__cta-container">
-          <Link to="/liikenne" className="cta-small">
-            <Icon img="icon_chevron-left" />
-            <FormattedMessage id="traffic-now_go-back" />
-          </Link>
-        </div>
-        <div className="disruption-details__empty">
-          <FormattedMessage
-            id="disruption-not-found"
-            defaultMessage="Disruption not found"
-          />
-        </div>
-      </>
-    );
+    return null;
   }
 
   const {

--- a/app/component/trafficnow/TrafficNowLink.js
+++ b/app/component/trafficnow/TrafficNowLink.js
@@ -3,14 +3,18 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from 'found';
 import { TRAFFICNOW } from '../../util/path';
 import Icon from '../Icon';
+import { useConfigContext } from '../../configurations/ConfigContext';
 
 const TrafficNowLink = () => {
+  const config = useConfigContext();
+  const themeColor = config.colors.primary;
+
   return (
     <Link className="traffic-now__link" to={`/${TRAFFICNOW}`}>
       <div className="traffic-now__link__left-column">
         <Icon
           img="icon_info-filled"
-          color="#007ac9"
+          color={themeColor}
           height={1.5}
           width={1.5}
           colorAsFillOnly={false}
@@ -29,7 +33,7 @@ const TrafficNowLink = () => {
         </div>
       </div>
       <span className="traffic-now__link__caret">
-        <Icon img="icon_arrow-collapse--right" color="#007ac9" />
+        <Icon img="icon_arrow-collapse--right" color={themeColor} />
       </span>
     </Link>
   );

--- a/app/component/trafficnow/styles/tokens.scss
+++ b/app/component/trafficnow/styles/tokens.scss
@@ -3,15 +3,6 @@
 // ============================================================================
 // Shared SCSS constants and component-level CSS custom properties.
 
-// Font weight definitions must be set before typography import in main.scss
-$font-weight-book: 350;
-$font-weight-medium: 500;
-
-:root {
-  --font-weight-book: #{$font-weight-book};
-  --font-weight-medium: #{$font-weight-medium};
-}
-
 // Breakpoints
 $bp-tablet-small: 620px;
 $bp-tablet: 900px;

--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -524,7 +524,7 @@
       color: #333;
       font-size: rem(15);
       font-style: normal;
-      font-weight: 500;
+      font-weight: var(--font-weight-medium);
       line-height: 24px;
       letter-spacing: -0.3px;
     }

--- a/static/assets/svg-sprite.default.svg
+++ b/static/assets/svg-sprite.default.svg
@@ -1346,6 +1346,12 @@
     <path fill-rule="evenodd" clip-rule="evenodd" d="M0 6.65406L1.20878 5.44528L7.61254 11.8491C7.94634 12.1829 7.94634 12.7241 7.61254 13.0578C7.27878 13.3916 6.73756 13.3916 6.40376 13.0578L0 6.65406Z" fill="currentcolor"/>
   </symbol>
 
+  <symbol id="icon_info-circled" viewBox="0 0 16 16" >
+   <path fill-rule="evenodd" clip-rule="evenodd" d="M8 14.8C11.7555 14.8 14.8 11.7555 14.8 8C14.8 4.24446 11.7555 1.2 8 1.2C4.24446 1.2 1.2 4.24446 1.2 8C1.2 11.7555 4.24446 14.8 8 14.8ZM8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16Z" fill="currentcolor"/>
+   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.35178 11.3686V7.65561C9.35178 6.92668 8.88564 6.3572 8.17533 6.3572H6.95448C6.35516 6.3572 6 6.76723 6 7.29114C6 7.74672 6.28856 8.22508 7.22085 8.22508V11.3686C7.22085 12.0975 7.5982 12.667 8.28631 12.667C8.99662 12.667 9.35178 12.0975 9.35178 11.3686Z" fill="currentcolor"/>
+   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.52941 4.05651V3.94262C9.52941 3.16813 8.90789 2.66699 8.08659 2.66699C7.2653 2.66699 6.64378 3.16813 6.64378 3.94262V4.05651C6.64378 4.831 7.2653 5.35492 8.08659 5.35492C8.90789 5.35492 9.52941 4.831 9.52941 4.05651Z" fill="currentcolor"/>
+  </symbol>
+
   <symbol id="icon_status" viewBox="0 0 16 16">
     <circle cx="8" cy="8" r="7" fill="currentcolor">
       <animate attributeName="opacity" values="0.15;0.7;0.15" dur="1s" repeatCount="indefinite"/>
@@ -1355,6 +1361,11 @@
       <animate attributeName="opacity" values="0.8;0.8;0.8" dur="1s" repeatCount="indefinite"/>
       <animate attributeName="r" values="3;1;3" dur="1s" repeatCount="indefinite"/>
     </circle>
+  </symbol>
+
+  <symbol id="icon_checkbox" viewBox="0 0 24 24" fill="none" >
+    <path d="M0 4C0 1.79086 1.79086 0 4 0H20C22.2091 0 24 1.79086 24 4V20C24 22.2091 22.2091 24 20 24H4C1.79086 24 0 22.2091 0 20V4Z" fill="currentcolor"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M16.0307 7.55772L10.3661 13.0814L7.91499 10.6913C7.37031 10.1602 6.55329 10.1602 6.00861 10.6913C5.46393 11.2225 5.46393 12.0191 6.00861 12.5503L10.3661 16.7992L17.9916 9.41665C18.5363 8.88553 18.5363 8.08885 17.9916 7.55772C17.3924 7.07972 16.5754 7.07972 16.0307 7.55772Z" fill="white"/>
   </symbol>
 </defs>
 </svg>


### PR DESCRIPTION
## Proposed Changes

  - Use theme icon colors for traffic now
  - Add missing traffic now icons for default svg sheet
  - Redirect to /liikenne when disruption id is not found
  - Make font weights work correctly based on theme