### PR TITLE
AB#121 Geolocation button is rendered over settings menu on desktop

### DIFF
--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -317,8 +317,13 @@ div.leaflet-marker-icon.vehicle-icon {
 }
 
 .map-control-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  line-height: 0;
   background-color: $white;
-  padding: 4px 6px;
   margin-top: 8px;
   border-radius: 5px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);

--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -656,6 +656,19 @@ section.content {
       display: flex;
       position: relative;
 
+      .map {
+        z-index: 1;
+      }
+
+      .offcanvas {
+        position: relative;
+        z-index: 900;
+      }
+
+      .offcanvas ~ .map .map-with-tracking-buttons {
+        max-width: none;
+      }
+
       @media print {
         page-break-before: always;
         width: 100%;

--- a/docs/ZIndex.md
+++ b/docs/ZIndex.md
@@ -28,6 +28,8 @@ Selector | Component | Z-Index | Comment
 `.itinerary-summary-row { .itinerary-legs { .line` | Summary result row leg lines | 1 |
 `.itinerary-summary-row { .itinerary-legs { .line { :after` | Hides the Summary result row leg lines behind the mode icon. | -1 |
 `.mobile.top-bar  | Mobile top bar | 1000 |
+`.desktop .map-content .map` | Contains map overlay stacking so buttons/attribution stay within the map | 1 |
+`.desktop .map-content .offcanvas` | Desktop settings drawer, kept above the map overlays | 900 |
 `.map-cluster-number-marker` | Cluster group marker for indoor route steps | 13000 |
 `.map-indoor-step-marker` | Indoor route step markers | 13050 |
 `.map-subway-entrance-info-icon-metro` | Entrance markers for indoor route | 13100 |


### PR DESCRIPTION
## Proposed Changes

  - Fixed Z-index causing the button to b rendered over the menu.
  - Adjusted button styles so that the white box around svg does not shrink away before it dissappears behind settings menu.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
