### PR TITLE
AB#650 - Rename `carPickupZone` to `taxiZone`

### DIFF
--- a/app/component/itinerary/Itinerary.js
+++ b/app/component/itinerary/Itinerary.js
@@ -180,7 +180,7 @@ const Itinerary = ({
   let containsScooterLeg = false;
   let nameLengthSum = 0; // approximate space required for route labels
   compressedLegs.forEach((leg, i) => {
-    if (isLegWithRoute(leg, config.carPickupZone.allowedRouteTypes)) {
+    if (isLegWithRoute(leg, config.taxiZone.allowedRouteTypes)) {
       legWithRouteCount += 1;
       nameLengthSum += getTripOrRouteText(leg.trip, leg.route, config).length;
     }
@@ -513,7 +513,7 @@ const Itinerary = ({
   const hasCallAgencyLeg = itinerary.legs.some(leg => isCallAgencyLeg(leg));
 
   const firstDeparture = compressedLegs.find(leg =>
-    isBoardableLeg(leg, config.carPickupZone.allowedRouteTypes),
+    isBoardableLeg(leg, config.taxiZone.allowedRouteTypes),
   );
   const firstLegStartTime = (
     <FirstLegStartTime

--- a/app/component/itinerary/ItineraryPage.js
+++ b/app/component/itinerary/ItineraryPage.js
@@ -73,7 +73,7 @@ import {
   mergeExternalFlexPlan,
   mergeScooterTransitPlan,
   mergeInternalFlexPlan,
-  mergeCarPickupZonePlan,
+  mergeTaxiZonePlan,
   parseCarTransitPlan,
   quitIteration,
   reportError,
@@ -180,7 +180,7 @@ export default function ItineraryPage(props, context) {
   const [scooterState, setScooterState] = useState(unset);
   const [externalFlexState, setExternalFlexState] = useState(unset);
   const [internalFlexState, setInternalFlexState] = useState(unset);
-  const [carPickupZoneState, setCarPickupZoneState] = useState(unset);
+  const [taxiZoneState, setTaxiZoneState] = useState(unset);
   const [isNavigatorIntroDismissed, setNavigatorIntroDismissed] = useState(
     getDialogState('navi-intro'),
   );
@@ -610,24 +610,24 @@ export default function ItineraryPage(props, context) {
     }
   }
 
-  async function makeCarPickupZoneQuery() {
-    if (!planQueryNeeded(config, match, PLANTYPE.CARPICKUPZONE)) {
-      setCarPickupZoneState(emptyPlan);
+  async function makeTaxiZoneQuery() {
+    if (!planQueryNeeded(config, match, PLANTYPE.TAXIZONE)) {
+      setTaxiZoneState(emptyPlan);
       return;
     }
-    setCarPickupZoneState({ loading: LOADSTATE.LOADING });
+    setTaxiZoneState({ loading: LOADSTATE.LOADING });
     const planParams = getPlanParams(
       config,
       match,
-      PLANTYPE.CARPICKUPZONE,
+      PLANTYPE.TAXIZONE,
       false, // no relaxed settings
     );
     try {
       const plan = await iterateQuery(planParams);
-      setCarPickupZoneState({ plan, loading: LOADSTATE.DONE });
+      setTaxiZoneState({ plan, loading: LOADSTATE.DONE });
     } catch (error) {
       reportError(error);
-      setCarPickupZoneState(emptyPlan);
+      setTaxiZoneState(emptyPlan);
     }
   }
 
@@ -1058,7 +1058,7 @@ export default function ItineraryPage(props, context) {
     makeScooterQuery();
     makeExternalFlexQuery();
     makeInternalFlexQuery();
-    makeCarPickupZoneQuery();
+    makeTaxiZoneQuery();
     makeMainQuery();
     Object.keys(altStates).forEach(key => makeAltQuery(key));
 
@@ -1179,7 +1179,7 @@ export default function ItineraryPage(props, context) {
       scooterState.loading === LOADSTATE.DONE &&
       externalFlexState.loading === LOADSTATE.DONE &&
       internalFlexState.loading === LOADSTATE.DONE &&
-      carPickupZoneState.loading === LOADSTATE.DONE
+      taxiZoneState.loading === LOADSTATE.DONE
     ) {
       let plan = mergeScooterTransitPlan(
         scooterState.plan,
@@ -1207,13 +1207,13 @@ export default function ItineraryPage(props, context) {
         );
       }
 
-      if (carPickupZoneState.plan?.edges) {
-        plan = mergeCarPickupZonePlan(
-          carPickupZoneState.plan,
+      if (taxiZoneState.plan?.edges) {
+        plan = mergeTaxiZonePlan(
+          taxiZoneState.plan,
           plan,
           match.location.query.arriveBy === 'true',
-          config.carPickupZone.showBothDirectAndTransitResults,
-          config.carPickupZone.allowedRouteTypes,
+          config.taxiZone.showBothDirectAndTransitResults,
+          config.taxiZone.allowedRouteTypes,
         );
       }
 
@@ -1232,7 +1232,7 @@ export default function ItineraryPage(props, context) {
     mainState.plan,
     externalFlexState.plan,
     internalFlexState.plan,
-    carPickupZoneState.plan,
+    taxiZoneState.plan,
   ]);
 
   // merge the relaxed scooter plan and the relaxed flex plan into one

--- a/app/component/itinerary/ItineraryPageUtils.js
+++ b/app/component/itinerary/ItineraryPageUtils.js
@@ -613,21 +613,21 @@ export function mergeInternalFlexPlan(
   return sortAndMergePlans(selectedInternalFlexEdges, plan, arriveBy);
 }
 
-/** Combine a car pickup zone taxi plan with the main transit plan. */
-export function mergeCarPickupZonePlan(
-  carPickupZonePlan,
+/** Combine a taxi zone plan with the main transit plan. */
+export function mergeTaxiZonePlan(
+  taxiZonePlan,
   transitPlan,
   arriveBy,
   showBothDirectAndTransitResults,
-  allowedCarPickupZoneRouteTypes,
+  allowedTaxiZoneRouteTypes,
 ) {
   const filteredEdges = filterItinerariesByRouteType(
-    carPickupZonePlan.edges,
-    allowedCarPickupZoneRouteTypes,
+    taxiZonePlan.edges,
+    allowedTaxiZoneRouteTypes,
   );
   const selectedEdges = selectEdgesWithAllowedRouteTypes(
     filteredEdges,
-    allowedCarPickupZoneRouteTypes,
+    allowedTaxiZoneRouteTypes,
     showBothDirectAndTransitResults,
   );
   return sortAndMergePlans(selectedEdges, transitPlan, arriveBy);

--- a/app/component/itinerary/customizesearch/CustomizeSearch.js
+++ b/app/component/itinerary/customizesearch/CustomizeSearch.js
@@ -124,7 +124,7 @@ export default function CustomizeSearch({ onToggleClick, mobile }) {
             <Scooters updateSettings={updateSettings} />
           </div>
         )}
-        {(config.flex.external.enabled || config.carPickupZone.enabled) &&
+        {(config.flex.external.enabled || config.taxiZone.enabled) &&
           config.transportModes.taxi.availableForSelection && (
             <div className="settings-section">
               <TaxiOptions

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -894,7 +894,7 @@ export default {
     },
     taxiExternalIcon: 'icon_taxi-external',
   },
-  carPickupZone: {
+  taxiZone: {
     enabled: false,
     direct: false,
     transit: false,

--- a/app/util/legUtils.js
+++ b/app/util/legUtils.js
@@ -505,21 +505,17 @@ export function isDirectItineraryWithAllowedRouteTypes(
     allowedRouteTypes.includes(legsWithRoute[0].route.type)
   );
 }
-export function isCarPickupZoneLeg(leg, allowedCarPickupZoneRouteTypes) {
-  return (
-    !leg.transitLeg && allowedCarPickupZoneRouteTypes.includes(leg.route?.type)
-  );
+export function isTaxiZoneLeg(leg, allowedTaxiZoneRouteTypes) {
+  return !leg.transitLeg && allowedTaxiZoneRouteTypes.includes(leg.route?.type);
 }
-export function isLegWithRoute(leg, allowedCarPickupZoneRouteTypes) {
-  return (
-    leg.transitLeg || isCarPickupZoneLeg(leg, allowedCarPickupZoneRouteTypes)
-  );
+export function isLegWithRoute(leg, allowedTaxiZoneRouteTypes) {
+  return leg.transitLeg || isTaxiZoneLeg(leg, allowedTaxiZoneRouteTypes);
 }
-export function isBoardableLeg(leg, allowedCarPickupZoneRouteTypes) {
+export function isBoardableLeg(leg, allowedTaxiZoneRouteTypes) {
   return (
     leg.transitLeg ||
     isBikeOrScooterRentalLeg(leg) ||
-    isCarPickupZoneLeg(leg, allowedCarPickupZoneRouteTypes)
+    isTaxiZoneLeg(leg, allowedTaxiZoneRouteTypes)
   );
 }
 

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -23,7 +23,7 @@ export const PLANTYPE = {
   SCOOTERTRANSIT: 'SCOOTERTRANSIT',
   FLEXTRANSIT_EXTERNAL: 'EXTERNAL_FLEXTRANSIT',
   FLEXTRANSIT_INTERNAL: 'INTERNAL_FLEXTRANSIT',
-  CARPICKUPZONE: 'CARPICKUPZONE',
+  TAXIZONE: 'TAXIZONE',
 };
 
 const directModes = [PLANTYPE.WALK, PLANTYPE.BIKE, PLANTYPE.CAR];
@@ -275,10 +275,10 @@ export function planQueryNeeded(
         config.flex.internal.enabled && transitModes.includes(TransportMode.Bus)
       );
 
-    case PLANTYPE.CARPICKUPZONE:
+    case PLANTYPE.TAXIZONE:
       return (
-        config.carPickupZone.enabled &&
-        (transitModes.length > 0 || config.carPickupZone.direct) &&
+        config.taxiZone.enabled &&
+        (transitModes.length > 0 || config.taxiZone.direct) &&
         settings.includeTaxiSuggestions !== relaxSettings
       );
 
@@ -479,10 +479,10 @@ export function getPlanParams(
       minTransferTime = config.flex.internal.minTransferTime || minTransferTime;
       via = null;
       break;
-    case PLANTYPE.CARPICKUPZONE:
-      access = config.carPickupZone.transit ? ['WALK', 'CAR_DROP_OFF'] : null;
-      egress = config.carPickupZone.transit ? ['WALK', 'CAR_PICKUP'] : null;
-      direct = config.carPickupZone.direct ? ['CAR'] : null;
+    case PLANTYPE.TAXIZONE:
+      access = config.taxiZone.transit ? ['WALK', 'TAXI'] : null;
+      egress = access;
+      direct = config.taxiZone.direct ? ['WALK', 'TAXI'] : null;
       transitOnly = false;
       via = null;
       break;


### PR DESCRIPTION
## Proposed Changes

  - Also use `TAXI` mode (which doesn't exist in schema) with taxi zone queries