### PR TITLE
Start using leg.stopCalls instead of intermediatePlaces

### DIFF
--- a/app/component/itinerary/navigator/NaviCardExtension.js
+++ b/app/component/itinerary/navigator/NaviCardExtension.js
@@ -79,11 +79,12 @@ const NaviCardExtension = (
   }
 
   if (legType === LEGTYPE.TRANSIT) {
-    const { intermediatePlaces, headsign, trip, route } = leg;
+    const { headsign, trip, route } = leg;
+    const intermediateCount = leg.stopCalls ? leg.stopCalls.length - 2 : 0;
     const hs = headsign || trip.tripHeadsign;
-    const stopCount = <span className="bold">{intermediatePlaces.length}</span>;
+    const stopCount = <span className="bold">{intermediateCount}</span>;
     const translationId =
-      intermediatePlaces.length === 1
+      intermediateCount === 1
         ? 'navileg-one-intermediate-stop'
         : 'navileg-intermediate-stops';
     const mode = getTripOrRouteMode(trip, route, config);

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -414,16 +414,22 @@ export const getTransitLegState = (
 export function itinerarySearchPath(time, leg, nextLeg, position, to) {
   let from;
   if (leg?.transitLeg) {
-    from = leg.intermediatePlaces.find(
-      p => legTime(p.arrival) > time + EARLIEST_NEXT_STOP,
+    const intermediate = leg.stopCalls?.slice(1, -1) ?? [];
+    const sc = intermediate.find(
+      s =>
+        legTime({
+          scheduledTime: s.schedule?.time?.arrival,
+          estimated: s.realTime?.arrival
+            ? { time: s.realTime.arrival.time }
+            : undefined,
+        }) >
+        time + EARLIEST_NEXT_STOP,
     );
-    if (!from) {
-      from = leg.to;
-    }
+    from = sc ? sc.stopLocation : leg.to;
   } else {
     from = position || leg?.to || nextLeg?.from;
   }
-  const location = { ...from, ...from.stop };
+  const location = { ...from };
 
   return getItineraryPagePath(locationToUri(location), to);
 }

--- a/app/component/itinerary/navigator/NaviUtils.js
+++ b/app/component/itinerary/navigator/NaviUtils.js
@@ -18,7 +18,12 @@ import {
 } from '../../../util/localeUtils';
 import { locationToUri } from '../../../util/otpStrings';
 import { getItineraryPagePath } from '../../../util/path';
-import { durationToString, epochToIso, timeStr } from '../../../util/timeUtils';
+import {
+  durationToString,
+  epochToIso,
+  stopCallTime,
+  timeStr,
+} from '../../../util/timeUtils';
 import Icon from '../../Icon';
 import { getModeIconColor } from '../../../util/colorUtils';
 import RouteNumberContainer from '../../RouteNumberContainer';
@@ -416,14 +421,7 @@ export function itinerarySearchPath(time, leg, nextLeg, position, to) {
   if (leg?.transitLeg) {
     const intermediate = leg.stopCalls?.slice(1, -1) ?? [];
     const sc = intermediate.find(
-      s =>
-        legTime({
-          scheduledTime: s.schedule?.time?.arrival,
-          estimated: s.realTime?.arrival
-            ? { time: s.realTime.arrival.time }
-            : undefined,
-        }) >
-        time + EARLIEST_NEXT_STOP,
+      s => legTime(stopCallTime(s, 'arrival')) > time + EARLIEST_NEXT_STOP,
     );
     from = sc ? sc.stopLocation : leg.to;
   } else {

--- a/app/component/itinerary/queries/ItineraryDetailsFragment.js
+++ b/app/component/itinerary/queries/ItineraryDetailsFragment.js
@@ -253,23 +253,31 @@ export const ItineraryDetailsFragment = graphql`
         }
         viaLocationType
       }
-      intermediatePlaces {
-        arrival {
-          scheduledTime
-          estimated {
+      stopCalls {
+        schedule {
+          time {
+            ... on ArrivalDepartureTime {
+              arrival
+            }
+          }
+        }
+        realTime {
+          arrival {
             time
           }
         }
-        stop {
-          gtfsId
-          lat
-          lon
-          name
-          code
-          platformCode
-          zoneId
-          parentStation {
+        stopLocation {
+          ... on Stop {
             gtfsId
+            lat
+            lon
+            name
+            code
+            platformCode
+            zoneId
+            parentStation {
+              gtfsId
+            }
           }
         }
       }

--- a/app/component/itinerary/queries/ItineraryFragment.js
+++ b/app/component/itinerary/queries/ItineraryFragment.js
@@ -28,18 +28,29 @@ export const ItineraryFragment = graphql`
       duration
       rentedBike
       interlineWithPreviousLeg
-      intermediatePlaces {
-        stop {
-          zoneId
-          gtfsId
-          parentStation {
-            gtfsId
+      stopCalls {
+        schedule {
+          time {
+            ... on ArrivalDepartureTime {
+              arrival
+            }
           }
         }
-        arrival {
-          scheduledTime
-          estimated {
+        realTime {
+          arrival {
             time
+          }
+        }
+        stopLocation {
+          ... on Stop {
+            zoneId
+            gtfsId
+            lat
+            lon
+            name
+            parentStation {
+              gtfsId
+            }
           }
         }
       }

--- a/app/component/itinerary/queries/LegQuery.js
+++ b/app/component/itinerary/queries/LegQuery.js
@@ -23,18 +23,26 @@ export const legQuery = graphql`
         alertHeaderText
         id
       }
-      intermediatePlaces {
-        arrival {
-          scheduledTime
-          estimated {
+      stopCalls {
+        schedule {
+          time {
+            ... on ArrivalDepartureTime {
+              arrival
+            }
+          }
+        }
+        realTime {
+          arrival {
             time
           }
         }
-        stop {
-          gtfsId
-          lat
-          lon
-          name
+        stopLocation {
+          ... on Stop {
+            gtfsId
+            lat
+            lon
+            name
+          }
         }
       }
       to {

--- a/app/component/itinerary/queries/PlanConnection.js
+++ b/app/component/itinerary/queries/PlanConnection.js
@@ -91,20 +91,28 @@ export const planConnection = graphql`
               alertHeaderText
               id
             }
-            intermediatePlaces {
-              arrival {
-                scheduledTime
-                estimated {
+            stopCalls {
+              schedule {
+                time {
+                  ... on ArrivalDepartureTime {
+                    arrival
+                  }
+                }
+              }
+              realTime {
+                arrival {
                   time
                 }
               }
-              stop {
-                gtfsId
-                lat
-                lon
-                name
-                code
-                platformCode
+              stopLocation {
+                ... on Stop {
+                  gtfsId
+                  lat
+                  lon
+                  name
+                  code
+                  platformCode
+                }
               }
             }
             start {

--- a/app/component/map/ItineraryLine.js
+++ b/app/component/map/ItineraryLine.js
@@ -200,16 +200,17 @@ function ItineraryLine({
   }
 
   function handleIntermediateStops(leg, mode, objs) {
-    if (!passive && showIntermediateStops && leg.intermediatePlaces != null) {
-      leg.intermediatePlaces
-        .filter(place => place.stop)
-        .forEach(place =>
+    if (!passive && showIntermediateStops && leg.stopCalls != null) {
+      leg.stopCalls
+        .slice(1, -1)
+        .filter(sc => sc.stopLocation)
+        .forEach(sc =>
           objs.push(
             <StopMarker
               disableModeIcons
               limitZoom={14}
-              stop={place.stop}
-              key={`intermediate-${place.stop.gtfsId}`}
+              stop={sc.stopLocation}
+              key={`intermediate-${sc.stopLocation.gtfsId}`}
               mode={mode}
               thin
             />,

--- a/app/component/map/StreetQuery.js
+++ b/app/component/map/StreetQuery.js
@@ -146,13 +146,15 @@ const streetQuery = graphql`
                 vehicleMode
               }
             }
-            intermediatePlaces {
-              stop {
-                gtfsId
-                lat
-                lon
-                name
-                platformCode
+            stopCalls {
+              stopLocation {
+                ... on Stop {
+                  gtfsId
+                  lat
+                  lon
+                  name
+                  platformCode
+                }
               }
             }
           }

--- a/app/component/trafficnow/components/CanceledDepartures.js
+++ b/app/component/trafficnow/components/CanceledDepartures.js
@@ -92,6 +92,7 @@ const CanceledDepartures = ({
                   !expandedDates.includes(serviceDate) &&
                   !inline && (
                     <button
+                      type="button"
                       className="show-departures-button"
                       onClick={() =>
                         setExpandedDates([...expandedDates, serviceDate])

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -235,6 +235,23 @@ function includesAndRemove(array, id) {
   return false;
 }
 
+// Converts a StopCall (from leg.stopCalls) to a Place-compatible shape
+function stopCallToPlace(sc) {
+  const stop = sc.stopLocation;
+  return {
+    stop,
+    lat: stop?.lat,
+    lon: stop?.lon,
+    name: stop?.name,
+    arrival: {
+      scheduledTime: sc.schedule?.time?.arrival,
+      estimated: sc.realTime?.arrival
+        ? { time: sc.realTime.arrival.time }
+        : undefined,
+    },
+  };
+}
+
 function isViaPointMatch(stop, viaPoints) {
   return (
     stop &&
@@ -269,7 +286,9 @@ export function splitLegsAtViaPoints(originalLegs, viaPlaces) {
   let nextLegStartsWithIntermediate = false;
   originalLegs.forEach(originalLeg => {
     const leg = { ...originalLeg };
-    const { intermediatePlaces } = leg;
+    const intermediatePlaces = leg.stopCalls
+      ? leg.stopCalls.slice(1, -1).map(stopCallToPlace)
+      : leg.intermediatePlaces;
     if (
       nextLegStartsWithIntermediate ||
       (leg.transitLeg && isViaPointMatch(leg.from.stop, viaPoints))
@@ -277,7 +296,7 @@ export function splitLegsAtViaPoints(originalLegs, viaPlaces) {
       leg.viaStopCall = true;
       nextLegStartsWithIntermediate = false;
     }
-    if (intermediatePlaces) {
+    if (intermediatePlaces && intermediatePlaces.length > 0) {
       let start = 0;
       let lastSplit = -1;
       intermediatePlaces.forEach((place, i) => {
@@ -301,7 +320,11 @@ export function splitLegsAtViaPoints(originalLegs, viaPlaces) {
         leg.from = syntheticEndpoint(leg.from, lastPlace);
         leg.start = lastPlace.arrival;
         leg.intermediatePlaces = intermediatePlaces.slice(lastSplit + 1);
+      } else {
+        leg.intermediatePlaces = intermediatePlaces;
       }
+    } else {
+      leg.intermediatePlaces = [];
     }
     splitLegs.push(leg);
     if (leg.transitLeg && isViaPointMatch(leg.to.stop, viaPoints)) {
@@ -326,17 +349,16 @@ export function markViaPoints(originalLegs, viaPlaces) {
     const viaAddress = getViaPointAddress(leg.from, viaPlaces)?.address;
     const isViaPoint = !!leg.from.viaLocationType;
 
-    if (leg.intermediatePlaces) {
+    const rawPlaces = leg.stopCalls
+      ? leg.stopCalls.slice(1, -1).map(stopCallToPlace)
+      : leg.intermediatePlaces;
+    if (rawPlaces && rawPlaces.length > 0) {
       // ViaLocationType pass_through
       const viaPoints = viaPlaces.map(p => p.gtfsId);
-      const intermediatePlaces = [];
-
-      leg.intermediatePlaces.forEach(place => {
-        intermediatePlaces.push({
-          ...place,
-          isViaPoint: isViaPointMatch(place.stop, viaPoints),
-        });
-      });
+      const intermediatePlaces = rawPlaces.map(place => ({
+        ...place,
+        isViaPoint: isViaPointMatch(place.stop, viaPoints),
+      }));
       legs.push({
         ...leg,
         intermediatePlaces,
@@ -346,6 +368,7 @@ export function markViaPoints(originalLegs, viaPlaces) {
     } else {
       legs.push({
         ...leg,
+        intermediatePlaces: [],
         isViaPoint,
         viaAddress,
       });
@@ -678,7 +701,19 @@ export function getZones(legs) {
         maxCharCode,
       );
     }
-    if (Array.isArray(leg.intermediatePlaces)) {
+    if (Array.isArray(leg.stopCalls)) {
+      leg.stopCalls
+        .slice(1, -1)
+        .filter(sc => sc.stopLocation?.zoneId)
+        .forEach(sc => {
+          const zoneCharCode = sc.stopLocation.zoneId.charCodeAt(0);
+          [minCharCode, maxCharCode] = getNewMinMaxCharCodes(
+            zoneCharCode,
+            minCharCode,
+            maxCharCode,
+          );
+        });
+    } else if (Array.isArray(leg.intermediatePlaces)) {
       leg.intermediatePlaces
         .filter(place => place.stop && place.stop.zoneId)
         .forEach(place => {

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -2,6 +2,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { getTripOrRouteMode } from './modeUtils';
 import { BIKEAVL_UNKNOWN } from './vehicleRentalUtils';
 import { ExtendedRouteTypes, OtpCornerNamingPattern } from '../constants';
+import { stopCallTime } from './timeUtils';
 
 /**
  * Gets a (nested) property value from an object
@@ -243,12 +244,7 @@ function stopCallToPlace(sc) {
     lat: stop?.lat,
     lon: stop?.lon,
     name: stop?.name,
-    arrival: {
-      scheduledTime: sc.schedule?.time?.arrival,
-      estimated: sc.realTime?.arrival
-        ? { time: sc.realTime.arrival.time }
-        : undefined,
-    },
+    arrival: stopCallTime(sc, 'arrival'),
   };
 }
 

--- a/app/util/shapes.js
+++ b/app/util/shapes.js
@@ -291,9 +291,23 @@ export const legShape = PropTypes.shape({
   }),
   rentedBike: PropTypes.bool,
   departureDelay: PropTypes.number,
+  stopCalls: PropTypes.arrayOf(
+    PropTypes.shape({
+      schedule: PropTypes.shape({
+        time: PropTypes.shape({
+          arrival: PropTypes.string,
+        }),
+      }),
+      realTime: PropTypes.shape({
+        arrival: PropTypes.shape({ time: PropTypes.string }),
+      }),
+      stopLocation: stopShape,
+    }),
+  ),
   intermediatePlaces: PropTypes.arrayOf(
     PropTypes.shape({
       arrival: legTimeShape,
+      stop: stopShape,
     }),
   ),
   interlineWithPreviousLeg: PropTypes.bool,

--- a/app/util/timeUtils.js
+++ b/app/util/timeUtils.js
@@ -26,6 +26,22 @@ export function getStartTimeWithColon(seconds) {
 }
 
 /**
+ * Builds a legTime-compatible object (scheduledTime/estimated) for a stop call's
+ * arrival or departure, as returned by leg.stopCalls.
+ * @param {Object} stopCall a StopCall from leg.stopCalls
+ * @param {'arrival'|'departure'} eventType
+ * @returns {{scheduledTime: string, estimated: ({time: string}|undefined)}}
+ */
+export function stopCallTime(stopCall, eventType) {
+  return {
+    scheduledTime: stopCall.schedule?.time?.[eventType],
+    estimated: stopCall.realTime?.[eventType]
+      ? { time: stopCall.realTime[eventType].time }
+      : undefined,
+  };
+}
+
+/**
  * @param {number} startTime milliseconds since 1970 UTC
  * @param {number} [refTime] milliseconds since 1970 UTC
  * @returns {boolean} true if startTime is the same day compared to refTime or if refTime is not given and startTime is today


### PR DESCRIPTION
## Proposed Changes

  - intermediatePlaces has been deprecated for a while, so moving onto the new leg.stopCalls. A notable difference (besides the structure) is that the stopCalls contains all stops, not just the intermediate ones.


## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
