### PR TITLE
AB#637 Filter past cancelations

### DIFF
--- a/app/component/trafficnow/CanceledTripsContainer.js
+++ b/app/component/trafficnow/CanceledTripsContainer.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useLazyLoadQuery } from 'react-relay/hooks';
 import { connectToStores } from 'fluxible-addons-react';
-import { DateTime } from 'luxon';
 import CanceledTrips from './CanceledTrips';
 import CanceledTripsForModeQuery from './queries/CanceledTripsForModeQuery';
 import { favouriteShape } from '../../util/shapes';
@@ -11,10 +10,15 @@ import { useFilterContext } from './filters/FiltersContext';
 import { splitGtfsId } from '../../util/gtfs';
 import { useConfigContext } from '../../configurations/ConfigContext';
 
-const CanceledTripsContainer = ({ mode, isMobile, favourites = [] }) => {
+const CanceledTripsContainer = ({
+  mode,
+  isMobile,
+  favourites = [],
+  dateTime,
+}) => {
   const { canceledTripsSummary } = useLazyLoadQuery(CanceledTripsForModeQuery, {
     mode: mode.toUpperCase(),
-    serviceDateRanges: [{ start: DateTime.now().toISODate(), end: null }],
+    runningTimeRanges: [{ start: dateTime, end: null }],
   });
   const favRoutes = favourites.map(({ gtfsId }) => gtfsId);
   const {
@@ -41,6 +45,7 @@ CanceledTripsContainer.propTypes = {
   mode: PropTypes.string.isRequired,
   isMobile: PropTypes.bool,
   favourites: PropTypes.arrayOf(favouriteShape),
+  dateTime: PropTypes.string.isRequired,
 };
 
 const connectedComponent = connectToStores(

--- a/app/component/trafficnow/Disruptions.js
+++ b/app/component/trafficnow/Disruptions.js
@@ -1,8 +1,8 @@
 import React, { useMemo, useRef } from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { FormattedMessage } from 'react-intl';
 import { useRouter } from 'found';
-import { DateTime } from 'luxon';
 import { useLazyLoadQuery } from 'react-relay/hooks';
 import { useConfigContext } from '../../configurations/ConfigContext';
 import { TransportMode } from '../../constants';
@@ -41,7 +41,7 @@ export function getCanceledModes(
     .filter(({ routes }) => routes.length);
 }
 
-export default function Disruptions() {
+export default function Disruptions({ dateTime }) {
   const breakpoint = useBreakpoint();
   const config = useConfigContext();
   const ref = useRef();
@@ -67,19 +67,24 @@ export default function Disruptions() {
           TransportMode.Ferry,
         ]
       : selectedFilters.vehicleModes.map(mode => mode.toUpperCase());
-  const canceledTripsVars = {
-    serviceDateRanges: [
-      {
-        start: DateTime.now().toISODate(),
-        end: null,
-      },
-    ],
-    fetchBus: modesToFetch.includes(TransportMode.Bus),
-    fetchTram: modesToFetch.includes(TransportMode.Tram),
-    fetchRail: modesToFetch.includes(TransportMode.Rail),
-    fetchSubway: modesToFetch.includes(TransportMode.Subway),
-    fetchFerry: modesToFetch.includes(TransportMode.Ferry),
-  };
+
+  // Memoized so the query variables stay stable across re-renders.
+  const canceledTripsVars = useMemo(
+    () => ({
+      runningTimeRanges: [
+        {
+          start: dateTime,
+          end: null,
+        },
+      ],
+      fetchBus: modesToFetch.includes(TransportMode.Bus),
+      fetchTram: modesToFetch.includes(TransportMode.Tram),
+      fetchRail: modesToFetch.includes(TransportMode.Rail),
+      fetchSubway: modesToFetch.includes(TransportMode.Subway),
+      fetchFerry: modesToFetch.includes(TransportMode.Ferry),
+    }),
+    [dateTime, selectedFilters.vehicleModes.join(',')],
+  );
 
   const cancelationsByMode = useLazyLoadQuery(
     CanceledTripsOverviewQuery,
@@ -157,3 +162,7 @@ export default function Disruptions() {
     </div>
   );
 }
+
+Disruptions.propTypes = {
+  dateTime: PropTypes.string.isRequired,
+};

--- a/app/component/trafficnow/TrafficNow.js
+++ b/app/component/trafficnow/TrafficNow.js
@@ -1,5 +1,6 @@
 import { useIntl } from 'react-intl';
 import cx from 'classnames';
+import PropTypes from 'prop-types';
 import React, { useEffect, Suspense, useState } from 'react';
 import { Button } from '@hsl-fi/layout-primitives';
 import { useRouter } from 'found';
@@ -20,7 +21,7 @@ import FiltersModal from './filters/FiltersModal';
 // defines the scroll position at which a drop shadow is applied to the header button on mobile
 const HEADER_HEIGHT = 320;
 
-const TrafficNow = () => {
+const TrafficNow = ({ dateTime }) => {
   const {
     match: {
       params: { mode, alertId },
@@ -86,7 +87,11 @@ const TrafficNow = () => {
             )}
             {!alertId && mode && (
               <Suspense fallback={<Loading />}>
-                <CanceledTripsContainer mode={mode} isMobile={mobile} />
+                <CanceledTripsContainer
+                  mode={mode}
+                  dateTime={dateTime}
+                  isMobile={mobile}
+                />
               </Suspense>
             )}
             {!alertId && !mode && (
@@ -120,7 +125,7 @@ const TrafficNow = () => {
                   </div>
                 )}
                 <Suspense fallback={<Loading />}>
-                  <Disruptions />
+                  <Disruptions dateTime={dateTime} />
                 </Suspense>
               </>
             )}
@@ -133,3 +138,7 @@ const TrafficNow = () => {
 };
 
 export default TrafficNow;
+
+TrafficNow.propTypes = {
+  dateTime: PropTypes.string.isRequired,
+};

--- a/app/component/trafficnow/components/CanceledDepartures.js
+++ b/app/component/trafficnow/components/CanceledDepartures.js
@@ -8,7 +8,6 @@ import groupBy from 'lodash/groupBy';
 import CanceledDeparturesFragment from '../queries/CanceledDeparturesFragment';
 import Icon from '../../Icon';
 import EntityBadge from './EntityBadge';
-import { stopShape } from '../../../util/shapes';
 
 const DEPARTURE_LIMIT = 10;
 
@@ -117,24 +116,7 @@ const CanceledDepartures = ({
 };
 
 CanceledDepartures.propTypes = {
-  patterns: PropTypes.arrayOf(
-    PropTypes.shape({
-      code: PropTypes.string.isRequired,
-      stops: PropTypes.arrayOf(stopShape).isRequired,
-      canceledTrips: PropTypes.arrayOf(
-        PropTypes.shape({
-          trip: PropTypes.shape({
-            gtfsId: PropTypes.string.isRequired,
-            stoptimes: PropTypes.arrayOf(
-              PropTypes.shape({
-                scheduledDeparture: PropTypes.number.isRequired,
-              }).isRequired,
-            ).isRequired,
-          }).isRequired,
-        }).isRequired,
-      ),
-    }).isRequired,
-  ).isRequired,
+  patterns: PropTypes.arrayOf(PropTypes.shape({})),
   departureLimit: PropTypes.number,
   inline: PropTypes.bool,
   mode: PropTypes.string,

--- a/app/component/trafficnow/queries/CanceledDeparturesFragment.js
+++ b/app/component/trafficnow/queries/CanceledDeparturesFragment.js
@@ -3,13 +3,15 @@ import { graphql } from 'react-relay';
 export default graphql`
   fragment CanceledDeparturesFragment on Pattern
   @relay(plural: true)
-  @argumentDefinitions(serviceDateRanges: { type: "[LocalDateRangeInput!]" }) {
+  @argumentDefinitions(
+    runningTimeRanges: { type: "[OffsetDateTimeRangeInput!]" }
+  ) {
     code
     headsign
     stops {
       name
     }
-    canceledTrips(serviceDateRanges: $serviceDateRanges) {
+    canceledTrips(runningTimeRanges: $runningTimeRanges) {
       serviceDate
       trip {
         gtfsId

--- a/app/component/trafficnow/queries/CanceledTripsForModeQuery.js
+++ b/app/component/trafficnow/queries/CanceledTripsForModeQuery.js
@@ -4,11 +4,11 @@ import './CanceledTripsPatternFragment';
 export default graphql`
   query CanceledTripsForModeQuery(
     $mode: TransitMode!
-    $serviceDateRanges: [LocalDateRangeInput!]!
+    $runningTimeRanges: [OffsetDateTimeRangeInput!]
   ) {
     canceledTripsSummary(
       filters: {
-        include: { modes: [$mode], serviceDateRanges: $serviceDateRanges }
+        include: { modes: [$mode], runningTimeRanges: $runningTimeRanges }
       }
     ) {
       routes {
@@ -24,7 +24,7 @@ export default graphql`
           pattern {
             code
             ...CanceledTripsPatternFragment
-              @arguments(serviceDateRanges: $serviceDateRanges)
+              @arguments(runningTimeRanges: $runningTimeRanges)
           }
         }
       }

--- a/app/component/trafficnow/queries/CanceledTripsOverviewQuery.js
+++ b/app/component/trafficnow/queries/CanceledTripsOverviewQuery.js
@@ -3,7 +3,7 @@ import './CanceledDeparturesFragment';
 
 export default graphql`
   query CanceledTripsOverviewQuery(
-    $serviceDateRanges: [LocalDateRangeInput!]!
+    $runningTimeRanges: [OffsetDateTimeRangeInput!]
     $fetchBus: Boolean!
     $fetchTram: Boolean!
     $fetchRail: Boolean!
@@ -12,7 +12,7 @@ export default graphql`
   ) {
     bus: canceledTripsSummary(
       filters: {
-        include: { modes: [BUS], serviceDateRanges: $serviceDateRanges }
+        include: { modes: [BUS], runningTimeRanges: $runningTimeRanges }
       }
     ) @include(if: $fetchBus) {
       routes {
@@ -27,7 +27,7 @@ export default graphql`
           cancellationCount
           pattern {
             ...CanceledDeparturesFragment
-              @arguments(serviceDateRanges: $serviceDateRanges)
+              @arguments(runningTimeRanges: $runningTimeRanges)
           }
         }
       }
@@ -35,7 +35,7 @@ export default graphql`
 
     tram: canceledTripsSummary(
       filters: {
-        include: { modes: [TRAM], serviceDateRanges: $serviceDateRanges }
+        include: { modes: [TRAM], runningTimeRanges: $runningTimeRanges }
       }
     ) @include(if: $fetchTram) {
       routes {
@@ -50,7 +50,7 @@ export default graphql`
           cancellationCount
           pattern {
             ...CanceledDeparturesFragment
-              @arguments(serviceDateRanges: $serviceDateRanges)
+              @arguments(runningTimeRanges: $runningTimeRanges)
           }
         }
       }
@@ -58,7 +58,7 @@ export default graphql`
 
     rail: canceledTripsSummary(
       filters: {
-        include: { modes: [RAIL], serviceDateRanges: $serviceDateRanges }
+        include: { modes: [RAIL], runningTimeRanges: $runningTimeRanges }
       }
     ) @include(if: $fetchRail) {
       routes {
@@ -73,7 +73,7 @@ export default graphql`
           cancellationCount
           pattern {
             ...CanceledDeparturesFragment
-              @arguments(serviceDateRanges: $serviceDateRanges)
+              @arguments(runningTimeRanges: $runningTimeRanges)
           }
         }
       }
@@ -81,7 +81,7 @@ export default graphql`
 
     subway: canceledTripsSummary(
       filters: {
-        include: { modes: [SUBWAY], serviceDateRanges: $serviceDateRanges }
+        include: { modes: [SUBWAY], runningTimeRanges: $runningTimeRanges }
       }
     ) @include(if: $fetchSubway) {
       routes {
@@ -96,7 +96,7 @@ export default graphql`
           cancellationCount
           pattern {
             ...CanceledDeparturesFragment
-              @arguments(serviceDateRanges: $serviceDateRanges)
+              @arguments(runningTimeRanges: $runningTimeRanges)
           }
         }
       }
@@ -104,7 +104,7 @@ export default graphql`
 
     ferry: canceledTripsSummary(
       filters: {
-        include: { modes: [FERRY], serviceDateRanges: $serviceDateRanges }
+        include: { modes: [FERRY], runningTimeRanges: $runningTimeRanges }
       }
     ) @include(if: $fetchFerry) {
       routes {
@@ -119,7 +119,7 @@ export default graphql`
           cancellationCount
           pattern {
             ...CanceledDeparturesFragment
-              @arguments(serviceDateRanges: $serviceDateRanges)
+              @arguments(runningTimeRanges: $runningTimeRanges)
           }
         }
       }

--- a/app/component/trafficnow/queries/CanceledTripsPatternFragment.js
+++ b/app/component/trafficnow/queries/CanceledTripsPatternFragment.js
@@ -3,7 +3,9 @@ import './CanceledDeparturesFragment';
 
 export default graphql`
   fragment CanceledTripsPatternFragment on Pattern
-  @argumentDefinitions(serviceDateRanges: { type: "[LocalDateRangeInput!]" }) {
+  @argumentDefinitions(
+    runningTimeRanges: { type: "[OffsetDateTimeRangeInput!]" }
+  ) {
     id
     code
     headsign
@@ -11,6 +13,6 @@ export default graphql`
       name
     }
     ...CanceledDeparturesFragment
-      @arguments(serviceDateRanges: $serviceDateRanges)
+      @arguments(runningTimeRanges: $runningTimeRanges)
   }
 `;

--- a/app/routes.js
+++ b/app/routes.js
@@ -355,6 +355,9 @@ export default config => {
                 /* webpackChunkName: "trafficnow" */ './component/trafficnow/TrafficNow'
               ).then(getDefault)
             }
+            render={({ Component }) =>
+              Component && <Component dateTime={new Date().toISOString()} />
+            }
           />
           <Route
             path={`/${TRAFFICNOW}/peruutukset/:mode`}
@@ -363,6 +366,9 @@ export default config => {
                 /* webpackChunkName: "trafficnow" */ './component/trafficnow/TrafficNow'
               ).then(getDefault)
             }
+            render={({ Component }) =>
+              Component && <Component dateTime={new Date().toISOString()} />
+            }
           />
           <Route
             path={TRAFFICNOW}
@@ -370,6 +376,9 @@ export default config => {
               import(
                 /* webpackChunkName: "trafficnow" */ './component/trafficnow/TrafficNow'
               ).then(getDefault)
+            }
+            render={({ Component }) =>
+              Component && <Component dateTime={new Date().toISOString()} />
             }
           />
           <Redirect from={`/${TRAFFICNOW}/*`} to={`/${TRAFFICNOW}`} />

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-query-utils",
-  "version": "4.5.12",
+  "version": "4.5.13",
   "description": "digitransit-search-util query-utils module",
   "main": "lib/index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/schema/schema.graphql
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/schema/schema.graphql
@@ -136,6 +136,13 @@ type Agency implements Node {
 "Alert of a current or upcoming disruption in public transportation"
 type Alert implements Node {
   """
+  The periods of time when this alert is active, sorted chronologically. There is always at
+  least one period. Each period has an inclusive start and an exclusive end. A period with an
+  unbounded start has always been active and a period with an unbounded end is active
+  indefinitely.
+  """
+  activityPeriods: [OffsetDateTimeRange!]!
+  """
   Agency affected by the disruption. Note that this value is present only if the
   disruption has an effect on all operations of the agency (e.g. in case of a strike).
   """
@@ -170,9 +177,9 @@ type Alert implements Node {
   "Url with more information in all different available languages"
   alertUrlTranslations: [TranslatedString!]! @deprecated(reason : "Use `alertUrl` instead. `accept-language` header can be used for translations or the `language` parameter on the `alertUrl` field.")
   "Time when this alert is not in effect anymore. Format: Unix timestamp in seconds"
-  effectiveEndDate: Long
+  effectiveEndDate: Long @deprecated(reason : "Use `activityPeriods` instead.")
   "Time when this alert comes into effect. Format: Unix timestamp in seconds"
-  effectiveStartDate: Long
+  effectiveStartDate: Long @deprecated(reason : "Use `activityPeriods` instead.")
   "Entities affected by the disruption."
   entities: [AlertEntity]
   "The feed in which this alert was published"
@@ -941,9 +948,9 @@ type Leg {
     originModesWithParentStation: [TransitMode!]
   ): [Leg!]
   "Whether there is real-time data about this Leg"
-  realTime: Boolean
+  realTime: Boolean @deprecated(reason : "Use `realTimeTripState.updated` on `TripOnServiceDate` instead.")
   "State of real-time data"
-  realtimeState: RealtimeState
+  realtimeState: RealtimeState @deprecated(reason : "Use `realTimeTripState` on `TripOnServiceDate` instead.")
   "Whether this leg is traversed with a rented vehicle."
   rentedBike: Boolean
   "Estimate of a hailed ride like Uber."
@@ -970,6 +977,8 @@ type Leg {
   transitLeg: Boolean
   "For transit legs, the trip that is used for traversing the leg. For non-transit legs, `null`."
   trip: Trip
+  "For transit legs, the trip on service date. For non-transit legs, `null`."
+  tripOnServiceDate: TripOnServiceDate
   "Whether this leg is walking with a bike."
   walkingBike: Boolean
 }
@@ -1050,6 +1059,31 @@ type Money {
   currency: Currency!
 }
 
+"""
+A textual message about a transit entity that is already known at planning time.
+
+It is not intended to convey real-time or emergency updates of the transit system but information that
+is known well ahead of time.
+"""
+type Notice {
+  "Textual representation of the message"
+  text: String
+}
+
+"""
+A range of time which can be unbounded in either direction.
+
+The start of the range is inclusive and the end is exclusive.
+A `null` start means that the range extends indefinitely into the past and a `null` end means
+that it extends indefinitely into the future.
+"""
+type OffsetDateTimeRange {
+  "The exclusive end of the range or `null` if the range is unbounded in the future."
+  end: OffsetDateTime
+  "The inclusive start of the range or `null` if the range is unbounded in the past."
+  start: OffsetDateTime
+}
+
 type OpeningHours {
   """
   Opening hours for the selected dates using the local time of the parking lot.
@@ -1106,6 +1140,18 @@ type Pattern implements Node {
   """
   canceledTrips(
     """
+    Only return canceled trips which are scheduled to be running during one of these time ranges.
+    A trip is considered to be running from its scheduled departure from the first stop until its
+    scheduled arrival at the last stop.
+        
+    An empty list or a list containing `null` is forbidden. If this argument is not provided or its
+    value is `null`, no filtering is applied.
+        
+    If both `runningTimeRanges` and `serviceDateRanges` are defined, a trip has to match both of
+    them to be returned.
+    """
+    runningTimeRanges: [OffsetDateTimeRangeInput!],
+    """
     Only return canceled trips whose service date falls within one of these ranges.
     An empty list or a list containing `null` is forbidden.  If this argument is not provided or its
     value is `null`, no filtering is applied.
@@ -1156,7 +1202,12 @@ type Pattern implements Node {
   tripsForDate(
     "Return trips of the pattern active on this date. Format: YYYYMMDD"
     serviceDate: String
-  ): [Trip!]
+  ): [Trip!] @deprecated(reason : "Use `tripsOnServiceDate`")
+  """
+  Instances of `TripOnServiceDates` which run on the specified date. If no trips run on this date
+  then this returns an empty list.
+  """
+  tripsOnServiceDate(serviceDate: LocalDate!): [TripOnServiceDate!]!
   "Real-time updated position of vehicles that are serving this pattern."
   vehiclePositions: [VehiclePosition!]
 }
@@ -2107,6 +2158,23 @@ type RealTimeEstimate {
   time: OffsetDateTime!
 }
 
+"The real-time state of a trip"
+type RealTimeTripState {
+  "Has the trip been added via real-time updates? (extra trip)"
+  added: Boolean!
+  "Has the trip been canceled?"
+  canceled: Boolean!
+  "Have any stop arrival or departure times been modified from the scheduled times?"
+  timesModified: Boolean!
+  """
+  Has the stop sequence changed from the scheduled pattern? True if stops were added, removed,
+  reordered, or reassigned to a different stop location (`assigned_stop_id`).
+  """
+  tripPatternModified: Boolean!
+  "Have there been any real-time updates on this trip?"
+  updated: Boolean!
+}
+
 "Rental vehicle represents a vehicle that belongs to a rental network."
 type RentalVehicle implements Node & PlaceInterface {
   "If true, vehicle is currently available for renting."
@@ -2270,6 +2338,8 @@ type Route implements Node {
   ): String
   "Transport mode of this route, e.g. `BUS`"
   mode: TransitMode
+  "Notices of this trip which are known ahead of time."
+  notices: [Notice!]! @deprecated(reason : "Experimental API that can be changed without notice.")
   "List of patterns which operate on this route"
   patterns(
     """
@@ -2389,11 +2459,28 @@ type Stop implements Node & PlaceInterface {
   """
   canceledCalls(
     """
+    Selects if only calls where boarding is allowed, only calls where alighting is allowed, or calls
+    where either boarding or alighting is possible (according to the original schedule).
+    """
+    arrivalDeparture: ArrivalDeparture = EITHER,
+    """
     Only include canceled calls whose trip's service date is within any of these date ranges.
     If omitted (or `null`), no service date filter is applied and canceled calls across the entire
     transit service period are returned. Defining a range is recommended.
     """
-    serviceDateRanges: [LocalDateRangeInput!]
+    serviceDateRanges: [LocalDateRangeInput!],
+    """
+    Only include canceled calls where the vehicle is scheduled to visit this stop during one of
+    these time ranges. The visit at a stop lasts from the scheduled arrival at the stop until the
+    scheduled departure from it.
+        
+    An empty list or a list containing `null` is forbidden. If this argument is not provided or its
+    value is `null`, no filtering is applied.
+        
+    If both `timeRanges` and `serviceDateRanges` are defined, a call has to match both of
+    them to be returned.
+    """
+    timeRanges: [OffsetDateTimeRangeInput!]
   ): [StopCallOnTripOnServiceDate!]!
   "The cluster which this stop is part of"
   cluster: Cluster @deprecated(reason : "Not implemented")
@@ -2552,6 +2639,8 @@ from a specific stop location.
 This may contain real-time information, if available.
 """
 type StopCall {
+  "Notices of this call which are known ahead of time."
+  notices: [Notice!]! @deprecated(reason : "Experimental API that can be changed without notice.")
   "Real-time estimates for arrival and departure times for this stop location."
   realTime: CallRealTime
   "Scheduled arrival and departure times for this stop location."
@@ -2644,7 +2733,12 @@ type Stoptime {
   realtimeArrival: Int
   "Real-time prediction of departure time. Format: seconds since midnight of the departure date"
   realtimeDeparture: Int
-  "State of real-time data"
+  """
+  State of real-time data. Currently used to determine, whether a stop has been canceled.
+  Disclaimer: this is, in most cases the trips realtime state, unless the stop is canceled,
+  then the Trips State will be overwritten to be CANCELED.
+  It is recommended to avoid using this field.
+  """
   realtimeState: RealtimeState
   "Scheduled arrival time. Format: seconds since midnight of the departure date"
   scheduledArrival: Int
@@ -2800,11 +2894,15 @@ type Trip implements Node {
   link in a DatedServiceJourney.
   """
   isReplacement: Boolean!
+  "Notices of the trip that are known ahead of time."
+  notices: [Notice!]! @deprecated(reason : "Experimental API that can be changed without notice.")
   """
   The latest real-time occupancy information for the latest occurance of this
   trip.
   """
   occupancy: TripOccupancy
+  "Return the trip on a specific service date or `null` if the trip does not run on it."
+  onServiceDate(date: LocalDate!): TripOnServiceDate
   "The pattern the trip is running on"
   pattern: Pattern
   """
@@ -2834,7 +2932,7 @@ type Trip implements Node {
   stoptimesForDate(
     "Date for which stoptimes are returned. Format: YYYYMMDD"
     serviceDate: String
-  ): [Stoptime]
+  ): [Stoptime] @deprecated(reason : "Use `onServiceDate` instead.")
   "Coordinates of the route of this trip in Google polyline encoded format"
   tripGeometry: Geometry
   "Headsign of the vehicle when running on this trip"
@@ -2865,6 +2963,8 @@ type TripOnServiceDate {
   end: StopCall!
   "Is this TripOnServiceDate a replacement? For GTFS-sourced data this might be all we know."
   isReplacement: Boolean
+  "Real-time state of the trip on this service date."
+  realTimeTripState: RealTimeTripState
   "Replaced by these TripOnServiceDates."
   replacedByRelation: [ReplacedByRelation!]!
   "Replacement for these TripOnServiceDates."
@@ -3358,6 +3458,19 @@ enum AlertSeverityLevelType {
   with irregular schedules.
   """
   WARNING
+}
+
+"""
+Enum for limiting the returned calls depending on pickup/drop off status on a stop
+based on the original schedules.
+"""
+enum ArrivalDeparture {
+  "Only include calls where alighting from the vehicle is allowed."
+  ARRIVALS
+  "Only include calls where boarding the vehicle is allowed."
+  DEPARTURES
+  "Include calls where either boarding or alighting is allowed."
+  EITHER
 }
 
 enum BikesAllowed {
@@ -4415,6 +4528,15 @@ input CanceledTripsFilterSelectInput {
   "Canceled trips from these transit modes should be included/excluded."
   modes: [TransitMode!]
   """
+  Canceled trips are included/excluded based on if they are scheduled to be running during any of
+  these time ranges. A trip is considered to be running from its scheduled departure from the first
+  stop until its scheduled arrival at the last stop.
+    
+  If both `runningTimeRanges` and `serviceDateRanges` are defined, a trip has to match both of
+  them to be included/excluded.
+  """
+  runningTimeRanges: [OffsetDateTimeRangeInput!]
+  """
   Canceled trips are included/excluded based on if their service date (but not necessarily their running date)  is within any of these time
   ranges.
   """
@@ -4441,6 +4563,15 @@ input CanceledTripsSummaryFilterInput {
 input CanceledTripsSummaryFilterSelectInput {
   "Canceled trips from these transit modes should be included/excluded."
   modes: [TransitMode!]
+  """
+  Canceled trips are included/excluded based on if they are scheduled to be running during any of
+  these time ranges. A trip is considered to be running from its scheduled departure from the first
+  stop until its scheduled arrival at the last stop.
+    
+  If both `runningTimeRanges` and `serviceDateRanges` are defined, a trip has to match both of
+  them to be included/excluded.
+  """
+  runningTimeRanges: [OffsetDateTimeRangeInput!]
   """
   Canceled trips are included/excluded based on if their service date is within any of these time
   ranges.
@@ -4704,6 +4835,29 @@ input LocalDateRangeInput {
   dates that are before `end` are selected.
   """
   start: LocalDate
+}
+
+"""
+Filters an entity by a time range. Both ends of the range are optional which makes it possible
+to define a range which is open ended in either or both directions.
+"""
+input OffsetDateTimeRangeInput {
+  """
+  **Exclusive** end time of the filter. This means that an entity which is exactly at `end` is not
+  selected.
+    
+  If `null` this means that no end filter is applied and all entities that are after or at `start`
+  are selected.
+  """
+  end: OffsetDateTime
+  """
+  **Inclusive** start time of the filter. This means that an entity which is exactly at `start` is
+  selected.
+    
+  If `null` this means that no `start` filter is applied and all entities that are before `end` are
+  selected.
+  """
+  start: OffsetDateTime
 }
 
 """

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -136,6 +136,13 @@ type Agency implements Node {
 "Alert of a current or upcoming disruption in public transportation"
 type Alert implements Node {
   """
+  The periods of time when this alert is active, sorted chronologically. There is always at
+  least one period. Each period has an inclusive start and an exclusive end. A period with an
+  unbounded start has always been active and a period with an unbounded end is active
+  indefinitely.
+  """
+  activityPeriods: [OffsetDateTimeRange!]!
+  """
   Agency affected by the disruption. Note that this value is present only if the
   disruption has an effect on all operations of the agency (e.g. in case of a strike).
   """
@@ -170,9 +177,9 @@ type Alert implements Node {
   "Url with more information in all different available languages"
   alertUrlTranslations: [TranslatedString!]! @deprecated(reason : "Use `alertUrl` instead. `accept-language` header can be used for translations or the `language` parameter on the `alertUrl` field.")
   "Time when this alert is not in effect anymore. Format: Unix timestamp in seconds"
-  effectiveEndDate: Long
+  effectiveEndDate: Long @deprecated(reason : "Use `activityPeriods` instead.")
   "Time when this alert comes into effect. Format: Unix timestamp in seconds"
-  effectiveStartDate: Long
+  effectiveStartDate: Long @deprecated(reason : "Use `activityPeriods` instead.")
   "Entities affected by the disruption."
   entities: [AlertEntity]
   "The feed in which this alert was published"
@@ -941,9 +948,9 @@ type Leg {
     originModesWithParentStation: [TransitMode!]
   ): [Leg!]
   "Whether there is real-time data about this Leg"
-  realTime: Boolean
+  realTime: Boolean @deprecated(reason : "Use `realTimeTripState.updated` on `TripOnServiceDate` instead.")
   "State of real-time data"
-  realtimeState: RealtimeState
+  realtimeState: RealtimeState @deprecated(reason : "Use `realTimeTripState` on `TripOnServiceDate` instead.")
   "Whether this leg is traversed with a rented vehicle."
   rentedBike: Boolean
   "Estimate of a hailed ride like Uber."
@@ -970,6 +977,8 @@ type Leg {
   transitLeg: Boolean
   "For transit legs, the trip that is used for traversing the leg. For non-transit legs, `null`."
   trip: Trip
+  "For transit legs, the trip on service date. For non-transit legs, `null`."
+  tripOnServiceDate: TripOnServiceDate
   "Whether this leg is walking with a bike."
   walkingBike: Boolean
 }
@@ -1050,6 +1059,31 @@ type Money {
   currency: Currency!
 }
 
+"""
+A textual message about a transit entity that is already known at planning time.
+
+It is not intended to convey real-time or emergency updates of the transit system but information that
+is known well ahead of time.
+"""
+type Notice {
+  "Textual representation of the message"
+  text: String
+}
+
+"""
+A range of time which can be unbounded in either direction.
+
+The start of the range is inclusive and the end is exclusive.
+A `null` start means that the range extends indefinitely into the past and a `null` end means
+that it extends indefinitely into the future.
+"""
+type OffsetDateTimeRange {
+  "The exclusive end of the range or `null` if the range is unbounded in the future."
+  end: OffsetDateTime
+  "The inclusive start of the range or `null` if the range is unbounded in the past."
+  start: OffsetDateTime
+}
+
 type OpeningHours {
   """
   Opening hours for the selected dates using the local time of the parking lot.
@@ -1106,6 +1140,18 @@ type Pattern implements Node {
   """
   canceledTrips(
     """
+    Only return canceled trips which are scheduled to be running during one of these time ranges.
+    A trip is considered to be running from its scheduled departure from the first stop until its
+    scheduled arrival at the last stop.
+        
+    An empty list or a list containing `null` is forbidden. If this argument is not provided or its
+    value is `null`, no filtering is applied.
+        
+    If both `runningTimeRanges` and `serviceDateRanges` are defined, a trip has to match both of
+    them to be returned.
+    """
+    runningTimeRanges: [OffsetDateTimeRangeInput!],
+    """
     Only return canceled trips whose service date falls within one of these ranges.
     An empty list or a list containing `null` is forbidden.  If this argument is not provided or its
     value is `null`, no filtering is applied.
@@ -1156,7 +1202,12 @@ type Pattern implements Node {
   tripsForDate(
     "Return trips of the pattern active on this date. Format: YYYYMMDD"
     serviceDate: String
-  ): [Trip!]
+  ): [Trip!] @deprecated(reason : "Use `tripsOnServiceDate`")
+  """
+  Instances of `TripOnServiceDates` which run on the specified date. If no trips run on this date
+  then this returns an empty list.
+  """
+  tripsOnServiceDate(serviceDate: LocalDate!): [TripOnServiceDate!]!
   "Real-time updated position of vehicles that are serving this pattern."
   vehiclePositions: [VehiclePosition!]
 }
@@ -2107,6 +2158,23 @@ type RealTimeEstimate {
   time: OffsetDateTime!
 }
 
+"The real-time state of a trip"
+type RealTimeTripState {
+  "Has the trip been added via real-time updates? (extra trip)"
+  added: Boolean!
+  "Has the trip been canceled?"
+  canceled: Boolean!
+  "Have any stop arrival or departure times been modified from the scheduled times?"
+  timesModified: Boolean!
+  """
+  Has the stop sequence changed from the scheduled pattern? True if stops were added, removed,
+  reordered, or reassigned to a different stop location (`assigned_stop_id`).
+  """
+  tripPatternModified: Boolean!
+  "Have there been any real-time updates on this trip?"
+  updated: Boolean!
+}
+
 "Rental vehicle represents a vehicle that belongs to a rental network."
 type RentalVehicle implements Node & PlaceInterface {
   "If true, vehicle is currently available for renting."
@@ -2270,6 +2338,8 @@ type Route implements Node {
   ): String
   "Transport mode of this route, e.g. `BUS`"
   mode: TransitMode
+  "Notices of this trip which are known ahead of time."
+  notices: [Notice!]! @deprecated(reason : "Experimental API that can be changed without notice.")
   "List of patterns which operate on this route"
   patterns(
     """
@@ -2389,11 +2459,28 @@ type Stop implements Node & PlaceInterface {
   """
   canceledCalls(
     """
+    Selects if only calls where boarding is allowed, only calls where alighting is allowed, or calls
+    where either boarding or alighting is possible (according to the original schedule).
+    """
+    arrivalDeparture: ArrivalDeparture = EITHER,
+    """
     Only include canceled calls whose trip's service date is within any of these date ranges.
     If omitted (or `null`), no service date filter is applied and canceled calls across the entire
     transit service period are returned. Defining a range is recommended.
     """
-    serviceDateRanges: [LocalDateRangeInput!]
+    serviceDateRanges: [LocalDateRangeInput!],
+    """
+    Only include canceled calls where the vehicle is scheduled to visit this stop during one of
+    these time ranges. The visit at a stop lasts from the scheduled arrival at the stop until the
+    scheduled departure from it.
+        
+    An empty list or a list containing `null` is forbidden. If this argument is not provided or its
+    value is `null`, no filtering is applied.
+        
+    If both `timeRanges` and `serviceDateRanges` are defined, a call has to match both of
+    them to be returned.
+    """
+    timeRanges: [OffsetDateTimeRangeInput!]
   ): [StopCallOnTripOnServiceDate!]!
   "The cluster which this stop is part of"
   cluster: Cluster @deprecated(reason : "Not implemented")
@@ -2552,6 +2639,8 @@ from a specific stop location.
 This may contain real-time information, if available.
 """
 type StopCall {
+  "Notices of this call which are known ahead of time."
+  notices: [Notice!]! @deprecated(reason : "Experimental API that can be changed without notice.")
   "Real-time estimates for arrival and departure times for this stop location."
   realTime: CallRealTime
   "Scheduled arrival and departure times for this stop location."
@@ -2644,7 +2733,12 @@ type Stoptime {
   realtimeArrival: Int
   "Real-time prediction of departure time. Format: seconds since midnight of the departure date"
   realtimeDeparture: Int
-  "State of real-time data"
+  """
+  State of real-time data. Currently used to determine, whether a stop has been canceled.
+  Disclaimer: this is, in most cases the trips realtime state, unless the stop is canceled,
+  then the Trips State will be overwritten to be CANCELED.
+  It is recommended to avoid using this field.
+  """
   realtimeState: RealtimeState
   "Scheduled arrival time. Format: seconds since midnight of the departure date"
   scheduledArrival: Int
@@ -2800,11 +2894,15 @@ type Trip implements Node {
   link in a DatedServiceJourney.
   """
   isReplacement: Boolean!
+  "Notices of the trip that are known ahead of time."
+  notices: [Notice!]! @deprecated(reason : "Experimental API that can be changed without notice.")
   """
   The latest real-time occupancy information for the latest occurance of this
   trip.
   """
   occupancy: TripOccupancy
+  "Return the trip on a specific service date or `null` if the trip does not run on it."
+  onServiceDate(date: LocalDate!): TripOnServiceDate
   "The pattern the trip is running on"
   pattern: Pattern
   """
@@ -2834,7 +2932,7 @@ type Trip implements Node {
   stoptimesForDate(
     "Date for which stoptimes are returned. Format: YYYYMMDD"
     serviceDate: String
-  ): [Stoptime]
+  ): [Stoptime] @deprecated(reason : "Use `onServiceDate` instead.")
   "Coordinates of the route of this trip in Google polyline encoded format"
   tripGeometry: Geometry
   "Headsign of the vehicle when running on this trip"
@@ -2865,6 +2963,8 @@ type TripOnServiceDate {
   end: StopCall!
   "Is this TripOnServiceDate a replacement? For GTFS-sourced data this might be all we know."
   isReplacement: Boolean
+  "Real-time state of the trip on this service date."
+  realTimeTripState: RealTimeTripState
   "Replaced by these TripOnServiceDates."
   replacedByRelation: [ReplacedByRelation!]!
   "Replacement for these TripOnServiceDates."
@@ -3358,6 +3458,19 @@ enum AlertSeverityLevelType {
   with irregular schedules.
   """
   WARNING
+}
+
+"""
+Enum for limiting the returned calls depending on pickup/drop off status on a stop
+based on the original schedules.
+"""
+enum ArrivalDeparture {
+  "Only include calls where alighting from the vehicle is allowed."
+  ARRIVALS
+  "Only include calls where boarding the vehicle is allowed."
+  DEPARTURES
+  "Include calls where either boarding or alighting is allowed."
+  EITHER
 }
 
 enum BikesAllowed {
@@ -4415,6 +4528,15 @@ input CanceledTripsFilterSelectInput {
   "Canceled trips from these transit modes should be included/excluded."
   modes: [TransitMode!]
   """
+  Canceled trips are included/excluded based on if they are scheduled to be running during any of
+  these time ranges. A trip is considered to be running from its scheduled departure from the first
+  stop until its scheduled arrival at the last stop.
+    
+  If both `runningTimeRanges` and `serviceDateRanges` are defined, a trip has to match both of
+  them to be included/excluded.
+  """
+  runningTimeRanges: [OffsetDateTimeRangeInput!]
+  """
   Canceled trips are included/excluded based on if their service date (but not necessarily their running date)  is within any of these time
   ranges.
   """
@@ -4441,6 +4563,15 @@ input CanceledTripsSummaryFilterInput {
 input CanceledTripsSummaryFilterSelectInput {
   "Canceled trips from these transit modes should be included/excluded."
   modes: [TransitMode!]
+  """
+  Canceled trips are included/excluded based on if they are scheduled to be running during any of
+  these time ranges. A trip is considered to be running from its scheduled departure from the first
+  stop until its scheduled arrival at the last stop.
+    
+  If both `runningTimeRanges` and `serviceDateRanges` are defined, a trip has to match both of
+  them to be included/excluded.
+  """
+  runningTimeRanges: [OffsetDateTimeRangeInput!]
   """
   Canceled trips are included/excluded based on if their service date is within any of these time
   ranges.
@@ -4704,6 +4835,29 @@ input LocalDateRangeInput {
   dates that are before `end` are selected.
   """
   start: LocalDate
+}
+
+"""
+Filters an entity by a time range. Both ends of the range are optional which makes it possible
+to define a range which is open ended in either or both directions.
+"""
+input OffsetDateTimeRangeInput {
+  """
+  **Exclusive** end time of the filter. This means that an entity which is exactly at `end` is not
+  selected.
+    
+  If `null` this means that no end filter is applied and all entities that are after or at `start`
+  are selected.
+  """
+  end: OffsetDateTime
+  """
+  **Inclusive** start time of the filter. This means that an entity which is exactly at `start` is
+  selected.
+    
+  If `null` this means that no `start` filter is applied and all entities that are before `end` are
+  selected.
+  """
+  start: OffsetDateTime
 }
 
 """

--- a/test/unit/component/trafficnow/TrafficNow.test.js
+++ b/test/unit/component/trafficnow/TrafficNow.test.js
@@ -45,12 +45,16 @@ describe('<TrafficNow />', () => {
     });
 
     it('renders the TrafficNowHeader', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(TrafficNowHeader)).to.have.lengthOf(1);
     });
 
     it('renders the desktop Filters panel inside .traffic-now__filters-container', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find('.traffic-now__filters-container')).to.have.lengthOf(
         1,
       );
@@ -60,19 +64,25 @@ describe('<TrafficNow />', () => {
     });
 
     it('renders Disruptions', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(Disruptions)).to.have.lengthOf(1);
     });
 
     it('does NOT render the mobile filters button container', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(
         wrapper.find('.traffic-now__filters-button-container'),
       ).to.have.lengthOf(0);
     });
 
     it('does NOT apply the mobile body modifier class', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find('.traffic-now__body--mobile')).to.have.lengthOf(0);
     });
   });
@@ -83,12 +93,16 @@ describe('<TrafficNow />', () => {
     });
 
     it('renders the TrafficNowHeader', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(TrafficNowHeader)).to.have.lengthOf(1);
     });
 
     it('renders the mobile filters button container instead of the desktop Filters panel', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(
         wrapper.find('.traffic-now__filters-button-container'),
       ).to.have.lengthOf(1);
@@ -98,12 +112,16 @@ describe('<TrafficNow />', () => {
     });
 
     it('renders Disruptions', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(Disruptions)).to.have.lengthOf(1);
     });
 
     it('applies the mobile body modifier class', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find('.traffic-now__body--mobile')).to.have.lengthOf(1);
     });
   });
@@ -114,26 +132,34 @@ describe('<TrafficNow />', () => {
     });
 
     it('shows the TrafficNowHeader (not a mobile canceled-trips view on desktop)', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(TrafficNowHeader)).to.have.lengthOf(1);
     });
 
     it('renders CanceledTripsContainer with the correct mode prop', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       const container = wrapper.find(CanceledTripsContainer);
       expect(container).to.have.lengthOf(1);
       expect(container.prop('mode')).to.equal('CANCELED');
     });
 
     it('passes isMobile=false to CanceledTripsContainer on desktop', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(CanceledTripsContainer).prop('isMobile')).to.equal(
         false,
       );
     });
 
     it('does NOT render Disruptions', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(Disruptions)).to.have.lengthOf(0);
     });
   });
@@ -144,31 +170,41 @@ describe('<TrafficNow />', () => {
     });
 
     it('hides the TrafficNowHeader', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(TrafficNowHeader)).to.have.lengthOf(0);
     });
 
     it('hides the separator', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find('.separator.horizontal')).to.have.lengthOf(0);
     });
 
     it('renders CanceledTripsContainer with the correct mode prop', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       const container = wrapper.find(CanceledTripsContainer);
       expect(container).to.have.lengthOf(1);
       expect(container.prop('mode')).to.equal('CANCELED');
     });
 
     it('passes isMobile=true to CanceledTripsContainer', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(CanceledTripsContainer).prop('isMobile')).to.equal(
         true,
       );
     });
 
     it('applies the mobile body modifier class', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find('.traffic-now__body--mobile')).to.have.lengthOf(1);
     });
   });
@@ -182,31 +218,41 @@ describe('<TrafficNow />', () => {
     });
 
     it('renders the TrafficNowHeader', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(TrafficNowHeader)).to.have.lengthOf(1);
     });
 
     it('renders DisruptionDetailsContainer with the correct alertId', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       const container = wrapper.find(DisruptionDetailsContainer);
       expect(container).to.have.lengthOf(1);
       expect(container.prop('alertId')).to.equal('alert-1');
     });
 
     it('passes isMobile=false to DisruptionDetailsContainer on desktop', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(
         wrapper.find(DisruptionDetailsContainer).prop('isMobile'),
       ).to.equal(false);
     });
 
     it('does NOT render Disruptions', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(Disruptions)).to.have.lengthOf(0);
     });
 
     it('does NOT render CanceledTripsContainer', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(CanceledTripsContainer)).to.have.lengthOf(0);
     });
   });
@@ -220,26 +266,34 @@ describe('<TrafficNow />', () => {
     });
 
     it('hides the TrafficNowHeader', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find(TrafficNowHeader)).to.have.lengthOf(0);
     });
 
     it('renders DisruptionDetailsContainer with the correct alertId', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       const container = wrapper.find(DisruptionDetailsContainer);
       expect(container).to.have.lengthOf(1);
       expect(container.prop('alertId')).to.equal('alert-1');
     });
 
     it('passes isMobile=true to DisruptionDetailsContainer on mobile', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(
         wrapper.find(DisruptionDetailsContainer).prop('isMobile'),
       ).to.equal(true);
     });
 
     it('applies the mobile body modifier class', () => {
-      const wrapper = shallow(<TrafficNow />);
+      const wrapper = shallow(
+        <TrafficNow dateTime="2024-01-01T00:00:00.000Z" />,
+      );
       expect(wrapper.find('.traffic-now__body--mobile')).to.have.lengthOf(1);
     });
   });


### PR DESCRIPTION
## Proposed Changes

  - Use runningTimeRanges instead of serviceDateRanges to filter out canceled trips that have been finished
  - dateTime prop is passed from router to avoid recomputing it inside component render function and causing infinite render loops
  - graphql schema also updated and search-util-query-utils version bumped

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
