### PR TITLE
AB#121-b consolidate z index

### DIFF
--- a/app/component/Snackbar.js
+++ b/app/component/Snackbar.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import cx from 'classnames';
 import { FormattedMessage, useIntl } from 'react-intl';
 import Icon from './Icon';
@@ -21,7 +22,7 @@ const Snackbar = ({
 }) => {
   const intl = useIntl();
   const config = useConfigContext();
-  return (
+  const content = (
     <>
       <div
         className={cx('snackbar', className, {
@@ -57,6 +58,17 @@ const Snackbar = ({
       </div>
     </>
   );
+
+  // Snackbar is portaled directly to document.body so it always escapes
+  // ancestor stacking contexts (e.g. the desktop offcanvas settings drawer,
+  // which establishes its own stacking context via position:relative +
+  // z-index). Without the portal, Snackbar's own z-index of 9999 would only
+  // apply *within* that ancestor's stacking context, so it could still be
+  // rendered behind unrelated elements (like the header) that live in a
+  // higher outer stacking context.
+  return typeof document !== 'undefined'
+    ? ReactDOM.createPortal(content, document.body)
+    : content;
 };
 
 Snackbar.propTypes = {

--- a/app/component/Snackbar.js
+++ b/app/component/Snackbar.js
@@ -53,7 +53,19 @@ const Snackbar = ({
           />
         </button>
       </div>
-      <div className="sr-only" aria-live="polite" role="status">
+      {/* .sr-only relies on position: absolute with no top/left, so its
+          static-position fallback is used. Portaled directly to
+          document.body (after all in-flow app content), that fallback
+          places it right at the bottom of the document, 1px below the
+          viewport, which creates a spurious scrollbar. Pinning it with an
+          inline style (highest CSS priority, so it overrides the shared
+          .sr-only rule) keeps it fixed to the viewport instead. */}
+      <div
+        className="sr-only"
+        style={{ position: 'fixed', top: 0, left: 0 }}
+        aria-live="polite"
+        role="status"
+      >
         {liveRegionMessage}
       </div>
     </>

--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -317,8 +317,13 @@ div.leaflet-marker-icon.vehicle-icon {
 }
 
 .map-control-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  line-height: 0;
   background-color: $white;
-  padding: 4px 6px;
   margin-top: 8px;
   border-radius: 5px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);

--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -1427,7 +1427,7 @@ div.map-click-prevent-overlay {
   top: 0;
   height: 100%;
   width: 100%;
-  z-index: 801;
+  z-index: global-z('map-click-prevent-overlay');
 }
 
 div.leaflet-control-scale.leaflet-control {

--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -656,6 +656,19 @@ section.content {
       display: flex;
       position: relative;
 
+      .map {
+        z-index: 1;
+      }
+
+      .offcanvas {
+        position: relative;
+        z-index: 900;
+      }
+
+      .offcanvas ~ .map .map-with-tracking-buttons {
+        max-width: none;
+      }
+
       @media print {
         page-break-before: always;
         width: 100%;

--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -39,7 +39,7 @@ $content-background-color: $background-color;
   justify-content: space-between;
   background: $top-bar-color;
   text-align: center;
-  z-index: 1008;
+  z-index: global-z('top-bar');
 
   // Fixed navbar height for now, as dynamic height leads to Safari issues
   // height: $topbar-height;
@@ -91,7 +91,7 @@ $content-background-color: $background-color;
 .mobile.top-bar {
   height: 50px;
   min-height: 50px;
-  z-index: 1000;
+  z-index: global-z('mobile-top-bar');
   background: $top-bar-color;
 
   .logo {
@@ -477,7 +477,7 @@ $content-background-color: $background-color;
   top: 0;
   left: 0;
   opacity: 0;
-  z-index: 1200;
+  z-index: global-z('mobile-menu-background');
   transition:
     left 0ms cubic-bezier(0.23, 1, 0.32, 1) 0ms,
     opacity 400ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
@@ -497,7 +497,7 @@ $content-background-color: $background-color;
   left: auto;
   right: 0;
   height: 100%;
-  z-index: 1300;
+  z-index: global-z('mobile-menu-content');
   box-shadow:
     rgba(0, 0, 0, 0.16) 0 3px 10px,
     rgba(0, 0, 0, 0.23) 0 3px 10px;
@@ -662,7 +662,7 @@ section.content {
 
       .offcanvas {
         position: relative;
-        z-index: 900;
+        z-index: global-z('desktop-settings-drawer');
       }
 
       .offcanvas ~ .map .map-with-tracking-buttons {

--- a/app/component/snackbar.scss
+++ b/app/component/snackbar.scss
@@ -21,7 +21,7 @@
   position: fixed;
   left: 50%;
   top: 78px;
-  z-index: 9999;
+  z-index: global-z('snackbar');
   color: #fff;
   display: flex;
   width: 480px;

--- a/app/component/stop/stop.scss
+++ b/app/component/stop/stop.scss
@@ -472,7 +472,7 @@
 #stop-page-action-bar {
   display: flex;
   justify-content: space-between;
-  z-index: 400; // get shadow over map
+  z-index: global-z('map-overlay-shadow'); // get shadow over map
   padding: 5px 10px;
   padding-bottom: 0.6em;
   text-align: right;

--- a/app/component/util.scss
+++ b/app/component/util.scss
@@ -242,7 +242,9 @@ $btn-heigth: 17px;
   position: fixed;
   width: 100%;
   height: 100%;
-  z-index: 1008;
+
+  // matches .top-bar so overlay + header agree on stacking level
+  z-index: global-z('top-bar');
   top: 0;
   left: 0;
 }

--- a/docs/ZIndex.md
+++ b/docs/ZIndex.md
@@ -12,6 +12,7 @@ Selector | Component | Z-Index | Comment
 `N/A` | Loading Page | 40000 |
 `.spinner-loader` | RoutePage | 40000 |
 `.top-bar` | AppBar | 1008 |
+`.snackbar` | Snackbar | 9999 | Rendered via a React portal directly under `document.body` so it always escapes ancestor stacking contexts (e.g. `.desktop .map-content .offcanvas`, which has its own z-index of 900) instead of being capped by them.
 `div.leaflet-marker-icon.from, div.leaflet-marker-icon.to { > span { &::before` | From/To marker letters | 1000 | Could be removed through new icon components
 `#splash-container` | Splash screen |  802 |
 `.toggle-positioning-container` | Pan-to-your-position button | 802 |
@@ -28,6 +29,8 @@ Selector | Component | Z-Index | Comment
 `.itinerary-summary-row { .itinerary-legs { .line` | Summary result row leg lines | 1 |
 `.itinerary-summary-row { .itinerary-legs { .line { :after` | Hides the Summary result row leg lines behind the mode icon. | -1 |
 `.mobile.top-bar  | Mobile top bar | 1000 |
+`.desktop .map-content .map` | Contains map overlay stacking so buttons/attribution stay within the map | 1 |
+`.desktop .map-content .offcanvas` | Desktop settings drawer, kept above the map overlays | 900 |
 `.map-cluster-number-marker` | Cluster group marker for indoor route steps | 13000 |
 `.map-indoor-step-marker` | Indoor route step markers | 13050 |
 `.map-subway-entrance-info-icon-metro` | Entrance markers for indoor route | 13100 |

--- a/docs/ZIndex.md
+++ b/docs/ZIndex.md
@@ -36,6 +36,16 @@ below uses the separate `$zindex` ordered list (`index($zindex, name)` in
 `sass/base/_zindex.scss`), which is fine for that purpose since all of those
 layers live inside the same local stacking scope.
 
+`$zindex` only lists names actually referenced via `index($zindex, name)` in
+this repo (`ui`). Note that several packages under `digitransit-component/`
+declare their *own*, separately-maintained copy of a `$zindex` list (each
+compiled independently, so there's no risk of one silently overriding
+another) - but those copies have already drifted out of sync with this one
+and with each other (different members/order), so don't assume a name here
+resolves to the same number in a component package. If elements from both
+sides ever need to be compared for real cross-component stacking, use
+`$global-zindex`/`global-z()` instead, not `index($zindex, name)`.
+
 Selector | Component | Z-Index | Comment
 ---------|-----------|---------|--------
 `.fullscreen-toggle` | Map fullscreen toggle | `index($zindex, map-fullscreen-toggle)` |

--- a/docs/ZIndex.md
+++ b/docs/ZIndex.md
@@ -2,35 +2,60 @@
 
 This is a list of the existing z-index values of UI components. The z-index property should only be used when absolutely necessary, and its use should be documented in the table below.
 
+## Global, page-level layers
+
+These values compete across *independent, page-level* stacking contexts (header,
+drawers, overlays, notifications, etc). They are centralized in the
+`$global-zindex` Sass map in `sass/base/_zindex.scss` and consumed via the
+`global-z('name')` function, instead of being hardcoded per component. This
+guarantees a single source of truth and prevents accidental collisions like the
+one described in the Snackbar row below. When adding a new global layer, add it
+to `$global-zindex` first (with a comment explaining why it needs that value
+relative to its neighbors), then reference it with `global-z('name')`, and
+update this table.
+
+Name (`$global-zindex` key) | Selector(s) | Z-Index | Comment
+-----------------------------|-------------|---------|--------
+`map-overlay-shadow` | `#stop-page-action-bar` | 400 | Shadow that should sit just above the map surface.
+`map-click-prevent-overlay` | `.map-click-prevent-overlay` | 801 | Overlay to prevent interaction with the map.
+`desktop-settings-drawer` | `.desktop .map-content .offcanvas` | 900 | Desktop settings drawer, kept above the map overlays/buttons.
+`mobile-top-bar` | `.mobile.top-bar` | 1000 | Mobile top bar.
+`top-bar` | `.top-bar`, `.popup-dark-overlay` | 1008 | Desktop top bar/AppBar. `.popup-dark-overlay` intentionally shares this value so full-page dark overlays sit at the same level as the header.
+`mobile-menu-background` | `.menu-background` | 1200 | Mobile main menu drawer background dimmer.
+`mobile-menu-content` | `.menu-content` | 1300 | Mobile main menu drawer content panel.
+`snackbar` | `.snackbar` | 9999 | Rendered via a React portal directly under `document.body` (see `app/component/Snackbar.js`) so it always escapes ancestor stacking contexts - e.g. `.desktop .map-content .offcanvas`, which forms its own stacking context via `position: relative` + `z-index: 900`. Without the portal, Snackbar's local `z-index: 9999` would only apply *within* that ancestor's stacking context and could still render behind unrelated elements (like the header) that live in a different, higher-level stacking context.
+`loading-spinner` | `div.spinner-loader` | 40000 | Full-page loading spinner, must appear above everything else.
+
+## Local, component-scoped values
+
+These are small integers used only to order a handful of siblings *within one
+component's own stacking context* (e.g. layering a couple of overlapping icons).
+They don't compete with unrelated components at the page level, so they are
+kept as plain literals rather than centralized. The map/search input family
+below uses the separate `$zindex` ordered list (`index($zindex, name)` in
+`sass/base/_zindex.scss`), which is fine for that purpose since all of those
+layers live inside the same local stacking scope.
+
 Selector | Component | Z-Index | Comment
 ---------|-----------|---------|--------
-`.modal-overlay` | Modal util | 1400 |
-`.menu-background` | Mobile menu drawer background | 1200 |
-`.menu-content` | Mobile menu drawer | 1300 |
-`.search-modal` | Search modal | 1301 |
-`.search-modal-overlay` | Search modal | 1100 |
-`N/A` | Loading Page | 40000 |
-`.spinner-loader` | RoutePage | 40000 |
-`.top-bar` | AppBar | 1008 |
-`.snackbar` | Snackbar | 9999 | Rendered via a React portal directly under `document.body` so it always escapes ancestor stacking contexts (e.g. `.desktop .map-content .offcanvas`, which has its own z-index of 900) instead of being capped by them.
-`div.leaflet-marker-icon.from, div.leaflet-marker-icon.to { > span { &::before` | From/To marker letters | 1000 | Could be removed through new icon components
-`#splash-container` | Splash screen |  802 |
-`.toggle-positioning-container` | Pan-to-your-position button | 802 |
-`.message-bar` | Messagebar | 802 |
-`.search-form-map-overlay` | Fake search field | 802 |
-`.fullscreen-toggle` | Map fullscreen toggle | 802 |
-`.background-gradient` | Shadow at top of map | 400 |
-`.map-click-prevent-overlay` | Overlay to prevent interaction with map | 801 |
-`.itinerary-feedback-container .form-container` | Itinerary feedback form | 800 | Component not in use
-`#stop-page-action-bar` | tool bar on stop page so that the shadow casts over the map|  400 |
+`.fullscreen-toggle` | Map fullscreen toggle | `index($zindex, map-fullscreen-toggle)` |
 `.trip-from, .trip-to` | Route schedule times | 1 |
 `.route-stop { div { .route-now-content { svg` | Selected trip icon with tail | 1 |
 `.origin-destination-bar { .field-link { span:first-child { &::before` | Summary search bar from/to marker letters | 1 | Could be removed through new icon components
 `.itinerary-summary-row { .itinerary-legs { .line` | Summary result row leg lines | 1 |
 `.itinerary-summary-row { .itinerary-legs { .line { :after` | Hides the Summary result row leg lines behind the mode icon. | -1 |
-`.mobile.top-bar  | Mobile top bar | 1000 |
 `.desktop .map-content .map` | Contains map overlay stacking so buttons/attribution stay within the map | 1 |
-`.desktop .map-content .offcanvas` | Desktop settings drawer, kept above the map overlays | 900 |
 `.map-cluster-number-marker` | Cluster group marker for indoor route steps | 13000 |
 `.map-indoor-step-marker` | Indoor route step markers | 13050 |
 `.map-subway-entrance-info-icon-metro` | Entrance markers for indoor route | 13100 |
+
+## Known undocumented/local z-index usages (follow-up)
+
+The audit that produced the table above found several other hardcoded
+`z-index` declarations in the codebase (e.g. in `popover.scss`,
+`itinerary.scss`, `navigator.scss`, `search-settings.scss`,
+`date-select-grouped.scss`, `trafficnow/`). Most of these are local ordering
+within a single component and are low risk, but a few (like the `1000`/`999`
+pair in `navigator.scss`, explicitly commented "higher than navbar") sit close
+enough to the global layers above that they deserve a closer look and possibly
+migration into `$global-zindex` in a future pass.

--- a/sass/base/_base.scss
+++ b/sass/base/_base.scss
@@ -174,7 +174,7 @@ h1 a {
 }
 
 div.spinner-loader {
-  z-index: 40000;
+  z-index: global-z('loading-spinner');
   position: absolute;
   left: 50%;
   margin: $spinner-size * 0.25 0 0 $spinner-size * -0.5;

--- a/sass/base/_zindex.scss
+++ b/sass/base/_zindex.scss
@@ -6,3 +6,43 @@ $zindex: base, map-container, map-gradient, map-fullscreen-toggle, map-buttons,
   autosuggest-suggestion-container, before-scrollable-area,
   click-prevent-overlay, front;
 $leaflet-overlay: 800;
+
+// Single source of truth for z-index values that compete across
+// *independent, page-level* stacking contexts (page chrome, drawers,
+// overlays, notifications, etc). Unlike $zindex above - which is an
+// ordered list meant for small, purely local sibling ordering within one
+// component's own stacking context - these are real, absolute numbers
+// with intentional gaps, so new layers can be inserted without
+// renumbering everything else. Keep this map and docs/ZIndex.md in sync.
+$global-zindex: (
+  // A thin shadow/overlay that should sit just above the map surface.
+  'map-overlay-shadow': 400,
+  // Overlay that blocks interaction with the map (e.g. while a modal is open).
+  'map-click-prevent-overlay': 801,
+  // Desktop settings drawer (.offcanvas), kept above map overlays/buttons.
+  'desktop-settings-drawer': 900,
+  // Mobile top bar / app header.
+  'mobile-top-bar': 1000,
+  // Desktop top bar / app header, and full-page dark overlays that should
+  // sit at the same level (e.g. .popup-dark-overlay).
+  'top-bar': 1008,
+  // Mobile main menu drawer background dimmer.
+  'mobile-menu-background': 1200,
+  // Mobile main menu drawer content panel.
+  'mobile-menu-content': 1300,
+  // Toast-style notification, portaled to document.body so it always
+  // escapes ancestor stacking contexts - see app/component/Snackbar.js.
+  'snackbar': 9999,
+  // Full-page loading spinner, must appear above everything else.
+  'loading-spinner': 40000
+);
+
+/// Returns the z-index for a named global layer defined in $global-zindex.
+/// Throws a build-time error for unknown names to prevent silent typos.
+@function global-z($name) {
+  @if not map-has-key($global-zindex, $name) {
+    @error "Unknown global z-index name `#{$name}`. Add it to $global-zindex in sass/base/_zindex.scss.";
+  }
+
+  @return map-get($global-zindex, $name);
+}

--- a/sass/base/_zindex.scss
+++ b/sass/base/_zindex.scss
@@ -1,10 +1,6 @@
-$zindex: base, map-container, map-gradient, map-fullscreen-toggle, map-buttons,
-  mobile-drawer, mobile-drawer-drag-line, context-panel, search-panel,
-  search-overlay, stop-route-station-input, destination-input, viapoint-input-5,
-  viapoint-input-4, viapoint-input-3, viapoint-input-2, viapoint-input-1,
-  origin-input, search-input-focus, search-input-icon,
-  autosuggest-suggestion-container, before-scrollable-area,
-  click-prevent-overlay, front;
+$zindex: base, map-container, map-fullscreen-toggle, map-buttons, mobile-drawer,
+  mobile-drawer-drag-line, autosuggest-suggestion-container,
+  before-scrollable-area, click-prevent-overlay, front;
 $leaflet-overlay: 800;
 
 // Single source of truth for z-index values that compete across


### PR DESCRIPTION
- Use centralized z index map instead of hard coded values
- Janne's geolocation button z index fix reapplied, broken snackbar fixed by rendering it to document.body
