### PR TITLE
Fix mobile snackbar styles

### DIFF
--- a/app/component/Snackbar.js
+++ b/app/component/Snackbar.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import cx from 'classnames';
 import { FormattedMessage, useIntl } from 'react-intl';
 import Icon from './Icon';
+import withBreakpoint from '../util/withBreakpoint';
 import { useConfigContext } from '../configurations/ConfigContext';
 
 /**
@@ -19,6 +20,7 @@ const Snackbar = ({
   onClose,
   iconImg = 'icon_checkmark-circled',
   className,
+  breakpoint,
 }) => {
   const intl = useIntl();
   const config = useConfigContext();
@@ -29,6 +31,8 @@ const Snackbar = ({
           hide: show === null,
           show: show === true,
           'slide-out': show === false,
+          'mobile-snackbar': breakpoint !== 'large',
+          'desktop-snackbar': breakpoint === 'large',
         })}
         aria-hidden="true"
       >
@@ -92,6 +96,7 @@ Snackbar.propTypes = {
   onClose: PropTypes.func.isRequired,
   iconImg: PropTypes.string,
   className: PropTypes.string,
+  breakpoint: PropTypes.string.isRequired,
 };
 
-export default Snackbar;
+export default withBreakpoint(Snackbar);

--- a/app/component/snackbar.scss
+++ b/app/component/snackbar.scss
@@ -1,30 +1,41 @@
-.mobile {
-  .snackbar {
-    width: calc(100% - 32px);
-    left: 16px;
-    top: unset;
-    bottom: 16px;
+.mobile-snackbar {
+  width: calc(100% - 32px);
+  left: 16px;
+  top: unset;
+  bottom: 16px;
 
-    &.show {
-      animation: slideUpFromBottomWithMargin 0.5s $slide-up-down-animation;
-      transform: translateY(calc(100% + 16px));
-    }
+  &.show {
+    animation: slideUpFromBottomWithMargin 0.5s $slide-up-down-animation;
+    transform: translateY(calc(100% + 16px));
+  }
 
-    &.slide-out {
-      animation: slideDownWithMargin 1s ease-in-out forwards;
-      transform: translateY(0);
-    }
+  &.slide-out {
+    animation: slideDownWithMargin 1s ease-in-out forwards;
+    transform: translateY(0);
+  }
+}
+
+.desktop-snackbar {
+  left: 50%;
+  top: 78px;
+  width: 480px;
+
+  &.show {
+    animation: slideDownFromTopCenter 0.5s $slide-up-down-animation;
+    transform: translateY(calc(-100% - 78px)) translateX(-50%);
+  }
+
+  &.slide-out {
+    animation: slideUpToTopCenter 1s ease-in-out forwards;
+    transform: translateY(0) translateX(-50%);
   }
 }
 
 .snackbar {
   position: fixed;
-  left: 50%;
-  top: 78px;
   z-index: global-z('snackbar');
   color: #fff;
   display: flex;
-  width: 480px;
   min-width: 320px;
   max-height: 96px;
   padding: 16px;
@@ -39,16 +50,6 @@
   line-height: 27px;
   letter-spacing: $letter-spacing;
   align-items: center;
-
-  &.show {
-    animation: slideDownFromTopCenter 0.5s $slide-up-down-animation;
-    transform: translateY(calc(-100% - 78px)) translateX(-50%);
-  }
-
-  &.slide-out {
-    animation: slideUpToTopCenter 1s ease-in-out forwards;
-    transform: translateY(0) translateX(-50%);
-  }
 
   .icon-container {
     display: flex;


### PR DESCRIPTION
Rendering snackbar directly to a react portal left out .mobile class added by TopLevel.js, breaking the mobile styles of the snackbar. Now the styling does not rely on .mobile parent class.

