### PR TITLE
AB#696 Fix zone circle layout bug on rental station / park and ride page

### DIFF
--- a/app/component/park-rental-station.scss
+++ b/app/component/park-rental-station.scss
@@ -69,32 +69,13 @@
     }
   }
 
-  .station-zone-icon {
-    .zone-icon-container .circle {
-      width: 16px;
-      height: 16px;
-      font-size: 13px;
-    }
-
-    padding-top: 2px;
-    position: absolute;
-    margin-left: 8px;
-
-    svg {
-      width: 14px;
-      height: 14px;
-    }
-  }
-
   .station-sub-header {
     font-size: 0.813rem;
     color: #666;
     font-weight: $font-weight-book;
-
-    span.itinerary-stop-code {
-      margin-right: 8px;
-      margin-left: 8px;
-    }
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   .citybike-content-container {


### PR DESCRIPTION
## Proposed Changes

  - multiletter zone icon now shown properly

Before:
<img width="479" height="113" alt="image" src="https://github.com/user-attachments/assets/254a2204-d6ab-45b2-bceb-85f5a6f0d528" />
