### PR TITLE
Fix CI build: force transpile optional chaining/nullish coalescing for Webpack 4

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -39,6 +39,12 @@ module.exports = function bbl(api) {
       },
     ],
     ['inline-react-svg'],
+    // These packages are bundled by the main app's Webpack 4 build, whose
+    // bundled acorn parser cannot handle optional chaining (?.) or nullish
+    // coalescing (??) syntax. @babel/preset-env skips transpiling these for
+    // modern browserslist targets, so force them here regardless of target.
+    '@babel/plugin-transform-optional-chaining',
+    '@babel/plugin-transform-nullish-coalescing-operator',
   ];
   if (process.env.NODE_ENV === 'production') {
     plugins.push(...productionPlugins);

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -196,6 +196,12 @@ module.exports = {
             '@babel/plugin-syntax-dynamic-import',
             '@babel/plugin-transform-class-properties',
             '@babel/plugin-transform-json-strings',
+            // Webpack 4's bundled acorn parser cannot parse optional chaining
+            // (?.) or nullish coalescing (??) syntax. @babel/preset-env skips
+            // transpiling these for modern browserslist targets, so force
+            // them here regardless of target to keep Webpack 4 happy.
+            '@babel/plugin-transform-optional-chaining',
+            '@babel/plugin-transform-nullish-coalescing-operator',
           ],
         },
       },
@@ -217,6 +223,8 @@ module.exports = {
           plugins: [
             '@babel/plugin-transform-class-properties',
             '@babel/plugin-transform-json-strings',
+            '@babel/plugin-transform-optional-chaining',
+            '@babel/plugin-transform-nullish-coalescing-operator',
           ],
         },
       },
@@ -239,6 +247,8 @@ module.exports = {
             plugins: [
               '@babel/plugin-transform-class-properties',
               '@babel/plugin-transform-json-strings',
+              '@babel/plugin-transform-optional-chaining',
+              '@babel/plugin-transform-nullish-coalescing-operator',
             ],
           },
         },


### PR DESCRIPTION
The recent caniuse-lite/browserslist bump (21a457c6) narrowed the resolved browserslist targets to only very recent browsers, all of which natively support optional chaining (?.) and nullish coalescing (??). @babel/preset-env correctly stops transpiling these operators for such targets, but the project still uses Webpack 4, whose bundled acorn parser (6.4.2) cannot parse this syntax at all, causing "Module parse failed: Unexpected token" errors across dozens of files and breaking the docker-push CI job.

Explicitly add @babel/plugin-transform-optional-chaining and @babel/plugin-transform-nullish-coalescing-operator to:
- the app/, node_modules(@hsl-fi|@radix-ui|@floating-ui) and *.mjs babel-loader rules in webpack.config.babel.js (main app bundle)
- config/babel.config.js (used by rollup to build the digitransit-* workspace packages consumed by the main app)

so these operators are always compiled down regardless of future browserslist/caniuse-lite updates.

