### PR TITLE
Fix workspace package `dependency` and `peerDependency` version management

### DIFF
--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest-panel",
-  "version": "8.4.1",
+  "version": "8.4.2",
   "description": "digitransit-component autosuggest-panel module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest-panel/package.json
@@ -28,8 +28,8 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^7.2.0",
-    "@digitransit-component/digitransit-component-icon": "^2.0.2",
+    "@digitransit-component/digitransit-component-autosuggest": "workspace:^",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
     "@hsl-fi/sass": "1.0.0",
     "classnames": "2.5.1",
     "downshift": "9.4.0",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -29,15 +29,15 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": "^3.3.8",
-    "@digitransit-search-util/digitransit-search-util-get-label": "^1.0.4",
-    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "^2.1.3",
+    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": "workspace:^",
+    "@digitransit-search-util/digitransit-search-util-get-label": "workspace:^",
+    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "workspace:^",
     "@hsl-fi/hooks": "^1.2.4"
   },
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-dialog-modal": "^4.0.0",
-    "@digitransit-component/digitransit-component-icon": "^2.0.2",
-    "@digitransit-component/digitransit-component-suggestion-item": "^3.0.3",
+    "@digitransit-component/digitransit-component-dialog-modal": "workspace:^",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
+    "@digitransit-component/digitransit-component-suggestion-item": "workspace:^",
     "@hsl-fi/sass": "1.0.0",
     "classnames": "2.5.1",
     "downshift": "9.4.0",

--- a/digitransit-component/packages/digitransit-component-autosuggest/package.json
+++ b/digitransit-component/packages/digitransit-component-autosuggest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-autosuggest",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "digitransit-component autosuggest module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-control-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-control-panel/package.json
@@ -29,7 +29,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-icon": "^2.0.2",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
     "@hsl-fi/modal": "^0.3.2",
     "@hsl-fi/sass": "1.0.0",
     "@hsl-fi/shimmer": "0.1.2",

--- a/digitransit-component/packages/digitransit-component-control-panel/package.json
+++ b/digitransit-component/packages/digitransit-component-control-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-control-panel",
-  "version": "7.1.5",
+  "version": "7.1.6",
   "description": "digitransit-component control-panel module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -29,7 +29,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-icon": "^2.0.2",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
     "classnames": "2.5.1",
     "downshift": "9.0.10",
     "i18next": "^22.5.1",

--- a/digitransit-component/packages/digitransit-component-datetimepicker/package.json
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-datetimepicker",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "description": "digitransit-component datetimepicker module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-favourite-bar/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-bar/package.json
@@ -29,11 +29,11 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "^2.1.3"
+    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "workspace:^"
   },
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-icon": "^2.0.2",
-    "@digitransit-component/digitransit-component-suggestion-item": "^3.0.3",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
+    "@digitransit-component/digitransit-component-suggestion-item": "workspace:^",
     "@hsl-fi/sass": "1.0.0",
     "@hsl-fi/shimmer": "0.1.2",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-favourite-bar/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-bar",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "digitransit-component favourite-bar module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
@@ -29,11 +29,11 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "^2.1.3"
+    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "workspace:^"
   },
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-dialog-modal": "^4.0.0",
-    "@digitransit-component/digitransit-component-icon": "^2.0.2",
+    "@digitransit-component/digitransit-component-dialog-modal": "workspace:^",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
     "@hsl-fi/loading-indicators": "^2.0.0",
     "@hsl-fi/modal": "^0.3.2",
     "@hsl-fi/sass": "1.0.0",

--- a/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-editing-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-editing-modal",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "digitransit-component favourite-editing-modal module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-favourite-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-modal/package.json
@@ -29,7 +29,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-icon": "^2.0.2",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
     "@hsl-fi/modal": "^0.3.2",
     "@hsl-fi/sass": "1.0.0",
     "classnames": "2.5.1",

--- a/digitransit-component/packages/digitransit-component-favourite-modal/package.json
+++ b/digitransit-component/packages/digitransit-component-favourite-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-favourite-modal",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "digitransit-component favourite-modal module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-suggestion-item/package.json
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-suggestion-item",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "digitransit-component suggestion-item module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component-suggestion-item/package.json
+++ b/digitransit-component/packages/digitransit-component-suggestion-item/package.json
@@ -29,7 +29,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-icon": "^2.0.2",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
     "@hsl-fi/sass": " 1.0.0",
     "classnames": "2.5.1",
     "prop-types": "^15.8.1",

--- a/digitransit-component/packages/digitransit-component-traffic-now-link/package.json
+++ b/digitransit-component/packages/digitransit-component-traffic-now-link/package.json
@@ -29,7 +29,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-icon": "^2.0.2",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
     "@hsl-fi/sass": "1.0.0",
     "i18next": "^22.5.1",
     "prop-types": "^15.8.1",

--- a/digitransit-component/packages/digitransit-component-traffic-now-link/package.json
+++ b/digitransit-component/packages/digitransit-component-traffic-now-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component-traffic-now-link",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "digitransit-component traffic-now-link module",
   "main": "index.js",
   "files": [

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -18,18 +18,18 @@
     "url": "git://github.com/HSLdevcom/digitransit-ui.git"
   },
   "dependencies": {
-    "@digitransit-component/digitransit-component-autosuggest": "^7.2.1",
-    "@digitransit-component/digitransit-component-autosuggest-panel": "^8.4.1",
-    "@digitransit-component/digitransit-component-control-panel": "^7.1.5",
-    "@digitransit-component/digitransit-component-favourite-bar": "^5.0.7",
-    "@digitransit-component/digitransit-component-favourite-editing-modal": "^5.1.2",
-    "@digitransit-component/digitransit-component-favourite-modal": "^4.0.6",
-    "@digitransit-component/digitransit-component-icon": "^2.0.3",
-    "@digitransit-component/digitransit-component-suggestion-item": "^3.0.4",
-    "@digitransit-component/digitransit-component-with-breakpoint": "^1.0.2"
+    "@digitransit-component/digitransit-component-autosuggest": "workspace:^",
+    "@digitransit-component/digitransit-component-autosuggest-panel": "workspace:^",
+    "@digitransit-component/digitransit-component-control-panel": "workspace:^",
+    "@digitransit-component/digitransit-component-favourite-bar": "workspace:^",
+    "@digitransit-component/digitransit-component-favourite-editing-modal": "workspace:^",
+    "@digitransit-component/digitransit-component-favourite-modal": "workspace:^",
+    "@digitransit-component/digitransit-component-icon": "workspace:^",
+    "@digitransit-component/digitransit-component-suggestion-item": "workspace:^",
+    "@digitransit-component/digitransit-component-with-breakpoint": "workspace:^"
   },
   "peerDependencies": {
-    "@digitransit-component/digitransit-component-dialog-modal": "^4.0.0",
+    "@digitransit-component/digitransit-component-dialog-modal": "workspace:^",
     "@hsl-fi/loading-indicators": "^2.0.0",
     "@hsl-fi/modal": "^0.3.2",
     "@hsl-fi/sass": "1.0.0",

--- a/digitransit-component/packages/digitransit-component/package.json
+++ b/digitransit-component/packages/digitransit-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-component/digitransit-component",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-component",
   "module": "digitransit-component.mjs",

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-execute-search-immidiate",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "description": "digitransit-search-util execute-search-immidiate module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate/package.json
@@ -21,10 +21,10 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "^1.0.2",
-    "@digitransit-search-util/digitransit-search-util-get-geocoding-results": "^1.0.4",
-    "@digitransit-search-util/digitransit-search-util-get-json": "^1.0.4",
-    "@digitransit-search-util/digitransit-search-util-helpers": "^2.3.5",
+    "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "workspace:^",
+    "@digitransit-search-util/digitransit-search-util-get-geocoding-results": "workspace:^",
+    "@digitransit-search-util/digitransit-search-util-get-json": "workspace:^",
+    "@digitransit-search-util/digitransit-search-util-helpers": "workspace:^",
     "lodash": "4.18.1"
   }
 }

--- a/digitransit-search-util/packages/digitransit-search-util-get-geocoding-results/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-get-geocoding-results/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-get-geocoding-results",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "digitransit-search-util get-geocoding-results module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-get-geocoding-results/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-get-geocoding-results/package.json
@@ -21,6 +21,6 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-get-json": "^1.0.4"
+    "@digitransit-search-util/digitransit-search-util-get-json": "workspace:^"
   }
 }

--- a/digitransit-search-util/packages/digitransit-search-util-get-json/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-get-json/package.json
@@ -21,7 +21,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-serialize": "^0.0.3",
+    "@digitransit-search-util/digitransit-search-util-serialize": "workspace:^",
     "axios": "1.17.0"
   }
 }

--- a/digitransit-search-util/packages/digitransit-search-util-get-json/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-get-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-get-json",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "digitransit-search-util get-json module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-get-label/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-get-label/package.json
@@ -21,6 +21,6 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "^2.1.3"
+    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "workspace:^"
   }
 }

--- a/digitransit-search-util/packages/digitransit-search-util-get-label/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-get-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-get-label",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "digitransit-search-util get-label module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-helpers/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-helpers",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "digitransit-search-util helpers module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-helpers/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-helpers/package.json
@@ -21,7 +21,7 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-is-duplicate": "^2.1.1",
+    "@digitransit-search-util/digitransit-search-util-is-duplicate": "workspace:^",
     "lodash": "4.18.1"
   }
 }

--- a/digitransit-search-util/packages/digitransit-search-util-is-duplicate/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-is-duplicate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-is-duplicate",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "digitransit-search-util is-duplicate module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-is-duplicate/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-is-duplicate/package.json
@@ -21,6 +21,6 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-tru-eq": "^0.0.3"
+    "@digitransit-search-util/digitransit-search-util-tru-eq": "workspace:^"
   }
 }

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-query-utils",
-  "version": "4.5.13",
+  "version": "4.5.14",
   "description": "digitransit-search-util query-utils module",
   "main": "lib/index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/package.json
@@ -39,9 +39,9 @@
     "relay-compiler": "16.2.0"
   },
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "^1.0.2",
-    "@digitransit-search-util/digitransit-search-util-helpers": "^2.3.5",
-    "@digitransit-search-util/digitransit-search-util-route-name-compare": "^0.0.3",
+    "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "workspace:^",
+    "@digitransit-search-util/digitransit-search-util-helpers": "workspace:^",
+    "@digitransit-search-util/digitransit-search-util-route-name-compare": "workspace:^",
     "babel-plugin-relay": "16.2.0"
   }
 }

--- a/digitransit-search-util/packages/digitransit-search-util-suggestion-to-location/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-suggestion-to-location/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-search-util/digitransit-search-util-suggestion-to-location",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "digitransit-search-util suggestion-to-location module",
   "main": "index.js",
   "publishConfig": {

--- a/digitransit-search-util/packages/digitransit-search-util-suggestion-to-location/package.json
+++ b/digitransit-search-util/packages/digitransit-search-util-suggestion-to-location/package.json
@@ -21,6 +21,6 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-search-util/digitransit-search-util-get-label": "^1.0.4"
+    "@digitransit-search-util/digitransit-search-util-get-label": "workspace:^"
   }
 }

--- a/digitransit-util/packages/digitransit-util-enrich-patterns/package.json
+++ b/digitransit-util/packages/digitransit-util-enrich-patterns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-util/digitransit-util-enrich-patterns",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "digitransit-util enrich-patterns module",
   "main": "index.js",
   "scripts": {

--- a/digitransit-util/packages/digitransit-util-enrich-patterns/package.json
+++ b/digitransit-util/packages/digitransit-util-enrich-patterns/package.json
@@ -18,8 +18,8 @@
   "author": "Digitransit Authors",
   "license": "(AGPL-3.0 OR EUPL-1.2)",
   "dependencies": {
-    "@digitransit-util/digitransit-util-day-range-allowed-diff": "^1.0.5",
-    "@digitransit-util/digitransit-util-day-range-pattern": "^1.1.1"
+    "@digitransit-util/digitransit-util-day-range-allowed-diff": "workspace:^",
+    "@digitransit-util/digitransit-util-day-range-pattern": "workspace:^"
   },
   "peerDependencies": {
     "lodash": "4.17.21",

--- a/digitransit-util/packages/digitransit-util/package.json
+++ b/digitransit-util/packages/digitransit-util/package.json
@@ -18,9 +18,9 @@
     "docs": "node -r esm ../../scripts/generate-readmes"
   },
   "dependencies": {
-    "@digitransit-util/digitransit-util-day-range-allowed-diff": "^1.0.5",
-    "@digitransit-util/digitransit-util-day-range-pattern": "^1.1.1",
-    "@digitransit-util/digitransit-util-enrich-patterns": "^2.0.1",
-    "@digitransit-util/digitransit-util-route-pattern-option-text": "^4.1.1"
+    "@digitransit-util/digitransit-util-day-range-allowed-diff": "workspace:^",
+    "@digitransit-util/digitransit-util-day-range-pattern": "workspace:^",
+    "@digitransit-util/digitransit-util-enrich-patterns": "workspace:^",
+    "@digitransit-util/digitransit-util-route-pattern-option-text": "workspace:^"
   }
 }

--- a/digitransit-util/packages/digitransit-util/package.json
+++ b/digitransit-util/packages/digitransit-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitransit-util/digitransit-util",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "a JavaScript library for Digitransit",
   "main": "digitransit-util",
   "module": "digitransit-util.mjs",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,13 +55,24 @@ yarn add-theme <name> '#RRGGBB' <optional navbar logo>
 
 ## Using `check-versions-workspaces.js`
 
-Fails if a workspace package changed since a given base commit but its `package.json` `version`
-wasn't bumped accordingly (or was bumped in the wrong direction). `lerna publish from-package`
-only republishes a package when its committed version is greater than what's already on npm, so a
-changed-but-unbumped package would otherwise silently never get published. Run it (with
-`BASE_SHA` set to the commit/branch to diff against) whenever you change a workspace package
-(`digitransit-component`, `digitransit-search-util`, `digitransit-store`, `digitransit-util`) to
-make sure you remembered to bump its version — this is also enforced in CI on pull requests.
+Runs two checks against the workspace packages (`digitransit-component`,
+`digitransit-search-util`, `digitransit-store`, `digitransit-util`); both are enforced in CI on
+pull requests.
+
+1. **Internal reference protocol.** Every `@digitransit-*` `dependencies`/`peerDependencies`
+   entry that points at another workspace package must be declared as exactly `"workspace:^"`.
+   `lerna version` only rewrites/cascades an internal cross-reference (and `yarn` only links the
+   local copy instead of pulling a stale published one) when it uses the `workspace:` protocol; a
+   plain semver pin is silently left behind on version bumps. `lerna publish` resolves
+   `"workspace:^"` to `"^<version>"` in the published tarball, so consumers outside the monorepo
+   are unaffected. This check always runs, regardless of `BASE_SHA`.
+
+2. **Version bumps.** Fails if a workspace package changed since a given base commit but its
+   `package.json` `version` wasn't bumped accordingly (or was bumped in the wrong direction).
+   `lerna publish from-package` only republishes a package when its committed version is greater
+   than what's already on npm, so a changed-but-unbumped package would otherwise silently never
+   get published. This check runs only when `BASE_SHA` is set. Run `yarn bump-versions-workspaces`
+   (`lerna version`) to bump the changed packages and cascade bumps to their dependents.
 
 ```
 BASE_SHA=<git ref> yarn check-versions-workspaces

--- a/scripts/check-versions-workspaces.js
+++ b/scripts/check-versions-workspaces.js
@@ -3,15 +3,19 @@
  * Runs two checks against the workspace packages:
  *
  * 1. checkInternalDependencyRanges(): for every workspace package, verifies
- *    that each of its @digitransit-* dependencies/peerDependencies is a range
- *    that is actually satisfied by the CURRENT version of the referenced
- *    workspace package. This catches stale internal pins (e.g. a package
- *    pinned to an exact old version of a dependency that has since been
- *    bumped), which would otherwise make yarn/npm resolve that dependency
- *    from the public registry instead of the local workspace copy - silently
- *    building against stale, disconnected code. This check always runs,
- *    regardless of $BASE_SHA, since it's a static consistency check on the
- *    current state of the repo, not a diff against history.
+ *    that each of its @digitransit-* dependencies/peerDependencies that refers
+ *    to another workspace package is declared as exactly "workspace:^".
+ *    `lerna version` only rewrites/cascades an internal cross-reference when it
+ *    uses the workspace: protocol (see getLocalDependency in lerna's source);
+ *    a plain semver pin is silently left untouched on version bumps and never
+ *    triggers a cascading bump of the dependent, so on a breaking change it
+ *    ends up resolving the dependency from the public registry instead of the
+ *    local workspace copy - silently building against stale, disconnected
+ *    code. The bare "workspace:^" alias (no pinned version) means the line
+ *    itself never needs maintenance; `lerna publish` rewrites it to
+ *    "^<version>" in the published tarball. This check always runs, regardless
+ *    of $BASE_SHA, since it's a static consistency check on the current state
+ *    of the repo, not a diff against history.
  *
  * 2. checkOwnVersionBumps(): fails if a workspace package changed since
  *    $BASE_SHA but its package.json "version" wasn't bumped accordingly.
@@ -61,15 +65,16 @@ function lernaLs(extraArgs) {
   return JSON.parse(output);
 }
 
-// Checks that every workspace package's @digitransit-* dependency/
-// peerDependency ranges are satisfied by the current version of the
-// referenced workspace package. devDependencies are intentionally excluded:
-// they don't affect published consumers.
+// The only spec allowed for an internal @digitransit-* cross-reference.
+const REQUIRED_INTERNAL_SPEC = 'workspace:^';
+
+// Checks that every workspace package references its sibling @digitransit-*
+// workspace packages via exactly "workspace:^" in dependencies/peerDependencies.
+// devDependencies are intentionally excluded: they don't affect published
+// consumers, and lerna doesn't cascade through them.
 function checkInternalDependencyRanges() {
   const allPackages = lernaLs([]);
-  const versionByName = new Map(
-    allPackages.map(pkg => [pkg.name, pkg.version]),
-  );
+  const workspacePackageNames = new Set(allPackages.map(pkg => pkg.name));
 
   const failures = [];
 
@@ -81,32 +86,20 @@ function checkInternalDependencyRanges() {
     ['dependencies', 'peerDependencies'].forEach(depField => {
       const deps = packageJson[depField] || {};
 
-      Object.entries(deps).forEach(([depName, range]) => {
-        if (!depName.startsWith('@digitransit-')) {
+      Object.entries(deps).forEach(([depName, spec]) => {
+        // Only sibling workspace packages are relevant. An external scoped
+        // dependency that merely shares the @digitransit- prefix is skipped.
+        if (!workspacePackageNames.has(depName)) {
           return;
         }
 
-        const currentDepVersion = versionByName.get(depName);
-
-        // Not a workspace package (e.g. an external scoped dependency not
-        // managed in this repo) - nothing to check.
-        if (!currentDepVersion) {
-          return;
-        }
-
-        if (!semver.satisfies(currentDepVersion, range)) {
-          failures.push({
-            name: pkg.name,
-            depField,
-            depName,
-            range,
-            currentDepVersion,
-          });
+        if (spec !== REQUIRED_INTERNAL_SPEC) {
+          failures.push({ name: pkg.name, depField, depName, spec });
 
           console.error(
             red(
-              `✗ ${pkg.name}: ${depField} "${depName}": "${range}" does not ` +
-                `match the current version of ${depName} (${currentDepVersion})`,
+              `✗ ${pkg.name}: ${depField} "${depName}": "${spec}" must be ` +
+                `"${REQUIRED_INTERNAL_SPEC}"`,
             ),
           );
         }
@@ -117,21 +110,25 @@ function checkInternalDependencyRanges() {
   if (failures.length > 0) {
     console.error(
       red(
-        '\nThe following internal dependency ranges are stale and must be updated:',
+        '\nThe following internal @digitransit-* references do not use the ' +
+          `"${REQUIRED_INTERNAL_SPEC}" protocol:`,
       ),
     );
 
     failures.forEach(failure => {
       console.error(
         red(
-          `  - ${failure.name} → ${failure.depName} (declared "${failure.range}", current ${failure.currentDepVersion})`,
+          `  - ${failure.name} → ${failure.depName} in ${failure.depField} (declared "${failure.spec}")`,
         ),
       );
     });
 
     console.error(
       red(
-        '\nUpdate the declared range so it is satisfied by the current version of the dependency.',
+        `\nDeclare every internal @digitransit-* dependency/peerDependency as ` +
+          `"${REQUIRED_INTERNAL_SPEC}" so \`lerna version\` maintains it (rewrites ` +
+          `and cascades bumps); \`lerna publish\` resolves it to "^<version>" in ` +
+          `the published package.`,
       ),
     );
 
@@ -139,7 +136,9 @@ function checkInternalDependencyRanges() {
   }
 
   console.log(
-    green('✓ All internal @digitransit-* dependency ranges are satisfied.'),
+    green(
+      `✓ All internal @digitransit-* references use "${REQUIRED_INTERNAL_SPEC}".`,
+    ),
   );
   return true;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,12 +3015,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest-panel@npm:^8.4.1, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
+"@digitransit-component/digitransit-component-autosuggest-panel@workspace:^, @digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest-panel@workspace:digitransit-component/packages/digitransit-component-autosuggest-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-autosuggest": ^7.2.0
-    "@digitransit-component/digitransit-component-icon": ^2.0.2
+    "@digitransit-component/digitransit-component-autosuggest": "workspace:^"
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
     "@hsl-fi/sass": 1.0.0
     classnames: 2.5.1
     downshift: 9.4.0
@@ -3034,18 +3034,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-autosuggest@npm:^7.2.1, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
+"@digitransit-component/digitransit-component-autosuggest@workspace:^, @digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-autosuggest@workspace:digitransit-component/packages/digitransit-component-autosuggest"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": "npm:^3.3.8"
-    "@digitransit-search-util/digitransit-search-util-get-label": "npm:^1.0.4"
-    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "npm:^2.1.3"
+    "@digitransit-search-util/digitransit-search-util-execute-search-immidiate": "workspace:^"
+    "@digitransit-search-util/digitransit-search-util-get-label": "workspace:^"
+    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "workspace:^"
     "@hsl-fi/hooks": "npm:^1.2.4"
   peerDependencies:
-    "@digitransit-component/digitransit-component-dialog-modal": ^4.0.0
-    "@digitransit-component/digitransit-component-icon": ^2.0.2
-    "@digitransit-component/digitransit-component-suggestion-item": ^3.0.3
+    "@digitransit-component/digitransit-component-dialog-modal": "workspace:^"
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
+    "@digitransit-component/digitransit-component-suggestion-item": "workspace:^"
     "@hsl-fi/sass": 1.0.0
     classnames: 2.5.1
     downshift: 9.4.0
@@ -3060,11 +3060,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-control-panel@npm:^7.1.5, @digitransit-component/digitransit-component-control-panel@workspace:digitransit-component/packages/digitransit-component-control-panel":
+"@digitransit-component/digitransit-component-control-panel@workspace:^, @digitransit-component/digitransit-component-control-panel@workspace:digitransit-component/packages/digitransit-component-control-panel":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-control-panel@workspace:digitransit-component/packages/digitransit-component-control-panel"
   peerDependencies:
-    "@digitransit-component/digitransit-component-icon": ^2.0.2
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
     "@hsl-fi/modal": ^0.3.2
     "@hsl-fi/sass": 1.0.0
     "@hsl-fi/shimmer": 0.1.2
@@ -3080,7 +3080,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-datetimepicker@workspace:digitransit-component/packages/digitransit-component-datetimepicker"
   peerDependencies:
-    "@digitransit-component/digitransit-component-icon": ^2.0.2
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
     classnames: 2.5.1
     downshift: 9.0.10
     i18next: ^22.5.1
@@ -3105,14 +3105,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-favourite-bar@npm:^5.0.7, @digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar":
+"@digitransit-component/digitransit-component-favourite-bar@workspace:^, @digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-favourite-bar@workspace:digitransit-component/packages/digitransit-component-favourite-bar"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "npm:^2.1.3"
+    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "workspace:^"
   peerDependencies:
-    "@digitransit-component/digitransit-component-icon": ^2.0.2
-    "@digitransit-component/digitransit-component-suggestion-item": ^3.0.3
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
+    "@digitransit-component/digitransit-component-suggestion-item": "workspace:^"
     "@hsl-fi/sass": 1.0.0
     "@hsl-fi/shimmer": 0.1.2
     classnames: 2.5.1
@@ -3125,14 +3125,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-favourite-editing-modal@npm:^5.1.2, @digitransit-component/digitransit-component-favourite-editing-modal@workspace:digitransit-component/packages/digitransit-component-favourite-editing-modal":
+"@digitransit-component/digitransit-component-favourite-editing-modal@workspace:^, @digitransit-component/digitransit-component-favourite-editing-modal@workspace:digitransit-component/packages/digitransit-component-favourite-editing-modal":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-favourite-editing-modal@workspace:digitransit-component/packages/digitransit-component-favourite-editing-modal"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "npm:^2.1.3"
+    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "workspace:^"
   peerDependencies:
-    "@digitransit-component/digitransit-component-dialog-modal": ^4.0.0
-    "@digitransit-component/digitransit-component-icon": ^2.0.2
+    "@digitransit-component/digitransit-component-dialog-modal": "workspace:^"
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
     "@hsl-fi/loading-indicators": ^2.0.0
     "@hsl-fi/modal": ^0.3.2
     "@hsl-fi/sass": 1.0.0
@@ -3144,11 +3144,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-favourite-modal@npm:^4.0.6, @digitransit-component/digitransit-component-favourite-modal@workspace:digitransit-component/packages/digitransit-component-favourite-modal":
+"@digitransit-component/digitransit-component-favourite-modal@workspace:^, @digitransit-component/digitransit-component-favourite-modal@workspace:digitransit-component/packages/digitransit-component-favourite-modal":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-favourite-modal@workspace:digitransit-component/packages/digitransit-component-favourite-modal"
   peerDependencies:
-    "@digitransit-component/digitransit-component-icon": ^2.0.2
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
     "@hsl-fi/modal": ^0.3.2
     "@hsl-fi/sass": 1.0.0
     classnames: 2.5.1
@@ -3161,7 +3161,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-icon@npm:^2.0.3, @digitransit-component/digitransit-component-icon@workspace:digitransit-component/packages/digitransit-component-icon":
+"@digitransit-component/digitransit-component-icon@workspace:^, @digitransit-component/digitransit-component-icon@workspace:digitransit-component/packages/digitransit-component-icon":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-icon@workspace:digitransit-component/packages/digitransit-component-icon"
   peerDependencies:
@@ -3170,11 +3170,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-suggestion-item@npm:^3.0.4, @digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item":
+"@digitransit-component/digitransit-component-suggestion-item@workspace:^, @digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-suggestion-item@workspace:digitransit-component/packages/digitransit-component-suggestion-item"
   peerDependencies:
-    "@digitransit-component/digitransit-component-icon": ^2.0.2
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
     "@hsl-fi/sass": " 1.0.0"
     classnames: 2.5.1
     prop-types: ^15.8.1
@@ -3186,7 +3186,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-traffic-now-link@workspace:digitransit-component/packages/digitransit-component-traffic-now-link"
   peerDependencies:
-    "@digitransit-component/digitransit-component-icon": ^2.0.2
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
     "@hsl-fi/sass": 1.0.0
     i18next: ^22.5.1
     prop-types: ^15.8.1
@@ -3195,7 +3195,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-component/digitransit-component-with-breakpoint@npm:^1.0.2, @digitransit-component/digitransit-component-with-breakpoint@workspace:digitransit-component/packages/digitransit-component-with-breakpoint":
+"@digitransit-component/digitransit-component-with-breakpoint@workspace:^, @digitransit-component/digitransit-component-with-breakpoint@workspace:digitransit-component/packages/digitransit-component-with-breakpoint":
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component-with-breakpoint@workspace:digitransit-component/packages/digitransit-component-with-breakpoint"
   peerDependencies:
@@ -3210,17 +3210,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-component/digitransit-component@workspace:digitransit-component/packages/digitransit-component"
   dependencies:
-    "@digitransit-component/digitransit-component-autosuggest": "npm:^7.2.1"
-    "@digitransit-component/digitransit-component-autosuggest-panel": "npm:^8.4.1"
-    "@digitransit-component/digitransit-component-control-panel": "npm:^7.1.5"
-    "@digitransit-component/digitransit-component-favourite-bar": "npm:^5.0.7"
-    "@digitransit-component/digitransit-component-favourite-editing-modal": "npm:^5.1.2"
-    "@digitransit-component/digitransit-component-favourite-modal": "npm:^4.0.6"
-    "@digitransit-component/digitransit-component-icon": "npm:^2.0.3"
-    "@digitransit-component/digitransit-component-suggestion-item": "npm:^3.0.4"
-    "@digitransit-component/digitransit-component-with-breakpoint": "npm:^1.0.2"
+    "@digitransit-component/digitransit-component-autosuggest": "workspace:^"
+    "@digitransit-component/digitransit-component-autosuggest-panel": "workspace:^"
+    "@digitransit-component/digitransit-component-control-panel": "workspace:^"
+    "@digitransit-component/digitransit-component-favourite-bar": "workspace:^"
+    "@digitransit-component/digitransit-component-favourite-editing-modal": "workspace:^"
+    "@digitransit-component/digitransit-component-favourite-modal": "workspace:^"
+    "@digitransit-component/digitransit-component-icon": "workspace:^"
+    "@digitransit-component/digitransit-component-suggestion-item": "workspace:^"
+    "@digitransit-component/digitransit-component-with-breakpoint": "workspace:^"
   peerDependencies:
-    "@digitransit-component/digitransit-component-dialog-modal": ^4.0.0
+    "@digitransit-component/digitransit-component-dialog-modal": "workspace:^"
     "@hsl-fi/loading-indicators": ^2.0.0
     "@hsl-fi/modal": ^0.3.2
     "@hsl-fi/sass": 1.0.0
@@ -3245,19 +3245,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-execute-search-immidiate@npm:^3.3.8, @digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate":
+"@digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:^, @digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-execute-search-immidiate@workspace:digitransit-search-util/packages/digitransit-search-util-execute-search-immidiate"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "npm:^1.0.2"
-    "@digitransit-search-util/digitransit-search-util-get-geocoding-results": "npm:^1.0.4"
-    "@digitransit-search-util/digitransit-search-util-get-json": "npm:^1.0.4"
-    "@digitransit-search-util/digitransit-search-util-helpers": "npm:^2.3.5"
+    "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "workspace:^"
+    "@digitransit-search-util/digitransit-search-util-get-geocoding-results": "workspace:^"
+    "@digitransit-search-util/digitransit-search-util-get-json": "workspace:^"
+    "@digitransit-search-util/digitransit-search-util-helpers": "workspace:^"
     lodash: "npm:4.18.1"
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-filter-matching-to-input@npm:^1.0.2, @digitransit-search-util/digitransit-search-util-filter-matching-to-input@workspace:digitransit-search-util/packages/digitransit-search-util-filter-matching-to-input":
+"@digitransit-search-util/digitransit-search-util-filter-matching-to-input@workspace:^, @digitransit-search-util/digitransit-search-util-filter-matching-to-input@workspace:digitransit-search-util/packages/digitransit-search-util-filter-matching-to-input":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-filter-matching-to-input@workspace:digitransit-search-util/packages/digitransit-search-util-filter-matching-to-input"
   dependencies:
@@ -3265,45 +3265,45 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-get-geocoding-results@npm:^1.0.4, @digitransit-search-util/digitransit-search-util-get-geocoding-results@workspace:digitransit-search-util/packages/digitransit-search-util-get-geocoding-results":
+"@digitransit-search-util/digitransit-search-util-get-geocoding-results@workspace:^, @digitransit-search-util/digitransit-search-util-get-geocoding-results@workspace:digitransit-search-util/packages/digitransit-search-util-get-geocoding-results":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-get-geocoding-results@workspace:digitransit-search-util/packages/digitransit-search-util-get-geocoding-results"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-get-json": "npm:^1.0.4"
+    "@digitransit-search-util/digitransit-search-util-get-json": "workspace:^"
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-get-json@npm:^1.0.4, @digitransit-search-util/digitransit-search-util-get-json@workspace:digitransit-search-util/packages/digitransit-search-util-get-json":
+"@digitransit-search-util/digitransit-search-util-get-json@workspace:^, @digitransit-search-util/digitransit-search-util-get-json@workspace:digitransit-search-util/packages/digitransit-search-util-get-json":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-get-json@workspace:digitransit-search-util/packages/digitransit-search-util-get-json"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-serialize": "npm:^0.0.3"
+    "@digitransit-search-util/digitransit-search-util-serialize": "workspace:^"
     axios: "npm:1.17.0"
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-get-label@npm:^1.0.4, @digitransit-search-util/digitransit-search-util-get-label@workspace:digitransit-search-util/packages/digitransit-search-util-get-label":
+"@digitransit-search-util/digitransit-search-util-get-label@workspace:^, @digitransit-search-util/digitransit-search-util-get-label@workspace:digitransit-search-util/packages/digitransit-search-util-get-label":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-get-label@workspace:digitransit-search-util/packages/digitransit-search-util-get-label"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "npm:^2.1.3"
+    "@digitransit-search-util/digitransit-search-util-uniq-by-label": "workspace:^"
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-helpers@npm:^2.3.5, @digitransit-search-util/digitransit-search-util-helpers@workspace:digitransit-search-util/packages/digitransit-search-util-helpers":
+"@digitransit-search-util/digitransit-search-util-helpers@workspace:^, @digitransit-search-util/digitransit-search-util-helpers@workspace:digitransit-search-util/packages/digitransit-search-util-helpers":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-helpers@workspace:digitransit-search-util/packages/digitransit-search-util-helpers"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-is-duplicate": "npm:^2.1.1"
+    "@digitransit-search-util/digitransit-search-util-is-duplicate": "workspace:^"
     lodash: "npm:4.18.1"
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-is-duplicate@npm:^2.1.1, @digitransit-search-util/digitransit-search-util-is-duplicate@workspace:digitransit-search-util/packages/digitransit-search-util-is-duplicate":
+"@digitransit-search-util/digitransit-search-util-is-duplicate@workspace:^, @digitransit-search-util/digitransit-search-util-is-duplicate@workspace:digitransit-search-util/packages/digitransit-search-util-is-duplicate":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-is-duplicate@workspace:digitransit-search-util/packages/digitransit-search-util-is-duplicate"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-tru-eq": "npm:^0.0.3"
+    "@digitransit-search-util/digitransit-search-util-tru-eq": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -3311,9 +3311,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-query-utils@workspace:digitransit-search-util/packages/digitransit-search-util-query-utils"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "npm:^1.0.2"
-    "@digitransit-search-util/digitransit-search-util-helpers": "npm:^2.3.5"
-    "@digitransit-search-util/digitransit-search-util-route-name-compare": "npm:^0.0.3"
+    "@digitransit-search-util/digitransit-search-util-filter-matching-to-input": "workspace:^"
+    "@digitransit-search-util/digitransit-search-util-helpers": "workspace:^"
+    "@digitransit-search-util/digitransit-search-util-route-name-compare": "workspace:^"
     babel-plugin-relay: "npm:16.2.0"
     relay-compiler: "npm:16.2.0"
   peerDependencies:
@@ -3323,13 +3323,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-route-name-compare@npm:^0.0.3, @digitransit-search-util/digitransit-search-util-route-name-compare@workspace:digitransit-search-util/packages/digitransit-search-util-route-name-compare":
+"@digitransit-search-util/digitransit-search-util-route-name-compare@workspace:^, @digitransit-search-util/digitransit-search-util-route-name-compare@workspace:digitransit-search-util/packages/digitransit-search-util-route-name-compare":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-route-name-compare@workspace:digitransit-search-util/packages/digitransit-search-util-route-name-compare"
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-serialize@npm:^0.0.3, @digitransit-search-util/digitransit-search-util-serialize@workspace:digitransit-search-util/packages/digitransit-search-util-serialize":
+"@digitransit-search-util/digitransit-search-util-serialize@workspace:^, @digitransit-search-util/digitransit-search-util-serialize@workspace:digitransit-search-util/packages/digitransit-search-util-serialize":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-serialize@workspace:digitransit-search-util/packages/digitransit-search-util-serialize"
   languageName: unknown
@@ -3339,17 +3339,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-suggestion-to-location@workspace:digitransit-search-util/packages/digitransit-search-util-suggestion-to-location"
   dependencies:
-    "@digitransit-search-util/digitransit-search-util-get-label": "npm:^1.0.4"
+    "@digitransit-search-util/digitransit-search-util-get-label": "workspace:^"
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-tru-eq@npm:^0.0.3, @digitransit-search-util/digitransit-search-util-tru-eq@workspace:digitransit-search-util/packages/digitransit-search-util-tru-eq":
+"@digitransit-search-util/digitransit-search-util-tru-eq@workspace:^, @digitransit-search-util/digitransit-search-util-tru-eq@workspace:digitransit-search-util/packages/digitransit-search-util-tru-eq":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-tru-eq@workspace:digitransit-search-util/packages/digitransit-search-util-tru-eq"
   languageName: unknown
   linkType: soft
 
-"@digitransit-search-util/digitransit-search-util-uniq-by-label@npm:^2.1.3, @digitransit-search-util/digitransit-search-util-uniq-by-label@workspace:digitransit-search-util/packages/digitransit-search-util-uniq-by-label":
+"@digitransit-search-util/digitransit-search-util-uniq-by-label@workspace:^, @digitransit-search-util/digitransit-search-util-uniq-by-label@workspace:digitransit-search-util/packages/digitransit-search-util-uniq-by-label":
   version: 0.0.0-use.local
   resolution: "@digitransit-search-util/digitransit-search-util-uniq-by-label@workspace:digitransit-search-util/packages/digitransit-search-util-uniq-by-label"
   dependencies:
@@ -3373,24 +3373,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-util/digitransit-util-day-range-allowed-diff@npm:^1.0.5, @digitransit-util/digitransit-util-day-range-allowed-diff@workspace:digitransit-util/packages/digitransit-util-day-range-allowed-diff":
+"@digitransit-util/digitransit-util-day-range-allowed-diff@workspace:^, @digitransit-util/digitransit-util-day-range-allowed-diff@workspace:digitransit-util/packages/digitransit-util-day-range-allowed-diff":
   version: 0.0.0-use.local
   resolution: "@digitransit-util/digitransit-util-day-range-allowed-diff@workspace:digitransit-util/packages/digitransit-util-day-range-allowed-diff"
   languageName: unknown
   linkType: soft
 
-"@digitransit-util/digitransit-util-day-range-pattern@npm:^1.1.1, @digitransit-util/digitransit-util-day-range-pattern@workspace:digitransit-util/packages/digitransit-util-day-range-pattern":
+"@digitransit-util/digitransit-util-day-range-pattern@workspace:^, @digitransit-util/digitransit-util-day-range-pattern@workspace:digitransit-util/packages/digitransit-util-day-range-pattern":
   version: 0.0.0-use.local
   resolution: "@digitransit-util/digitransit-util-day-range-pattern@workspace:digitransit-util/packages/digitransit-util-day-range-pattern"
   languageName: unknown
   linkType: soft
 
-"@digitransit-util/digitransit-util-enrich-patterns@npm:^2.0.1, @digitransit-util/digitransit-util-enrich-patterns@workspace:digitransit-util/packages/digitransit-util-enrich-patterns":
+"@digitransit-util/digitransit-util-enrich-patterns@workspace:^, @digitransit-util/digitransit-util-enrich-patterns@workspace:digitransit-util/packages/digitransit-util-enrich-patterns":
   version: 0.0.0-use.local
   resolution: "@digitransit-util/digitransit-util-enrich-patterns@workspace:digitransit-util/packages/digitransit-util-enrich-patterns"
   dependencies:
-    "@digitransit-util/digitransit-util-day-range-allowed-diff": "npm:^1.0.5"
-    "@digitransit-util/digitransit-util-day-range-pattern": "npm:^1.1.1"
+    "@digitransit-util/digitransit-util-day-range-allowed-diff": "workspace:^"
+    "@digitransit-util/digitransit-util-day-range-pattern": "workspace:^"
   peerDependencies:
     lodash: 4.17.21
     lodash-es: 4.17.21
@@ -3398,7 +3398,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digitransit-util/digitransit-util-route-pattern-option-text@npm:^4.1.1, @digitransit-util/digitransit-util-route-pattern-option-text@workspace:digitransit-util/packages/digitransit-util-route-pattern-option-text":
+"@digitransit-util/digitransit-util-route-pattern-option-text@workspace:^, @digitransit-util/digitransit-util-route-pattern-option-text@workspace:digitransit-util/packages/digitransit-util-route-pattern-option-text":
   version: 0.0.0-use.local
   resolution: "@digitransit-util/digitransit-util-route-pattern-option-text@workspace:digitransit-util/packages/digitransit-util-route-pattern-option-text"
   peerDependencies:
@@ -3413,10 +3413,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@digitransit-util/digitransit-util@workspace:digitransit-util/packages/digitransit-util"
   dependencies:
-    "@digitransit-util/digitransit-util-day-range-allowed-diff": "npm:^1.0.5"
-    "@digitransit-util/digitransit-util-day-range-pattern": "npm:^1.1.1"
-    "@digitransit-util/digitransit-util-enrich-patterns": "npm:^2.0.1"
-    "@digitransit-util/digitransit-util-route-pattern-option-text": "npm:^4.1.1"
+    "@digitransit-util/digitransit-util-day-range-allowed-diff": "workspace:^"
+    "@digitransit-util/digitransit-util-day-range-pattern": "workspace:^"
+    "@digitransit-util/digitransit-util-enrich-patterns": "workspace:^"
+    "@digitransit-util/digitransit-util-route-pattern-option-text": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Proposed Changes

  - While `lerna version` updated  the `dependency` field, it did not update the `peerDependency` field. This PR eliminates workspace package peer dependency management altogether by using the `workspace:^` protocol
  - Also updated the version check script and docs