### PR TITLE
AB#678 freeze ItineraryPage router match to last valid state

### DIFF
--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -143,7 +143,20 @@ const unset = { plan: {}, loading: LOADSTATE.UNSET };
 const noFocus = { center: undefined, zoom: undefined, bounds: undefined };
 
 export default function ItineraryPage(props, context) {
-  const { match, router } = useRouter();
+  const { match: routerMatch, router } = useRouter();
+  // found's useRouter() exposes the globally current match. While navigating
+  // away to an unrelated, paramless route (e.g. the embedded search generator
+  // from MainMenu), the router context can update to the new route's match
+  // before this component actually unmounts, so match.params/match.location
+  // can momentarily describe a completely different, non-itinerary route.
+  // Keep rendering the last known-good itinerary match in that case instead
+  // of crashing on missing from/to - this component is being torn down
+  // anyway and will unmount on the next render.
+  const lastValidMatchRef = useRef(routerMatch);
+  if (routerMatch.params.from && routerMatch.params.to) {
+    lastValidMatchRef.current = routerMatch;
+  }
+  const match = lastValidMatchRef.current;
   const config = useConfigContext();
   const headerRef = useRef(null);
   const mwtRef = useRef();

--- a/app/component/itinerary/navigator/NaviCardContainer.js
+++ b/app/component/itinerary/navigator/NaviCardContainer.js
@@ -166,7 +166,7 @@ function NaviCardContainer(
     }
     let timeoutId;
     if (legChanged) {
-      updateClient(getNaviTopics(), context);
+      updateClient(getNaviTopics(), context, config);
       setLegChanging(true);
       timeoutId = setTimeout(() => {
         setLegChanging(false);


### PR DESCRIPTION
found's useRouter() exposes the globally current match via context. When navigating away to an unrelated, paramless route (e.g. the embedded search generator link in MainMenu), that context can update to the new route's match before ItineraryPage actually unmounts, so match.params/match.location can momentarily describe a completely different route while this component is still mounted. This crashed in multiple, unrelated places that all assume a valid itinerary match (otpToLocation on params.from/to, and pathname parsing in updateLocalStorage).

Instead, freeze the match at its single source: keep using the last match that had both from and to params until the router provides another valid one. The component is being torn down anyway and unmounts on the next render, so briefly continuing to render with the last known-good match is safe and avoids crashing on every current and future param usage.