### PR TITLE
Traffic Now - Filter out canceled trips from irrelevant feeds

### DIFF
--- a/app/component/trafficnow/CanceledTripsContainer.js
+++ b/app/component/trafficnow/CanceledTripsContainer.js
@@ -7,6 +7,9 @@ import CanceledTrips from './CanceledTrips';
 import CanceledTripsForModeQuery from './queries/CanceledTripsForModeQuery';
 import { favouriteShape } from '../../util/shapes';
 import { sortRoutes } from './utils';
+import { useFilterContext } from './filters/FiltersContext';
+import { splitGtfsId } from '../../util/gtfs';
+import { useConfigContext } from '../../configurations/ConfigContext';
 
 const CanceledTripsContainer = ({ mode, isMobile, favourites = [] }) => {
   const { canceledTripsSummary } = useLazyLoadQuery(CanceledTripsForModeQuery, {
@@ -14,10 +17,21 @@ const CanceledTripsContainer = ({ mode, isMobile, favourites = [] }) => {
     serviceDateRanges: [{ start: DateTime.now().toISODate(), end: null }],
   });
   const favRoutes = favourites.map(({ gtfsId }) => gtfsId);
+  const {
+    selectedFilters: { selectedFeeds },
+  } = useFilterContext();
+  const { feedIds } = useConfigContext();
+
+  const filteredRoutes = canceledTripsSummary.routes.filter(
+    route =>
+      (!selectedFeeds?.length &&
+        feedIds.includes(splitGtfsId(route.route.gtfsId)?.feedId)) ||
+      selectedFeeds?.includes(splitGtfsId(route.route.gtfsId)?.feedId),
+  );
 
   return (
     <CanceledTrips
-      canceledRoutes={sortRoutes(canceledTripsSummary.routes, favRoutes)}
+      canceledRoutes={sortRoutes(filteredRoutes, favRoutes)}
       mode={mode}
       isMobile={isMobile}
     />


### PR DESCRIPTION
## Proposed Changes

  - On Traffic now front page canceled trips are filtered by feedIds according to config and then selected feeds
  - When cancellation card was clicked the drilldown view showed cancellations from all feeds (an issue for waltti themes that use a shared otp instance)
  - This pr fixes this issue by adding a similar filtering than on the front page.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
