### PR TITLE
AB#671 - Inline `@hsl-fi/design-system-core` styles instead of leaving them as a passthrough import

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -2,7 +2,17 @@
 $body-font-family: $font-family;
 $body-font-weight: $font-weight-medium;
 
-@import '@hsl-fi/design-system-core/css/styles.css';
+// Note: the '.css' extension is intentionally dropped here. Dart Sass only
+// leaves an '@import' as a literal, un-inlined passthrough when the path
+// explicitly ends in '.css'; webpack's splitChunks then treats that
+// passthrough import as its own module and, since it resolves under
+// node_modules/@hsl-fi/, pulls it into the shared 'digitransit-components'
+// chunk which loads *after* each theme's own CSS. That let this file's
+// default '--font-weight-medium'/'--font-weight-book' values win over the
+// theme-specific ones set later in this same file by base/helper-mixins.
+// Importing without the extension makes Sass inline the file's contents
+// here instead, so the theme override below still applies last and wins.
+@import '@hsl-fi/design-system-core/css/styles';
 
 // Apply theme specific values over standard hsl theme
 @import 'design-theme.css';


### PR DESCRIPTION
## Proposed Changes

- Fixes font-weight not working correctly with themes

AI summary:

**Root cause:**
sass/_main.scss  imported  @hsl-fi/design-system-core/css/styles.css  with an explicit  .css  extension. Dart Sass leaves  .css -suffixed imports as literal passthroughs instead of inlining them, so webpack's  splitChunks  picked it up as its own module (resolved under  node_modules/@hsl-fi/ ) and extracted it into the shared  digitransit-components.css  chunk — which loads after each theme's own CSS in the HTML. Since  @hsl-fi/design-system-core@2.7.1  added  --font-weight-medium: 500 / --font-weight-book  to that stylesheet, it silently overrode every non-HSL theme's correct value sitewide (HSL coincidentally used 500 already, so it looked fine there).

**Fix:**
dropped the  .css  extension so Sass inlines the file directly into  sass/_main.scss , before  base/helper-mixins  (which sets each theme's real value) — restoring correct cascade order within a single file.

**Verified:**
stylelint clean, 52/52 trafficnow tests pass, and a real production build ( CONFIG=oulu ) confirms  --font-weight-medium  now resolves to 600 in the theme bundle, is gone from the shared chunk, and all other design-system-core tokens (colors/shadows) remain intact.