### PR TITLE
AB#695 Fix crashing issue with downshift 9.4 on mobile autosuggest

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "8.3.9",
+  "version": "8.3.10",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [
@@ -28,11 +28,11 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^7.1.14",
+    "@digitransit-component/digitransit-component-autosuggest": "^7.1.15",
     "@digitransit-component/digitransit-component-icon": "^2.0.2",
     "@hsl-fi/sass": "1.0.0",
     "classnames": "2.5.1",
-    "downshift": "9.0.10",
+    "downshift": "9.4.0",
     "i18next": "^22.5.1",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "7.1.14",
+  "version": "7.1.15",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [
@@ -40,7 +40,7 @@
     "@digitransit-component/digitransit-component-suggestion-item": "^3.0.3",
     "@hsl-fi/sass": "1.0.0",
     "classnames": "2.5.1",
-    "downshift": "9.0.10",
+    "downshift": "9.4.0",
     "i18next": "^22.5.1",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/components/MobileView.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/components/MobileView.js
@@ -144,10 +144,8 @@ const MobileView = ({
     },
   });
   // call to suppress ref errors from downshift
-  getLabelProps({}, { suppressRefError: true });
   getMenuProps({}, { suppressRefError: true });
   getInputProps({}, { suppressRefError: true });
-  getItemProps({ index: -1 }, { suppressRefError: true });
 
   const handleValueChange = useCallback(
     newValue =>

--- a/digitransit-component/packages/digitransit-component-autosuggest/src/components/Suggestions.js
+++ b/digitransit-component/packages/digitransit-component-autosuggest/src/components/Suggestions.js
@@ -112,7 +112,9 @@ export const Suggestions = memo(function Suggestions({
           );
         })}
         {renderClearHistoryButton && (
-          <li {...getItemProps({ index: suggestions.length })}>
+          // Not a selectable downshift item, so getItemProps is intentionally
+          // not used here (its index would always be out of the items bounds).
+          <li>
             <button
               onClick={handleClearHistory}
               type="button"

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component",
-  "version": "5.0.17",
+  "version": "5.0.18",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-component",
   "module": "digitransit-component.mjs",
@@ -18,8 +18,8 @@
     "url": "git://github.com/HSLdevcom/digitransit-ui.git"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^7.1.14",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^8.3.9",
+    "@digitransit-component/digitransit-component-autosuggest": "^7.1.15",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "^8.3.10",
     "@digitransit-component/digitransit-component-control-panel": "^7.1.4",
     "@digitransit-component/digitransit-component-favourite-bar": "^5.0.6",
     "@digitransit-component/digitransit-component-favourite-editing-modal": "^5.0.5",
@@ -35,7 +35,7 @@
     "@hsl-fi/sass": "1.0.0",
     "@hsl-fi/shimmer": "0.1.2",
     "classnames": "2.5.1",
-    "downshift": "9.0.10",
+    "downshift": "9.4.0",
     "hoist-non-react-statics": "2.5.4",
     "i18next": "^22.5.1",
     "lodash": "4.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,15 +2074,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@npm:^8.3.9, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@npm:^8.3.10, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^7.1.14
+    "@digitransit-component/digitransit-component-autosuggest": ^7.1.15
     "@digitransit-component/digitransit-component-icon": ^2.0.2
     "@hsl-fi/sass": 1.0.0
     classnames: 2.5.1
-    downshift: 9.0.10
+    downshift: 9.4.0
     i18next: ^22.5.1
     lodash: 4.18.1
     lodash-es: 4.18.1
@@ -2093,7 +2093,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@npm:^7.1.14, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@npm:^7.1.15, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
@@ -2107,7 +2107,7 @@ __metadata:
     "@digitransit-component/digitransit-component-suggestion-item": ^3.0.3
     "@hsl-fi/sass": 1.0.0
     classnames: 2.5.1
-    downshift: 9.0.10
+    downshift: 9.4.0
     i18next: ^22.5.1
     lodash: 4.18.1
     lodash-es: 4.18.1
@@ -2275,8 +2275,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": "npm:^7.1.14"
-    "@digitransit-component/digitransit-component-autosuggest-panel": "npm:^8.3.9"
+    "@digitransit-component/digitransit-component-autosuggest": "npm:^7.1.15"
+    "@digitransit-component/digitransit-component-autosuggest-panel": "npm:^8.3.10"
     "@digitransit-component/digitransit-component-control-panel": "npm:^7.1.4"
     "@digitransit-component/digitransit-component-favourite-bar": "npm:^5.0.6"
     "@digitransit-component/digitransit-component-favourite-editing-modal": "npm:^5.0.5"
@@ -2291,7 +2291,7 @@ __metadata:
     "@hsl-fi/sass": 1.0.0
     "@hsl-fi/shimmer": 0.1.2
     classnames: 2.5.1
-    downshift: 9.0.10
+    downshift: 9.4.0
     hoist-non-react-statics: 2.5.4
     i18next: ^22.5.1
     lodash: 4.18.1


### PR DESCRIPTION
## Proposed Changes

  - After downshift upgrade, downshift maps out of bounds index values on getItemProps() to undefined which causes the app to crash
  - Calls with out of bounds index weren't doing anything before so we can safely remove those without effect

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
