### PR TITLE
AB#659 - Add first leg text for citybikes and scooters

### DIFF
--- a/app/component/itinerary/FirstLegStartTime.js
+++ b/app/component/itinerary/FirstLegStartTime.js
@@ -2,12 +2,11 @@ import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { legTimeStr } from '../../util/legUtils';
 import {
-  legTimeStr,
-  isBikeOrScooterRentalLeg,
-  isScooterLeg,
-} from '../../util/legUtils';
-import { getFirstDepartureStopTypeText } from '../../util/localeUtils';
+  getFirstDepartureStopTypeText,
+  getFirstDepartureMessageId,
+} from '../../util/localeUtils';
 import Icon from '../Icon';
 import BoardingInformation from './BoardingInformation';
 import { legShape } from '../../util/shapes';
@@ -34,41 +33,11 @@ const FirstLegStartTime = ({
     );
   }
 
-  if (isBikeOrScooterRentalLeg(firstDeparture)) {
-    const firstDepartureTime = (
-      <span
-        className={cx('start-time', {
-          realtime: firstDeparture.realTime,
-        })}
-      >
-        {legTimeStr(firstDeparture.start)}
-      </span>
-    );
-    return (
-      <div className={cx('itinerary-first-leg-start-time', { small })}>
-        {isScooterLeg(firstDeparture) ? (
-          <FormattedMessage
-            id="itinerary-summary-row.first-leg-start-time-scooter"
-            values={{ firstDepartureTime }}
-          />
-        ) : (
-          <FormattedMessage
-            id="itinerary-summary-row.first-leg-start-time-citybike"
-            values={{
-              firstDepartureTime,
-              firstDepartureStop: firstDeparture.from.name,
-            }}
-          />
-        )}
-      </div>
-    );
-  }
-
   if (firstDeparture) {
     return (
       <div className={cx('itinerary-first-leg-start-time', { small })}>
         <FormattedMessage
-          id="itinerary-summary-row.first-leg-start-time"
+          id={getFirstDepartureMessageId(firstDeparture, false)}
           values={{
             firstDepartureTime: (
               <span
@@ -83,7 +52,7 @@ const FirstLegStartTime = ({
               intl,
               firstDeparture.mode,
             ),
-            // In case the first leg is a scooter leg, stopNames[0] is an empty string
+            // In case the first leg is a scooter leg, stopNames[0] is an empty string.
             firstDepartureStop: stopNames[0] || stopNames[1],
             firstDeparturePlatform: (
               <BoardingInformation leg={firstDeparture} />

--- a/app/component/itinerary/FirstLegStartTime.js
+++ b/app/component/itinerary/FirstLegStartTime.js
@@ -77,8 +77,4 @@ FirstLegStartTime.propTypes = {
   stopNames: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
-FirstLegStartTime.defaultProps = {
-  firstDeparture: null,
-};
-
 export default FirstLegStartTime;

--- a/app/component/itinerary/FirstLegStartTime.js
+++ b/app/component/itinerary/FirstLegStartTime.js
@@ -2,15 +2,14 @@ import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { legTimeStr, isBikeOrScooterRentalLeg } from '../../util/legUtils';
 import {
-  BIKEAVL_UNKNOWN,
-  getVehicleCapacity,
-} from '../../util/vehicleRentalUtils';
+  legTimeStr,
+  isBikeOrScooterRentalLeg,
+  isScooterLeg,
+} from '../../util/legUtils';
 import { getFirstDepartureStopTypeText } from '../../util/localeUtils';
 import Icon from '../Icon';
 import BoardingInformation from './BoardingInformation';
-import { useConfigContext } from '../../configurations/ConfigContext';
 import { legShape } from '../../util/shapes';
 
 const FirstLegStartTime = ({
@@ -20,7 +19,6 @@ const FirstLegStartTime = ({
   stopNames,
 }) => {
   const intl = useIntl();
-  const config = useConfigContext();
   const small = breakpoint !== 'large';
 
   if (hasCallAgencyLeg) {
@@ -37,38 +35,31 @@ const FirstLegStartTime = ({
   }
 
   if (isBikeOrScooterRentalLeg(firstDeparture)) {
+    const firstDepartureTime = (
+      <span
+        className={cx('start-time', {
+          realtime: firstDeparture.realTime,
+        })}
+      >
+        {legTimeStr(firstDeparture.start)}
+      </span>
+    );
     return (
       <div className={cx('itinerary-first-leg-start-time', { small })}>
-        <FormattedMessage
-          id="itinerary-summary-row.first-leg-start-time-citybike"
-          values={{
-            firstDepartureTime: (
-              <span
-                className={cx('start-time', {
-                  realtime: firstDeparture.realTime,
-                })}
-              >
-                {legTimeStr(firstDeparture.start)}
-              </span>
-            ),
-            firstDepartureStop: firstDeparture.from.name,
-          }}
-        />
-        <div>
-          {getVehicleCapacity(
-            config,
-            firstDeparture.from.vehicleRentalStation.rentalNetwork.networkId,
-          ) !== BIKEAVL_UNKNOWN && (
-            <FormattedMessage
-              id="bikes-available"
-              values={{
-                amount:
-                  firstDeparture.from.vehicleRentalStation.availableVehicles
-                    .total,
-              }}
-            />
-          )}
-        </div>
+        {isScooterLeg(firstDeparture) ? (
+          <FormattedMessage
+            id="itinerary-summary-row.first-leg-start-time-scooter"
+            values={{ firstDepartureTime }}
+          />
+        ) : (
+          <FormattedMessage
+            id="itinerary-summary-row.first-leg-start-time-citybike"
+            values={{
+              firstDepartureTime,
+              firstDepartureStop: firstDeparture.from.name,
+            }}
+          />
+        )}
       </div>
     );
   }

--- a/app/component/itinerary/Itinerary.js
+++ b/app/component/itinerary/Itinerary.js
@@ -27,7 +27,6 @@ import {
   isLegWithRoute,
   isBoardableLeg,
   isWalkOrBicycleWalkLeg,
-  isCarPickupZoneLeg,
 } from '../../util/legUtils';
 import {
   dateOrEmpty,
@@ -502,19 +501,12 @@ const Itinerary = ({
   const iconLegsInPixels = (24 * onlyIconLegCount) / normalLegCount;
   const hasCallAgencyLeg = itinerary.legs.some(leg => isCallAgencyLeg(leg));
 
-  // TODO the below 2 variables should be combined when it has been decided what to do with
-  // legs that have isBikeOrScooterRentalLeg=true (related to <FirstLegStartTime>)
-  const firstDepartureWithoutRental = compressedLegs.find(
-    leg =>
-      leg.transitLeg ||
-      isCarPickupZoneLeg(leg, config.carPickupZone.allowedRouteTypes),
-  );
   const firstDeparture = compressedLegs.find(leg =>
     isBoardableLeg(leg, config.carPickupZone.allowedRouteTypes),
   );
   const firstLegStartTime = (
     <FirstLegStartTime
-      firstDeparture={firstDepartureWithoutRental}
+      firstDeparture={firstDeparture}
       hasCallAgencyLeg={hasCallAgencyLeg}
       breakpoint={breakpoint}
       stopNames={stopNames}

--- a/app/translations/de.js
+++ b/app/translations/de.js
@@ -132,12 +132,12 @@ export default {
     'itinerary-summary-row.clickable-area-description': 'Auf der Karte zeigen',
     'itinerary-summary-row.description':
       'Route fährt ab {departureDate} {departureTime} mit Ankunft {arrivalDate} {arrivalTime}. {firstDeparture} {transfers} Gesamte Dauer {totalTime}.',
-    'itinerary-summary-row.first-departure':
-      '{vehicle} fährt um {firstDepartureTime} von {firstDepartureStop}.',
     'itinerary-summary-row.first-leg-start-time':
       'Fährt ab um {firstDepartureTime} von {firstDepartureStopType} {firstDepartureStop}',
     'itinerary-summary-row.first-leg-start-time-citybike':
       'Abfahrt um {firstDepartureTime} von {firstDepartureStop} Leihrad-Station',
+    'itinerary-summary-row.first-leg-start-time-sr':
+      '{vehicle} fährt um {firstDepartureTime} von {firstDepartureStop}.',
     'itinerary-summary-row.no-transit-legs': 'Start jederzeit möglich',
     'itinerary-summary-row.transfers':
       'Umstieg auf {vehicle} an Halt {stopName}',

--- a/app/translations/de.js
+++ b/app/translations/de.js
@@ -44,7 +44,6 @@ export default {
     bicycle_walk: 'Fahrrad schieben',
     'bike-availability': 'Fahrräder verfügbar',
     'bike-station-disabled': 'Pyöräasema ei ole käytössä.',
-    'bikes-available': 'Fahrräder verfügbar',
     'biking-speed': 'Geschwindigkeit mit dem Fahrrad',
     bus: 'Bus',
     'bus-with-route-number': 'Bus {routeNumber} {headSign}',

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -81,7 +81,6 @@ export default {
       'You can park your bike near the station or stop and continue your journey by public transport',
     'bike-park-disclaimer-header': 'Park your bike',
     'bike-station-disabled': 'The bike station is out of service.',
-    'bikes-available': '{amount} bikes at the station ',
     'biking-speed': 'Biking speed',
     'book-a-lift': 'Use taxis via the app',
     'booking-method': 'Booking method',

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -322,7 +322,7 @@ export default {
     'itinerary-summary-row.first-leg-start-time-citybike':
       'Departure at {firstDepartureTime} from {firstDepartureStop} bike station',
     'itinerary-summary-row.first-leg-start-time-scooter':
-      'Departure at {firstDepartureTime} by a scooter',
+      'Departure at {firstDepartureTime} with a scooter',
     'itinerary-summary-row.first-leg-start-time-sr':
       '{vehicle} leaves at {firstDepartureTime} from stop {firstDepartureStop} {firstDeparturePlatform}.',
     'itinerary-summary-row.first-leg-start-time-taxi':

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -229,7 +229,6 @@ export default {
     'from-bus': 'bus',
     'from-ferry': 'ferry',
     'from-ferrypier': 'ferry pier',
-    'from-place': ' ',
     'from-rail': 'train',
     'from-scooter-location': 'the scooter location',
     'from-station': 'station',
@@ -318,14 +317,14 @@ export default {
     'itinerary-summary-row.clickable-area-description': 'Show on map',
     'itinerary-summary-row.description':
       'Itinerary departing at {departureDate} {departureTime} and arriving at {arrivalDate} {arrivalTime}. {firstDeparture} {transfers} Total time {totalTime}.',
-    'itinerary-summary-row.first-departure':
-      '{vehicle} leaves at {firstDepartureTime} from stop {firstDepartureStop} {firstDeparturePlatform}.',
     'itinerary-summary-row.first-leg-start-time':
       'Leaves at {firstDepartureTime} from {firstDepartureStopType} {firstDepartureStop}{firstDeparturePlatform}',
     'itinerary-summary-row.first-leg-start-time-citybike':
       'Departure at {firstDepartureTime} from {firstDepartureStop} bike station',
     'itinerary-summary-row.first-leg-start-time-scooter':
       'Departure at {firstDepartureTime} by a scooter',
+    'itinerary-summary-row.first-leg-start-time-sr':
+      '{vehicle} leaves at {firstDepartureTime} from stop {firstDepartureStop} {firstDeparturePlatform}.',
     'itinerary-summary-row.first-leg-start-time-taxi':
       'Departure at {firstDepartureTime} by taxi from {firstDepartureStop}',
     'itinerary-summary-row.no-transit-legs': 'Leave when it suits you',

--- a/app/translations/fi.js
+++ b/app/translations/fi.js
@@ -76,7 +76,6 @@ export default {
       'Voit jättää pyörän parkkiin aseman tai pysäkin tuntumaan ja jatkaa matkaasi kätevästi julkisilla',
     'bike-park-disclaimer-header': 'Jätä pyörä parkkiin',
     'bike-station-disabled': 'Pyöräasema ei ole käytössä.',
-    'bikes-available': 'Pyöriä asemalla {amount}',
     'biking-speed': 'Pyöräilynopeus',
     'book-a-lift': 'Tilaa kyyti sovelluksella',
     'booking-method': 'Tilaustapa',

--- a/app/translations/fi.js
+++ b/app/translations/fi.js
@@ -224,7 +224,6 @@ export default {
     'from-bus': 'bussista',
     'from-ferry': 'lautasta',
     'from-ferrypier': 'lauttalaiturilta',
-    'from-place': 'kohteesta',
     'from-rail': 'junasta',
     'from-scooter-location': 'potkulaudan sijainti',
     'from-station': 'asemalta',
@@ -308,14 +307,14 @@ export default {
     'itinerary-summary-row.clickable-area-description': 'Näytä kartalla',
     'itinerary-summary-row.description':
       'Lähtö {departureDate} kello {departureTime}. Perillä {arrivalDate} kello {arrivalTime}. {firstDeparture} {transfers} Matka-aika {totalTime}',
-    'itinerary-summary-row.first-departure':
-      '{vehicle} lähtee asemalta {firstDepartureStop} kello {firstDepartureTime} {firstDeparturePlatform}.',
     'itinerary-summary-row.first-leg-start-time':
       'Lähtee klo {firstDepartureTime} {firstDepartureStopType} {firstDepartureStop}{firstDeparturePlatform}',
     'itinerary-summary-row.first-leg-start-time-citybike':
       'Lähtö klo {firstDepartureTime} kaupunkipyöräasemalta {firstDepartureStop}',
     'itinerary-summary-row.first-leg-start-time-scooter':
       'Lähtö klo {firstDepartureTime} sähköpotkulaudalla',
+    'itinerary-summary-row.first-leg-start-time-sr':
+      '{vehicle} lähtee asemalta {firstDepartureStop} kello {firstDepartureTime} {firstDeparturePlatform}.',
     'itinerary-summary-row.first-leg-start-time-taxi':
       'Lähtö klo {firstDepartureTime} taksilla kohteesta {firstDepartureStop}',
     'itinerary-summary-row.no-transit-legs': 'Lähde, kun sinulle sopii',

--- a/app/translations/pl.js
+++ b/app/translations/pl.js
@@ -75,7 +75,6 @@ export default {
       'You can park your bike near the station or stop and continue your journey conveniently by public transport',
     'bike-park-disclaimer-header': 'Zaparkuj rower',
     'bike-station-disabled': 'The bike station is out of service.',
-    'bikes-available': '{amount} rowery na stacji ',
     'biking-speed': 'Prędkość jazdy rowerem',
     bus: 'Autobus',
     'bus-express': 'Trunk bus',

--- a/app/translations/pl.js
+++ b/app/translations/pl.js
@@ -260,12 +260,12 @@ export default {
     'itinerary-summary-row.clickable-area-description': 'Pokaż na mapie',
     'itinerary-summary-row.description':
       'Itinerary departing at {departureDate} {departureTime} and arriving at {arrivalDate} {arrivalTime}. {firstDeparture} {transfers} Total time {totalTime}.',
-    'itinerary-summary-row.first-departure':
-      '{vehicle} odjeżdża o {firstDepartureTime} z przystanku {firstDepartureStop}.',
     'itinerary-summary-row.first-leg-start-time':
       'Odjeżdża o {firstDepartureTime} {firstDepartureStopType} {firstDepartureStop}{firstDeparturePlatform}',
     'itinerary-summary-row.first-leg-start-time-citybike':
       'Departure at {firstDepartureTime} from {firstDepartureStop} bike station',
+    'itinerary-summary-row.first-leg-start-time-sr':
+      '{vehicle} odjeżdża o {firstDepartureTime} z przystanku {firstDepartureStop}.',
     'itinerary-summary-row.no-transit-legs': 'Wyrusz, kiedy ci to pasuje',
     'itinerary-summary-row.transfers':
       'Transfer to {vehicle} on stop {stopName}',

--- a/app/translations/ro.js
+++ b/app/translations/ro.js
@@ -113,7 +113,7 @@ export default {
     'itinerary-summary-row.clickable-area-description': 'Afișați pe hartă',
     'itinerary-summary-row.description':
       'Itinerarul cu plecare la {departureDate} {departureTime} și sosire la {arrivalDate} {arrivalTime}. {firstDeparture} {transfers} Timp total {totalTime}.',
-    'itinerary-summary-row.first-departure':
+    'itinerary-summary-row.first-leg-start-time-sr':
       '{vehicle} pleacă la {firstDepartureTime} de la {firstDepartureStop}.',
     'itinerary-summary-row.transfers': 'Schimbați cu {vehicle} la {stopName}',
     'itinerary-summary.show-on-map': 'Vedeți pe hartă {target}',

--- a/app/translations/sv.js
+++ b/app/translations/sv.js
@@ -81,7 +81,6 @@ export default {
       'Du kan lämna cykeln på parkeringen vid stationen eller hållplatsen och fortsätta enkelt din resa med kollektivtrafiken',
     'bike-park-disclaimer-header': 'Lämna din cykel i parkeringen',
     'bike-station-disabled': 'Stadscykelstationen är ur bruk.',
-    'bikes-available': '{amount} cyklar vid stationen',
     'biking-speed': 'Cykling hastighet',
     'book-a-lift': 'Beställ skjuts med appen',
     'booking-method': 'Beställningssätt',

--- a/app/translations/sv.js
+++ b/app/translations/sv.js
@@ -227,7 +227,6 @@ export default {
     'from-bus': 'bussen',
     'from-ferry': 'färjan',
     'from-ferrypier': 'färjerkajen',
-    'from-place': ' ',
     'from-rail': 'tåget',
     'from-scooter-location': 'platsen för sparkcykel',
     'from-station': 'stationen',
@@ -314,14 +313,14 @@ export default {
     'itinerary-summary-row.clickable-area-description': 'Visa på kartan',
     'itinerary-summary-row.description':
       'Avgång {departureDate} klockan {departureTime}. Framme {arrivalDate} klockan {arrivalTime}. {firstDeparture} {transfers} Restid {totalTime}.',
-    'itinerary-summary-row.first-departure':
-      '{vehicle} avgår från station {firstDepartureStop} klockan {firstDepartureTime} {firstDeparturePlatform}.',
     'itinerary-summary-row.first-leg-start-time':
       'Avgår kl {firstDepartureTime} från {firstDepartureStopType} {firstDepartureStop}{firstDeparturePlatform}',
     'itinerary-summary-row.first-leg-start-time-citybike':
       'Avgång kl {firstDepartureTime} från {firstDepartureStop} stadscykelstation',
     'itinerary-summary-row.first-leg-start-time-scooter':
       'Avgång kl {firstDepartureTime} med en sparkcykel',
+    'itinerary-summary-row.first-leg-start-time-sr':
+      '{vehicle} avgår från station {firstDepartureStop} klockan {firstDepartureTime} {firstDeparturePlatform}.',
     'itinerary-summary-row.first-leg-start-time-taxi':
       'Taxi avgår från {firstDepartureStop} kl. {firstDepartureTime}',
     'itinerary-summary-row.no-transit-legs': 'Avgå när det passar för dig',

--- a/app/util/localeUtils.js
+++ b/app/util/localeUtils.js
@@ -1,9 +1,9 @@
 import { TransportMode } from '../constants';
 import {
   isBikeOrScooterRentalLeg,
+  isPlatformChanged,
   isScooterLeg,
   isTaxiLeg,
-  isPlatformChanged,
   legTimeStr,
 } from './legUtils';
 import { dateOrEmpty, durationToString } from './timeUtils';
@@ -126,7 +126,6 @@ const FIRST_DEPARTURE_STOP_TYPE_MSGS = {
   FERRY: { id: 'from-ferrypier' },
   RAIL: { id: 'from-station' },
   SUBWAY: { id: 'from-station' },
-  TAXI: { id: 'from-place' },
   default: { id: 'from-stop' },
 };
 
@@ -168,7 +167,10 @@ export function getBoardingInformationText(
   return '';
 }
 
-function getFirstDepartureLabelId(firstDepartureLeg) {
+export function getFirstDepartureMessageId(
+  firstDepartureLeg,
+  isScreenReaderMessage,
+) {
   if (isBikeOrScooterRentalLeg(firstDepartureLeg)) {
     return isScooterLeg(firstDepartureLeg)
       ? 'itinerary-summary-row.first-leg-start-time-scooter'
@@ -177,7 +179,9 @@ function getFirstDepartureLabelId(firstDepartureLeg) {
   if (isTaxiLeg(firstDepartureLeg)) {
     return 'itinerary-summary-row.first-leg-start-time-taxi';
   }
-  return 'itinerary-summary-row.first-departure';
+  return isScreenReaderMessage
+    ? 'itinerary-summary-row.first-leg-start-time-sr'
+    : 'itinerary-summary-row.first-leg-start-time';
 }
 
 /**
@@ -229,7 +233,7 @@ export function getSummaryDescriptionText(
   const firstDepartureText =
     vehicleNames.length && firstDeparture
       ? intl.formatMessage(
-          { id: getFirstDepartureLabelId(firstDeparture) },
+          { id: getFirstDepartureMessageId(firstDeparture, true) },
           {
             vehicle: vehicleNames[0],
             firstDepartureTime,


### PR DESCRIPTION
## Proposed Changes

  - Scooters and citybikes now have their own first leg text.
  - Scooters, citybikes, and taxis all now use their mode-specific translation keys.
  - Combine screen reader and visual text keys into one util function
  - Remove unused translation keys
  - Rename translation keys for clarity