### PR TITLE
Replace old hsl-fi button usage on traffic now page

### DIFF
--- a/app/component/trafficnow/CanceledTrips.js
+++ b/app/component/trafficnow/CanceledTrips.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import Button from '@hsl-fi/button';
+import { Button } from '@hsl-fi/layout-primitives';
 import cx from 'classnames';
 import Link from 'found/Link';
 import PropTypes from 'prop-types';
@@ -64,22 +64,23 @@ const CanceledTrips = ({ canceledRoutes = [], mode, isMobile = false }) => {
             totalAmount={canceledRoutes.length}
           />
           {showAmount < canceledRoutes.length && (
-            <Button
-              className="load-more-button link-bold-small"
-              size="small"
-              fullWidth={false}
-              variant="white"
-              value={intl.formatMessage({ id: 'show-more' })}
-              onClick={() =>
-                setShowAmount(
-                  // cannot be set to more than the amount of cancellations
-                  showAmount + DEFAULT_ROUTES_SHOWN_AMOUNT >
-                    canceledRoutes.length
-                    ? canceledRoutes.length
-                    : showAmount + DEFAULT_ROUTES_SHOWN_AMOUNT,
-                )
-              }
-            />
+            <div className="canceled-trips__footer-show-more-container">
+              <Button
+                size="s"
+                variant="secondary"
+                onClick={() =>
+                  setShowAmount(
+                    // cannot be set to more than the amount of cancellations
+                    showAmount + DEFAULT_ROUTES_SHOWN_AMOUNT >
+                      canceledRoutes.length
+                      ? canceledRoutes.length
+                      : showAmount + DEFAULT_ROUTES_SHOWN_AMOUNT,
+                  )
+                }
+              >
+                {intl.formatMessage({ id: 'show-more' })}
+              </Button>
+            </div>
           )}
         </div>
       </footer>

--- a/app/component/trafficnow/TrafficNow.js
+++ b/app/component/trafficnow/TrafficNow.js
@@ -1,7 +1,7 @@
 import { useIntl } from 'react-intl';
 import cx from 'classnames';
 import React, { useEffect, Suspense, useState } from 'react';
-import Button from '@hsl-fi/button';
+import { Button } from '@hsl-fi/layout-primitives';
 import { useRouter } from 'found';
 import ReactModal from 'react-modal';
 import { useBreakpoint } from '../../util/withBreakpoint';
@@ -107,16 +107,16 @@ const TrafficNow = () => {
                       onClose={() => setShowFiltersModal(false)}
                     />
                     <Button
-                      className="traffic-now__filters-button"
-                      size="medium"
-                      fullWidth
-                      variant="blue"
-                      value={intl.formatMessage({
+                      size="m"
+                      variant="primary"
+                      expandOnMobile
+                      onClick={() => setShowFiltersModal(true)}
+                    >
+                      {intl.formatMessage({
                         id: 'filters',
                         defaultMessage: 'Filters',
                       })}
-                      onClick={() => setShowFiltersModal(true)}
-                    />
+                    </Button>
                   </div>
                 )}
                 <Suspense fallback={<Loading />}>

--- a/app/component/trafficnow/filters/Filters.js
+++ b/app/component/trafficnow/filters/Filters.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
-import Button from '@hsl-fi/button';
+import { Button } from '@hsl-fi/layout-primitives';
 import PropTypes from 'prop-types';
 import ValidityPeriodFilter from './ValidityPeriodFilter';
 import { useFilterContext } from './FiltersContext';
@@ -51,28 +51,22 @@ const Filters = ({ onApplyClick = undefined, onResetClick = () => {} }) => {
   const buttons = (
     <>
       {onApplyClick && (
-        <Button
-          type="button"
-          size="medium"
-          fullWidth
-          variant="blue"
-          value={intl.formatMessage({
+        <Button size="m" variant="primary" onClick={onApplyClick}>
+          {intl.formatMessage({
             id: 'traffic-now_filters_view-results',
           })}
-          onClick={onApplyClick}
-        />
+        </Button>
       )}
       <Button
-        type="button"
-        size="medium"
+        size="m"
+        variant="secondary"
+        onClick={handleResetClick}
         disabled={
           JSON.stringify(selectedFilters) === JSON.stringify(DEFAULT_FILTERS)
         }
-        fullWidth={false}
-        variant="white"
-        value={intl.formatMessage({ id: 'clear-button-label' })}
-        onClick={handleResetClick}
-      />
+      >
+        {intl.formatMessage({ id: 'clear-button-label' })}
+      </Button>
     </>
   );
 

--- a/app/component/trafficnow/styles/cards.scss
+++ b/app/component/trafficnow/styles/cards.scss
@@ -83,8 +83,8 @@
           gap: var(--space-m);
         }
 
-        button.load-more-button {
-          border-radius: var(--radius-pill, 999px);
+        &-show-more-container {
+          align-self: center;
         }
       }
 


### PR DESCRIPTION
## Proposed Changes

  - Replaces old @hsl-fi/button usage with the button component from @hsl-fi/layout-primitives
  - Fixes theming issue that was happening with the old Button component

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
