### PR TITLE
AB#697 Traffic Now - Add configurable link to the breadcrumb, unify design with hslfi, make use of hslfi components

### DIFF
--- a/app/component/AppBarHsl.js
+++ b/app/component/AppBarHsl.js
@@ -215,6 +215,7 @@ const AppBarHsl = ({ favourites = [] }, context) => {
           userMenu={userMenu}
           langMenu={languages}
           search={search}
+          selectedMainNavSection="traveling"
         />
       )}
     </>

--- a/app/component/app-bar-hsl.scss
+++ b/app/component/app-bar-hsl.scss
@@ -10,3 +10,15 @@
     color: #0062a1 !important;
   }
 }
+
+// Force 40px height for the white top bar section of the header
+// for some reason it otherwise gets a height of 41.59px
+// even though the height is derived based on the content and
+// all the items look identical
+.hsl-header-container {
+  [class*='_topBar_'] {
+    box-sizing: border-box;
+    height: 40px;
+    align-items: center;
+  }
+}

--- a/app/component/trafficnow/CanceledTripCard.js
+++ b/app/component/trafficnow/CanceledTripCard.js
@@ -3,10 +3,10 @@ import { useRouter } from 'found';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { connectToStores } from 'fluxible-addons-react';
+import { ArrowLinkButton } from '@hsl-fi/navigation';
 import { useConfigContext } from '../../configurations/ConfigContext';
 import { TRAFFICNOW, routePagePath } from '../../util/path';
 import Card from '../Card';
-import Icon from '../Icon';
 import CanceledDepartures from './components/CanceledDepartures';
 import DisruptionStatus from './components/DisruptionStatus';
 import RouteBadgeGroup from './components/RouteBadgeGroup';
@@ -24,7 +24,7 @@ const CanceledTripCard = ({
 }) => {
   const { router } = useRouter();
   const intl = useIntl();
-  const { colors, trafficNowMaxRoutesPerCard } = useConfigContext();
+  const { trafficNowMaxRoutesPerCard } = useConfigContext();
   const { selectedFilters } = useFilterContext();
   const handleRouteBadgeClick = url => e => {
     e.preventDefault();
@@ -49,18 +49,12 @@ const CanceledTripCard = ({
               <DisruptionStatus
                 active
                 showDates={false}
-                className="text-xs-bold"
+                variant="text-xs-bold"
               />
             </>
           )}
         </span>
-        <button type="button">
-          <Icon
-            img="icon_arrow-collapse--right"
-            color={colors.primary}
-            className="disruption-card__icon"
-          />
-        </button>
+        <ArrowLinkButton />
       </header>
       <div className="badges">
         <RouteBadgeGroup
@@ -107,7 +101,7 @@ const CanceledTripCard = ({
         />
       </div>
       {isMobile && (
-        <DisruptionStatus active showDates={false} className="text-xs-bold" />
+        <DisruptionStatus active showDates={false} variant="text-xs-bold" />
       )}
     </Card>
   );

--- a/app/component/trafficnow/CanceledTrips.js
+++ b/app/component/trafficnow/CanceledTrips.js
@@ -1,21 +1,19 @@
 import React, { useState } from 'react';
-import { Button } from '@hsl-fi/layout-primitives';
-import cx from 'classnames';
-import Link from 'found/Link';
+import { Button, Text } from '@hsl-fi/layout-primitives';
 import PropTypes from 'prop-types';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { useConfigContext } from '../../configurations/ConfigContext';
 import Card from '../Card';
-import Icon from '../Icon';
 import CancellationContainer from './components/CancellationContainer';
 import ResultsProgressBar from './components/ResultsProgressBar';
 import { patternShape, routeShape } from '../../util/shapes';
+import CTAContainer from './components/CTAContainer';
 
 const DEFAULT_ROUTES_SHOWN_AMOUNT = 8;
 
 const CanceledTrips = ({ canceledRoutes = [], mode, isMobile = false }) => {
   const { colors } = useConfigContext();
-  const intl = useIntl();
+  const { formatMessage } = useIntl();
   const [showAmount, setShowAmount] = useState(
     DEFAULT_ROUTES_SHOWN_AMOUNT > canceledRoutes.length
       ? canceledRoutes.length
@@ -50,15 +48,17 @@ const CanceledTrips = ({ canceledRoutes = [], mode, isMobile = false }) => {
           );
         })}
       </div>
-      <footer className="canceled-trips__footer paragraph-extra-small">
+      <footer className="canceled-trips__footer">
         <div className="canceled-trips__footer-body">
-          <FormattedMessage
-            id="traffic-now_canceled-trips--amount"
-            values={{
-              amount: showAmount,
-              totalAmount: canceledRoutes.length,
-            }}
-          />
+          <Text variant="text-xs" as="div">
+            {formatMessage(
+              { id: 'traffic-now_canceled-trips--amount' },
+              {
+                amount: showAmount,
+                totalAmount: canceledRoutes.length,
+              },
+            )}
+          </Text>
           <ResultsProgressBar
             currentAmount={showAmount}
             totalAmount={canceledRoutes.length}
@@ -78,7 +78,7 @@ const CanceledTrips = ({ canceledRoutes = [], mode, isMobile = false }) => {
                   )
                 }
               >
-                {intl.formatMessage({ id: 'show-more' })}
+                {formatMessage({ id: 'show-more' })}
               </Button>
             </div>
           )}
@@ -89,18 +89,7 @@ const CanceledTrips = ({ canceledRoutes = [], mode, isMobile = false }) => {
 
   return (
     <>
-      <div
-        className={cx('detail-view__cta-container', {
-          'detail-view__cta-container--mobile': isMobile,
-        })}
-      >
-        <Link to="/liikenne" className="cta-small">
-          <Icon img="icon_chevron-left" />
-          <FormattedMessage id="traffic-now_go-back" />
-          {isMobile && <div />}
-        </Link>
-      </div>
-
+      <CTAContainer isMobile={isMobile} />
       <div className="canceled-trips__container">{content}</div>
     </>
   );

--- a/app/component/trafficnow/DisruptionBadge.js
+++ b/app/component/trafficnow/DisruptionBadge.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 import capitalize from 'lodash/capitalize';
+import { Text } from '@hsl-fi/layout-primitives';
 import Icon from '../Icon';
 import { AlertSeverityLevelType } from '../../constants';
 
@@ -42,16 +43,16 @@ export default function DisruptionBadge({
   className = undefined,
   ...rest
 }) {
+  const { formatMessage } = useIntl();
   return (
-    <div
-      {...rest}
-      className={cx('badge tag-bold', variant.toLowerCase(), className)}
-    >
+    <div {...rest} className={cx('badge', variant.toLowerCase(), className)}>
       {showIcon && getIcon(variant)}
-      <FormattedMessage
-        id={`${DISRUPTION_BADGE_PREFIX}${label.toLowerCase()}`}
-        defaultMessage={capitalize(label.toLowerCase()).replace(/_/g, ' ')}
-      />
+      <Text variant="tag-bold">
+        {formatMessage({
+          id: `${DISRUPTION_BADGE_PREFIX}${label.toLowerCase()}`,
+          defaultMessage: capitalize(label.toLowerCase()).replace(/_/g, ' '),
+        })}
+      </Text>
     </div>
   );
 }

--- a/app/component/trafficnow/DisruptionCard.js
+++ b/app/component/trafficnow/DisruptionCard.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useConfigContext } from '../../configurations/ConfigContext';
+import { ArrowLinkButton } from '@hsl-fi/navigation';
+import { Text } from '@hsl-fi/layout-primitives';
 import { AlertSeverityLevelType } from '../../constants';
 import { alertShape } from '../../util/shapes';
 import Card from '../Card';
 import DisruptionBadge from './DisruptionBadge';
 import DisruptionStatus from './components/DisruptionStatus';
-import Icon from '../Icon';
 import RouteBadges from './RouteBadges';
 import OperatorBadge from './components/OperatorBadge';
 
@@ -26,7 +26,6 @@ export default function DisruptionCard({
     effectiveEndDate,
     feed,
   } = alert;
-  const { colors } = useConfigContext();
 
   return (
     <Card
@@ -49,27 +48,23 @@ export default function DisruptionCard({
               <DisruptionStatus
                 effectiveStartDate={effectiveStartDate}
                 effectiveEndDate={effectiveEndDate}
-                className="text-xs-bold"
+                variant="text-xs-bold"
                 showDates={alertSeverityLevel !== AlertSeverityLevelType.Info}
               />
             </>
           )}
         </span>
-        <button type="button">
-          <Icon
-            img="icon_arrow-collapse--right"
-            color={colors.primary}
-            className="disruption-card__icon"
-          />
-        </button>
+        <ArrowLinkButton size="m" />
       </header>
       {entities && <RouteBadges entities={entities} mode={mode} compact />}
-      <h2 className="cta-small">{alertHeaderText}</h2>
+      <Text variant="cta-small" color="default" as="h2">
+        {alertHeaderText}
+      </Text>
       {isMobile && (
         <DisruptionStatus
           effectiveStartDate={effectiveStartDate}
           effectiveEndDate={effectiveEndDate}
-          className="text-xs-bold"
+          variant="text-xs-bold"
           showDates={alertSeverityLevel !== AlertSeverityLevelType.Info}
         />
       )}

--- a/app/component/trafficnow/DisruptionDetailsContainer.js
+++ b/app/component/trafficnow/DisruptionDetailsContainer.js
@@ -11,7 +11,7 @@ import DisruptionStatus from './components/DisruptionStatus';
 import RouteBadges from './RouteBadges';
 import AlertsQuery from './queries/AlertsQuery';
 import { AlertSeverityLevelType } from '../../constants';
-import CTAContaineer from './components/CTAContainer';
+import CTAContainer from './components/CTAContainer';
 
 const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
   const config = useConfigContext();
@@ -121,7 +121,7 @@ const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
   if (isMobile) {
     return (
       <>
-        <CTAContaineer isMobile />
+        <CTAContainer isMobile />
         <div className="disruption-details disruption-details--mobile">
           {content}
         </div>
@@ -131,7 +131,7 @@ const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
 
   return (
     <>
-      <CTAContaineer />
+      <CTAContainer />
       <div className="disruption-details__container">
         <Card>{content}</Card>
       </div>

--- a/app/component/trafficnow/DisruptionDetailsContainer.js
+++ b/app/component/trafficnow/DisruptionDetailsContainer.js
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, useIntl } from 'react-intl';
-import { ButtonLink } from '@hsl-fi/layout-primitives';
-import Link from 'found/Link';
+import { useIntl } from 'react-intl';
+import { ButtonLink, Text } from '@hsl-fi/layout-primitives';
 import { useRouter } from 'found';
 import { useLazyLoadQuery } from 'react-relay/hooks';
 import { useConfigContext } from '../../configurations/ConfigContext';
@@ -10,13 +9,13 @@ import Card from '../Card';
 import DisruptionBadge from './DisruptionBadge';
 import DisruptionStatus from './components/DisruptionStatus';
 import RouteBadges from './RouteBadges';
-import Icon from '../Icon';
 import AlertsQuery from './queries/AlertsQuery';
 import { AlertSeverityLevelType } from '../../constants';
+import CTAContaineer from './components/CTAContainer';
 
 const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
   const config = useConfigContext();
-  const intl = useIntl();
+  const { formatMessage } = useIntl();
   const { router } = useRouter();
   const { alerts } = useLazyLoadQuery(AlertsQuery, {
     feedIds: config.feedIds,
@@ -71,7 +70,7 @@ const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
           <DisruptionStatus
             effectiveStartDate={effectiveStartDate}
             effectiveEndDate={effectiveEndDate}
-            className="routes-s-bold"
+            variant="routes-s-bold"
             showDates={alertSeverityLevel !== AlertSeverityLevelType.Info}
           />
         )}
@@ -82,10 +81,20 @@ const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
             <RouteBadges entities={entities} />
           </div>
         )}
-        <h2 className="disruption-details__title">{alertHeaderText}</h2>
-        <p className="disruption-details__description">
+        <Text
+          variant="heading-xs"
+          as="h2"
+          className="disruption-details__title"
+        >
+          {alertHeaderText}
+        </Text>
+        <Text
+          variant="text-m"
+          as="p"
+          className="disruption-details__description"
+        >
           {alertDescriptionText}
-        </p>
+        </Text>
         {checkedUrl && (
           <div className="disruption-details__link">
             <ButtonLink
@@ -98,7 +107,7 @@ const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
                 minWidth: isMobile ? '100%' : 'none',
               }}
             >
-              {intl.formatMessage({
+              {formatMessage({
                 id: 'extra-info',
                 defaultMessage: 'More info',
               })}
@@ -112,13 +121,7 @@ const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
   if (isMobile) {
     return (
       <>
-        <div className="detail-view__cta-container detail-view__cta-container--mobile">
-          <Link to="/liikenne" className="cta-small">
-            <Icon img="icon_chevron-left" />
-            <FormattedMessage id="traffic-now_go-back" />
-            <div />
-          </Link>
-        </div>
+        <CTAContaineer isMobile />
         <div className="disruption-details disruption-details--mobile">
           {content}
         </div>
@@ -128,12 +131,7 @@ const DisruptionDetailsContainer = ({ alertId, isMobile = false }) => {
 
   return (
     <>
-      <div className="detail-view__cta-container">
-        <Link to="/liikenne" className="cta-small">
-          <Icon img="icon_chevron-left" />
-          <FormattedMessage id="traffic-now_go-back" />
-        </Link>
-      </div>
+      <CTAContaineer />
       <div className="disruption-details__container">
         <Card>{content}</Card>
       </div>

--- a/app/component/trafficnow/Disruptions.js
+++ b/app/component/trafficnow/Disruptions.js
@@ -1,9 +1,10 @@
 import React, { useMemo, useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useRouter } from 'found';
 import { useLazyLoadQuery } from 'react-relay/hooks';
+import { Text } from '@hsl-fi/layout-primitives';
 import { useConfigContext } from '../../configurations/ConfigContext';
 import { TransportMode } from '../../constants';
 import { useBreakpoint } from '../../util/withBreakpoint';
@@ -58,6 +59,7 @@ export default function Disruptions({ dateTime }) {
   const config = useConfigContext();
   const { router } = useRouter();
   const { selectedFilters } = useFilterContext();
+  const { formatMessage } = useIntl();
 
   const [hasUpdates, setHasUpdates] = useState(null);
   const [fetchKey, setFetchKey] = useState(0);
@@ -220,13 +222,15 @@ export default function Disruptions({ dateTime }) {
           <NoDisruptions />
         ) : (
           <>
-            <FormattedMessage
-              id="disruptions-found-amount"
-              values={{ amount: resultAmount }}
-              defaultValue="No disruptions found"
-            >
-              {msg => <h3 className="heading-xs">{msg}</h3>}
-            </FormattedMessage>
+            <Text variant="heading-xs" as="h3">
+              {formatMessage(
+                {
+                  id: 'disruptions-found-amount',
+                  defaultMessage: 'No disruptions found',
+                },
+                { amount: resultAmount },
+              )}
+            </Text>
             <div className="disruptions-list">
               {canceledModesFiltered.map(({ key, routes }) => (
                 <CanceledTripCard

--- a/app/component/trafficnow/TrafficNowHeader.js
+++ b/app/component/trafficnow/TrafficNowHeader.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import Link from 'found/Link';
 import cx from 'classnames';
-import Icon from '../Icon';
+import { Text } from '@hsl-fi/layout-primitives';
+import { Icon, ArrowRightS } from '@hsl-fi/icons';
 import { useBreakpoint } from '../../util/withBreakpoint';
 import { useConfigContext } from '../../configurations/ConfigContext';
 import { useLogo } from '../../hooks/useLogo';
@@ -63,6 +64,7 @@ export default function TrafficNowHeader() {
     language,
     URL: { ROOTLINK },
   } = useConfigContext();
+  const { formatMessage } = useIntl();
 
   const { logo } = useLogo(trafficNowHeaderGraphic);
   const desktop = breakpoint === 'large';
@@ -70,7 +72,9 @@ export default function TrafficNowHeader() {
   const breadcrumbHref = localizedRootPath
     ? `${ROOTLINK}${localizedRootPath}`
     : undefined;
-  const breadcrumbLabel = <FormattedMessage id="traffic-now_bread" />;
+  const breadcrumbLabel = (
+    <Text>{formatMessage({ id: 'traffic-now_bread' })}</Text>
+  );
   return (
     <header
       className={cx('traffic-now__header', {
@@ -83,19 +87,17 @@ export default function TrafficNowHeader() {
         ) : (
           <Link to="/">{breadcrumbLabel}</Link>
         )}
-        <Icon
-          img="icon_chevron-right"
-          className="traffic-now__header-crumbarrow"
-        />
-        <FormattedMessage id="traffic-now" />
+        <Icon icon={ArrowRightS} size="s" />
+        <Text>{formatMessage({ id: 'traffic-now' })}</Text>
       </span>
-      <h2 className="heading-l">
-        <FormattedMessage id="traffic-now" />
-      </h2>
-      <p className="traffic-now__header-description text-l">
-        <FormattedMessage id="traffic-now_description" />
+      <Text variant="heading-l" as="h2">
+        {formatMessage({ id: 'traffic-now' })}
+      </Text>
+
+      <Text variant="text-l" as="p">
+        <span>{formatMessage({ id: 'traffic-now_description' })}</span>
         {CONFIG === 'hsl' && <AdditionalDescription />}
-      </p>
+      </Text>
       {logo && desktop && (
         <img src={logo} alt="" className="traffic-now__header-image" />
       )}

--- a/app/component/trafficnow/TrafficNowHeader.js
+++ b/app/component/trafficnow/TrafficNowHeader.js
@@ -90,17 +90,19 @@ export default function TrafficNowHeader() {
         <Icon icon={ArrowRightS} size="s" />
         <Text>{formatMessage({ id: 'traffic-now' })}</Text>
       </span>
-      <Text variant="heading-l" as="h2">
-        {formatMessage({ id: 'traffic-now' })}
-      </Text>
+      <div className="traffic-now__header-text-area">
+        <Text variant="heading-l" as="h2">
+          {formatMessage({ id: 'traffic-now' })}
+        </Text>
 
-      <Text variant="text-l" as="p">
-        <span>{formatMessage({ id: 'traffic-now_description' })}</span>
-        {CONFIG === 'hsl' && <AdditionalDescription />}
-      </Text>
-      {logo && desktop && (
-        <img src={logo} alt="" className="traffic-now__header-image" />
-      )}
+        <Text variant="text-l" as="p">
+          <span>{formatMessage({ id: 'traffic-now_description' })}</span>
+          {CONFIG === 'hsl' && <AdditionalDescription />}
+        </Text>
+        {logo && desktop && (
+          <img src={logo} alt="" className="traffic-now__header-image" />
+        )}
+      </div>
     </header>
   );
 }

--- a/app/component/trafficnow/TrafficNowHeader.js
+++ b/app/component/trafficnow/TrafficNowHeader.js
@@ -1,5 +1,5 @@
-import { FormattedMessage, useIntl } from 'react-intl';
 import React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
 import Link from 'found/Link';
 import cx from 'classnames';
 import Icon from '../Icon';
@@ -56,10 +56,21 @@ const AdditionalDescription = () => {
 
 export default function TrafficNowHeader() {
   const breakpoint = useBreakpoint();
-  const { CONFIG, trafficNowHeaderGraphic } = useConfigContext();
+  const {
+    CONFIG,
+    trafficNowHeaderGraphic,
+    trafficNowRootPath,
+    language,
+    URL: { ROOTLINK },
+  } = useConfigContext();
 
   const { logo } = useLogo(trafficNowHeaderGraphic);
   const desktop = breakpoint === 'large';
+  const localizedRootPath = trafficNowRootPath && trafficNowRootPath[language];
+  const breadcrumbHref = localizedRootPath
+    ? `${ROOTLINK}${localizedRootPath}`
+    : undefined;
+  const breadcrumbLabel = <FormattedMessage id="traffic-now_bread" />;
   return (
     <header
       className={cx('traffic-now__header', {
@@ -67,9 +78,11 @@ export default function TrafficNowHeader() {
       })}
     >
       <span className="traffic-now__header-breadcrumb">
-        <Link to="/">
-          <FormattedMessage id="traffic-now_bread" />
-        </Link>
+        {breadcrumbHref ? (
+          <a href={breadcrumbHref}>{breadcrumbLabel}</a>
+        ) : (
+          <Link to="/">{breadcrumbLabel}</Link>
+        )}
         <Icon
           img="icon_chevron-right"
           className="traffic-now__header-crumbarrow"

--- a/app/component/trafficnow/TrafficNowLink.js
+++ b/app/component/trafficnow/TrafficNowLink.js
@@ -1,12 +1,14 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'found';
+import { Text } from '@hsl-fi/layout-primitives';
 import { TRAFFICNOW } from '../../util/path';
 import Icon from '../Icon';
 import { useConfigContext } from '../../configurations/ConfigContext';
 
 const TrafficNowLink = () => {
   const config = useConfigContext();
+  const { formatMessage } = useIntl();
   const themeColor = config.colors.primary;
 
   return (
@@ -19,16 +21,18 @@ const TrafficNowLink = () => {
           width={1.5}
         />
         <div className="traffic-now__link__left-column-body">
-          <FormattedMessage
-            id="traffic-now_link"
-            defaultMessage="Services now"
-            tagName="h2"
-          />
-          <FormattedMessage
-            id="traffic-now_link-description"
-            defaultMessage="See changes and disruptions"
-            tagName="p"
-          />
+          <Text as="h2">
+            {formatMessage({
+              id: 'traffic-now_link',
+              defaultMessage: 'Services now',
+            })}
+          </Text>
+          <Text as="p">
+            {formatMessage({
+              id: 'traffic-now_link-description',
+              defaultMessage: 'See changes and disruptions',
+            })}
+          </Text>
         </div>
       </div>
       <span className="traffic-now__link__caret">

--- a/app/component/trafficnow/components/CTAContainer.js
+++ b/app/component/trafficnow/components/CTAContainer.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Link } from 'found';
+import { Text } from '@hsl-fi/layout-primitives';
+import { Icon, ArrowLeft } from '@hsl-fi/icons';
+import { useIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+const CTAContainer = ({ isMobile = false }) => {
+  const { formatMessage } = useIntl();
+  return (
+    <div
+      className={cx('detail-view__cta-container', {
+        'detail-view__cta-container--mobile': isMobile,
+      })}
+    >
+      <Link to="/liikenne">
+        <Icon icon={ArrowLeft} color="accent" size="s" />
+        <Text variant="cta-small" color="default">
+          {formatMessage({ id: 'traffic-now_go-back' })}
+        </Text>
+        <div />
+      </Link>
+    </div>
+  );
+};
+
+CTAContainer.propTypes = {
+  isMobile: PropTypes.bool,
+};
+
+export default CTAContainer;

--- a/app/component/trafficnow/components/CanceledDepartures.js
+++ b/app/component/trafficnow/components/CanceledDepartures.js
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon';
 import cx from 'classnames';
 import { useIntl } from 'react-intl';
 import groupBy from 'lodash/groupBy';
+import { Text } from '@hsl-fi/layout-primitives';
 import CanceledDeparturesFragment from '../queries/CanceledDeparturesFragment';
 import Icon from '../../Icon';
 import EntityBadge from './EntityBadge';
@@ -58,12 +59,12 @@ const CanceledDepartures = ({
                 {serviceDate !== DateTime.now().toISODate() && (
                   <div className="departures-date-badge">
                     <Icon img="icon_calendar" />
-                    <div className="routes-s-bold">
+                    <Text variant="routes-s-bold" as="div">
                       {serviceDate ===
                       DateTime.now().plus({ days: 1 }).toISODate()
                         ? formatMessage({ id: 'tomorrow' })
                         : DateTime.fromISO(serviceDate).toFormat('d.L.')}
-                    </div>
+                    </Text>
                   </div>
                 )}
                 <div className="departuretimes">
@@ -79,11 +80,11 @@ const CanceledDepartures = ({
                         key={`${trip.gtfsId}-${trip.stoptimes[0].scheduledDeparture}`}
                         className="badges__departure-time"
                       >
-                        <span className="routes-m-narrow">
+                        <Text variant="routes-s-narrow" as="span">
                           {DateTime.fromISO(serviceDate)
                             .plus(trip.stoptimes[0].scheduledDeparture * 1000)
                             .toFormat(' HH:mm ')}
-                        </span>
+                        </Text>
                       </span>
                     ))}
                 </div>
@@ -105,9 +106,9 @@ const CanceledDepartures = ({
           )}
           {inline && pattern.hiddenDepartureCount > 0 && (
             <span className="badges__departure-time badges__departure-time--show-more">
-              <span className="routes-m-narrow">
+              <Text variant="routes-s-narrow" as="span">
                 +{pattern.hiddenDepartureCount}
-              </span>
+              </Text>
             </span>
           )}
         </React.Fragment>

--- a/app/component/trafficnow/components/DisruptionStatus.js
+++ b/app/component/trafficnow/components/DisruptionStatus.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { DateTime } from 'luxon';
+import { Text } from '@hsl-fi/layout-primitives';
 import Icon from '../../Icon';
 import { getFormattedTimeDate } from '../../../util/timeUtils';
 import { useConfigContext } from '../../../configurations/ConfigContext';
@@ -13,9 +14,9 @@ export default function DisruptionStatus({
   effectiveEndDate,
   showDates = true,
   active,
-  className,
+  variant = 'text-xs-bold',
 }) {
-  const intl = useIntl();
+  const { formatMessage } = useIntl();
   const {
     colors: { primary: primaryColor },
   } = useConfigContext();
@@ -45,23 +46,23 @@ export default function DisruptionStatus({
   const dates = showDates && startDate;
 
   return (
-    <span className={`disruption-status ${className || ''}`}>
+    <span className="disruption-status">
       <Icon
         img={isValid ? 'icon_status' : 'icon_calendar'}
         color={primaryColor}
       />
-      <span>
-        {`${intl.formatMessage({
+      <Text variant={variant}>
+        {`${formatMessage({
           id: isValid ? 'valid' : 'upcoming',
           defaultMessage: isValid ? 'Active' : 'Upcoming',
         })}${dates ? ':' : ''}`}
-      </span>
+      </Text>
       {dates && (
-        <span className="routes-s">
+        <Text variant="routes-s">
           {`${startDate}${
             endDate && startDate !== endDate ? ` - ${endDate}` : ''
           }`}
-        </span>
+        </Text>
       )}
     </span>
   );
@@ -72,5 +73,5 @@ DisruptionStatus.propTypes = {
   effectiveEndDate: PropTypes.number,
   showDates: PropTypes.bool,
   active: PropTypes.bool,
-  className: PropTypes.string,
+  variant: PropTypes.string,
 };

--- a/app/component/trafficnow/components/EntityBadge.js
+++ b/app/component/trafficnow/components/EntityBadge.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { Text } from '@hsl-fi/layout-primitives';
 import Icon from '../../Icon';
 import { entityShape } from '../../../util/shapes';
 
@@ -24,15 +25,19 @@ function EntityBadge({
         highlight: highlighted,
       })}
     >
-      <span className="routes-m-narrow">{name}</span>
+      <Text variant="routes-s-narrow" as="span" color="default">
+        {name}
+      </Text>
     </a>
   ) : (
     <a onClick={handleClick} href={url} className={mode}>
-      <span className="routes-m-narrow">{entity.stops[0].name}</span>
+      <Text variant="routes-s-narrow" as="span" color="default">
+        {entity.stops[0].name}
+      </Text>
       <Icon img="icon_arrow-right-long" color="currentcolor" />
-      <span className="routes-m-narrow">
+      <Text variant="routes-s-narrow" as="span" color="default">
         {entity.headsign || entity.stops?.at(-1).name}
-      </span>
+      </Text>
     </a>
   );
 

--- a/app/component/trafficnow/components/OperatorBadge.js
+++ b/app/component/trafficnow/components/OperatorBadge.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Icon, MapLocation } from '@hsl-fi/icons';
+import { Text } from '@hsl-fi/layout-primitives';
 import { useConfigContext } from '../../../configurations/ConfigContext';
 
 function OperatorBadge({ feed }) {
@@ -15,7 +16,7 @@ function OperatorBadge({ feed }) {
     area && (
       <div className="disruption-operator-badge">
         <Icon icon={MapLocation} size="s" color="default" />
-        <span className="tag-bold">{area}</span>
+        <Text variant="tag-bold">{area}</Text>
       </div>
     )
   );

--- a/app/component/trafficnow/filters/FiltersModal.js
+++ b/app/component/trafficnow/filters/FiltersModal.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import Modal from '@hsl-fi/modal';
+import { CloseButton } from '@hsl-fi/layout-primitives';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import Filters from './Filters';
-import Icon from '../../Icon';
-import IconBackground from '../../icon/IconBackground';
 import { useFilterContext } from './FiltersContext';
 
 const FiltersModal = ({ isOpen, onClose }) => {
@@ -33,16 +32,7 @@ const FiltersModal = ({ isOpen, onClose }) => {
             </h3>
           )}
         </FormattedMessage>
-        <button type="button" onClick={onClose}>
-          <Icon
-            height={2.1}
-            width={2.1}
-            iconScale={0.5}
-            img="icon_close"
-            color="#007ac9"
-            background={<IconBackground shape="circle" color="#ebf6fd" />}
-          />
-        </button>
+        <CloseButton lang={intl.locale} onClick={onClose} />
       </header>
       <Filters onApplyClick={onClose} onResetClick={resetFilters} />
     </Modal>

--- a/app/component/trafficnow/styles/cards.scss
+++ b/app/component/trafficnow/styles/cards.scss
@@ -12,13 +12,12 @@
         border-right: 1px solid $light-gray;
         min-width: 258px;
 
-        .cta-small {
+        a {
           display: flex;
           flex-direction: row;
-          gap: var(--space-xs);
           align-items: center;
-          width: 100%;
-          flex-wrap: nowrap;
+          gap: var(--space-s);
+          color: var(--color-text-default);
         }
 
         &--mobile {
@@ -28,14 +27,12 @@
           justify-content: space-between;
           border-bottom: 1px solid $light-gray;
 
-          .cta-small {
-            width: 100%;
+          a {
+            color: var(--color-text-default);
+            display: flex;
+            align-items: center;
             justify-content: space-between;
           }
-        }
-
-        .icon-container {
-          color: $link-color;
         }
       }
     }

--- a/app/component/trafficnow/styles/layout.scss
+++ b/app/component/trafficnow/styles/layout.scss
@@ -51,11 +51,14 @@
     }
 
     &-breadcrumb {
-      display: inline-flex;
+      display: flex;
       align-items: center;
+      align-content: center;
+      gap: 10px;
+      flex-wrap: wrap;
 
       a {
-        text-decoration: none;
+        color: var(--color-text-link);
       }
     }
 

--- a/app/component/trafficnow/styles/layout.scss
+++ b/app/component/trafficnow/styles/layout.scss
@@ -39,15 +39,21 @@
   &__header {
     display: flex;
     flex-direction: column;
-    gap: var(--space-m);
-    padding: var(--space-l) $padding-horizontal-gutter var(--space-xl)
-      $padding-horizontal-gutter;
+    padding: 30px var(--padding-horizontal-gutter) var(--space-xl)
+      var(--padding-horizontal-gutter);
     flex: 0 0 50%;
 
     &-image {
       position: absolute;
       right: 0;
       bottom: 0;
+    }
+
+    &-text-area {
+      padding-top: 40px;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
     }
 
     &-breadcrumb {
@@ -101,6 +107,10 @@
       flex-direction: column;
       min-width: 0;
       min-height: 0;
+      overflow: auto;
+      padding: var(--space-xl) var(--padding-horizontal-gutter) var(--space-xl)
+        var(--space-xl);
+      gap: var(--space-s);
 
       &__scroll {
         overflow: auto;
@@ -325,7 +335,7 @@
       max-width: 480px;
       background-color: $white;
       flex-shrink: 0;
-      padding-left: $padding-horizontal-gutter;
+      padding-left: var(--padding-horizontal-gutter);
       border-right: 1px solid $light-gray;
     }
 

--- a/app/component/trafficnow/styles/tokens.scss
+++ b/app/component/trafficnow/styles/tokens.scss
@@ -7,9 +7,13 @@
 $bp-tablet-small: 620px;
 $bp-tablet: 900px;
 $bp-typography-tablet: 768px;
+$bp-desktop-narrow: 1260px;
 
 // Layout padding & sizing
+// Horizontal gutter is exposed as a custom property so it can adapt to
+// viewport width, use var(--padding-horizontal-gutter) in layout rules.
 $padding-horizontal-gutter: 50px;
+$padding-horizontal-gutter-narrow: 42px;
 $padding-mobile-small-x: 20px;
 $padding-mobile-small-y: 25px;
 
@@ -54,4 +58,9 @@ $placeholder-color: #888;
 .traffic-now {
   --white: #{$white};
   --background-color-lighter: #{$background-color-lighter};
+  --padding-horizontal-gutter: #{$padding-horizontal-gutter};
+
+  @media screen and (max-width: $bp-desktop-narrow) {
+    --padding-horizontal-gutter: #{$padding-horizontal-gutter-narrow};
+  }
 }

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -740,6 +740,10 @@ export default {
   showVehiclesOnItineraryPage: false,
   trafficNowLink: false,
   trafficNowTest: TRAFFIC_NOW_TEST,
+  // per-language path appended to URL.ROOTLINK used as the TrafficNowHeader
+  // breadcrumb link target; falls back to the index page when not defined,
+  // e.g. { fi: '/matkustaminen', sv: '/sv/att-resa', en: '/en/travelling' }
+  trafficNowRootPath: undefined,
   RUN_ENV,
   SURVEY_SHARE,
   // Maximum number of routes shown per transport mode card in the Traffic now

--- a/app/configurations/config.hsl.js
+++ b/app/configurations/config.hsl.js
@@ -388,6 +388,11 @@ export default {
     en: 'travelling/services-now',
     sv: 'att-resa/Trafiken-just-nu',
   },
+  trafficNowRootPath: {
+    fi: '/matkustaminen',
+    sv: '/sv/att-resa',
+    en: '/en/travelling',
+  },
 
   vehicleRental: {
     minZoomStopsNearYou: 10,

--- a/test/unit/component/trafficnow/CanceledDepartures.test.js
+++ b/test/unit/component/trafficnow/CanceledDepartures.test.js
@@ -21,6 +21,11 @@ const makePattern = canceledTrips => ({
 });
 
 describe('<CanceledDepartures />', () => {
+  const departureTimes = container =>
+    Array.from(
+      container.querySelectorAll('.badges__departure-time .routes-s-narrow'),
+    ).map(node => node.textContent.trim());
+
   const renderCanceledDepartures = props => {
     const { container } = renderWithProviders(
       <CanceledDepartures
@@ -40,28 +45,29 @@ describe('<CanceledDepartures />', () => {
 
   it('splits departures per date and applies the limit per date', () => {
     const container = renderCanceledDepartures();
+
     expect(
       container.querySelectorAll('.badges__departure-group__date-group'),
     ).to.have.lengthOf(2);
-    const times = [...container.querySelectorAll('.routes-m-narrow')].map(n =>
-      n.textContent.trim(),
-    );
-    expect(times).to.deep.equal(['08:00', '09:00']);
+    expect(departureTimes(container)).to.deep.equal(['08:00', '09:00']);
   });
 
   it('shows a button when a date has more departures than the limit', () => {
     const container = renderCanceledDepartures();
-    expect(
-      container.querySelectorAll('.show-departures-button'),
-    ).to.have.lengthOf(1);
+    const showAllButton = container.querySelector('.show-departures-button');
+
+    expect(showAllButton).to.not.equal(null);
+    expect(showAllButton.textContent).to.equal('Show all');
   });
 
   it('shows all departures for the date when the button is clicked', () => {
     const container = renderCanceledDepartures();
+
     fireEvent.click(container.querySelector('.show-departures-button'));
-    const times = [...container.querySelectorAll('.routes-m-narrow')].map(n =>
-      n.textContent.trim(),
-    );
-    expect(times).to.deep.equal(['08:00', '08:05', '09:00']);
+    expect(departureTimes(container)).to.deep.equal([
+      '08:00',
+      '08:05',
+      '09:00',
+    ]);
   });
 });

--- a/test/unit/component/trafficnow/CanceledTripCard.test.js
+++ b/test/unit/component/trafficnow/CanceledTripCard.test.js
@@ -1,19 +1,36 @@
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import React from 'react';
-import { shallow } from 'enzyme';
+import PropTypes from 'prop-types';
 import sinon from 'sinon';
-import {
-  shallowWithIntl,
-  createShallowHookSandbox,
-} from '../../helpers/mock-intl-enzyme';
+import { render, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import * as found from 'found';
+import translations from '../../../../app/translations/en';
+import { ConfigProvider } from '../../../../app/configurations/ConfigContext';
 import { Component as CanceledTripCard } from '../../../../app/component/trafficnow/CanceledTripCard';
-import Card from '../../../../app/component/Card';
-import DisruptionStatus from '../../../../app/component/trafficnow/components/DisruptionStatus';
-import RouteBadgeGroup from '../../../../app/component/trafficnow/components/RouteBadgeGroup';
-import CanceledDepartures from '../../../../app/component/trafficnow/components/CanceledDepartures';
 import * as FiltersContext from '../../../../app/component/trafficnow/filters/FiltersContext';
-import EntityBadge from '../../../../app/component/trafficnow/components/EntityBadge';
+import { mockContext } from '../../helpers/mock-context';
+
+// RouteBadgeGroup is rendered via its `connectToStores`-wrapped default
+// export, which reads `FavouriteStore` off the legacy Fluxible context.
+// Reuse the shared mockContext so the real component tree renders.
+class LegacyFluxibleContext extends React.Component {
+  getChildContext() {
+    return {
+      getStore: name => ({
+        ...mockContext.getStore(name),
+        getFavourites: () => [],
+      }),
+    };
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+LegacyFluxibleContext.childContextTypes = { getStore: PropTypes.func };
+LegacyFluxibleContext.propTypes = { children: PropTypes.node.isRequired };
 
 const makeRouteSummary = ({
   shortName = '21B',
@@ -85,292 +102,259 @@ const baseConfig = {
 };
 
 describe('<CanceledTripCard />', () => {
-  let stubs;
-  let sandbox;
-  let filterContextStub;
+  let router;
 
   beforeEach(() => {
-    ({ sandbox, stubs } = createShallowHookSandbox({ config: baseConfig }));
-    filterContextStub = sandbox.stub(FiltersContext, 'useFilterContext');
-    filterContextStub.returns({
-      selectedFilters: {},
-    });
+    router = { push: sinon.spy() };
+    sinon.stub(found, 'useRouter').returns({ router });
+    sinon
+      .stub(FiltersContext, 'useFilterContext')
+      .returns({ selectedFilters: {} });
   });
-  afterEach(() => sandbox.restore());
+
+  afterEach(() => {
+    found.useRouter.restore();
+    FiltersContext.useFilterContext.restore();
+  });
+
+  const renderCanceledTripCard = (props, config = baseConfig) => {
+    const { container } = render(
+      <IntlProvider locale="en" messages={translations.en}>
+        <ConfigProvider value={config}>
+          <LegacyFluxibleContext>
+            <CanceledTripCard {...baseProps} {...props} />
+          </LegacyFluxibleContext>
+        </ConfigProvider>
+      </IntlProvider>,
+    );
+    return container;
+  };
+
+  const routeBadgeNames = container =>
+    Array.from(
+      container.querySelectorAll(
+        '.badges__headsign-group > .badge-container:not(.more-routes) a, .badges__headsign-group > .badges__headsign-group--route > .badge-container:not(.more-routes) a',
+      ),
+    ).map(a => a.textContent.trim());
+
+  const routeBadgeHrefs = container =>
+    Array.from(
+      container.querySelectorAll(
+        '.badges__headsign-group > .badge-container:not(.more-routes) a, .badges__headsign-group > .badges__headsign-group--route > .badge-container:not(.more-routes) a',
+      ),
+    ).map(a => a.getAttribute('href'));
 
   describe('RouteBadgeGroup props', () => {
     it('maps canceled route summaries to route badges', () => {
-      const wrapper = shallowWithIntl(<CanceledTripCard {...baseProps} />);
-      const badgeGroup = wrapper.find(RouteBadgeGroup);
+      const container = renderCanceledTripCard();
 
-      expect(badgeGroup).to.have.lengthOf(1);
-      expect(badgeGroup.prop('mode')).to.equal('bus');
-      expect(badgeGroup.prop('stopPropagation')).to.equal(true);
-      expect(badgeGroup.prop('routes')).to.deep.equal([
-        {
-          name: '21B',
-          gtfsId: 'HSL:21B',
-          id: 'route-21B',
-          url: '/linjat/HSL%3A21B',
-        },
-      ]);
+      expect(routeBadgeNames(container)).to.deep.equal(['21B']);
+      expect(routeBadgeHrefs(container)).to.deep.equal(['/linjat/HSL%3A21B']);
     });
 
     it('limits the amount of route badges', () => {
-      stubs.useConfigContext.returns({
-        ...baseConfig,
-        trafficNowMaxRoutesPerCard: 3,
-      });
-      const wrapper = shallowWithIntl(
-        <CanceledTripCard {...baseProps} routes={makeRoutes(6)} />,
+      const container = renderCanceledTripCard(
+        { routes: makeRoutes(6) },
+        { ...baseConfig, trafficNowMaxRoutesPerCard: 3 },
       );
-      const routes = wrapper.find(RouteBadgeGroup).prop('routes');
 
-      expect(routes).to.have.lengthOf(3);
-      expect(routes.map(route => route.name)).to.deep.equal(['20', '21', '22']);
+      expect(routeBadgeNames(container)).to.deep.equal(['20', '21', '22']);
     });
 
     it('renders the count of hidden routes when there are more than allowed', () => {
-      stubs.useConfigContext.returns({
-        ...baseConfig,
-        trafficNowMaxRoutesPerCard: 3,
-      });
-      const wrapper = shallowWithIntl(
-        <CanceledTripCard {...baseProps} routes={makeRoutes(6)} />,
+      const container = renderCanceledTripCard(
+        { routes: makeRoutes(6) },
+        { ...baseConfig, trafficNowMaxRoutesPerCard: 3 },
       );
-      const renderSuffix = wrapper.find(RouteBadgeGroup).prop('renderSuffix');
-      const rendered = shallow(<div>{renderSuffix}</div>);
-      const moreRoutes = rendered.find(EntityBadge);
+      const moreRoutes = container.querySelector('.more-routes');
 
-      expect(moreRoutes).to.have.lengthOf(1);
-      expect(moreRoutes.prop('className')).to.equal('more-routes');
-      expect(moreRoutes.prop('entity').name).to.equal('+3');
+      expect(moreRoutes).to.not.equal(null);
+      expect(moreRoutes.textContent.trim()).to.equal('+3');
     });
 
     it('does not render the three-dots icon when all routes are visible', () => {
-      const wrapper = shallowWithIntl(
-        <CanceledTripCard {...baseProps} routes={makeRoutes(5)} />,
-      );
+      const container = renderCanceledTripCard({ routes: makeRoutes(5) });
 
-      expect(wrapper.find(RouteBadgeGroup).prop('renderSuffix')).to.equal(null);
+      expect(container.querySelector('.more-routes')).to.equal(null);
     });
 
     it('renders the departure time when there is only a single route', () => {
-      const wrapper = shallowWithIntl(<CanceledTripCard {...baseProps} />);
-      const badgeGroup = wrapper.find(RouteBadgeGroup);
-      const [route] = badgeGroup.prop('routes');
-      const renderedSuffix = shallow(
-        <div>{badgeGroup.prop('renderRouteSuffix')(route)}</div>,
-      );
+      const container = renderCanceledTripCard();
+      const departureTimes = Array.from(
+        container.querySelectorAll(
+          '.badges__headsign-group--route .badges__departure-time .routes-s-narrow',
+        ),
+      ).map(node => node.textContent.trim());
 
-      expect(
-        renderedSuffix
-          .find(CanceledDepartures)
-          .dive()
-          .find('.routes-m-narrow')
-          .text(),
-      ).to.equal(' 08:00 ');
+      expect(departureTimes).to.deep.equal(['08:00']);
     });
 
     it('renders cancellations from all patterns when there is only a single route', () => {
-      const wrapper = shallowWithIntl(
-        <CanceledTripCard
-          {...baseProps}
-          routes={[
-            makeRouteSummary({
-              patterns: [
-                {
-                  cancellationCount: 1,
-                  pattern: {
-                    code: 'pattern-21B-1',
-                    headsign: 'Kamppi',
-                    stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
-                    canceledTrips: [
-                      {
-                        serviceDate: '2026-01-01',
-                        trip: {
-                          gtfsId: 'trip-21B-1',
-                          stoptimes: [{ scheduledDeparture: 28800 }],
-                        },
+      const container = renderCanceledTripCard({
+        routes: [
+          makeRouteSummary({
+            patterns: [
+              {
+                cancellationCount: 1,
+                pattern: {
+                  code: 'pattern-21B-1',
+                  headsign: 'Kamppi',
+                  stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
+                  canceledTrips: [
+                    {
+                      serviceDate: '2026-01-01',
+                      trip: {
+                        gtfsId: 'trip-21B-1',
+                        stoptimes: [{ scheduledDeparture: 28800 }],
                       },
-                    ],
-                  },
+                    },
+                  ],
                 },
-                {
-                  cancellationCount: 1,
-                  pattern: {
-                    code: 'pattern-21B-2',
-                    headsign: 'Rautatientori',
-                    stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
-                    canceledTrips: [
-                      {
-                        serviceDate: '2026-01-01',
-                        trip: {
-                          gtfsId: 'trip-21B-2',
-                          stoptimes: [{ scheduledDeparture: 29100 }],
-                        },
+              },
+              {
+                cancellationCount: 1,
+                pattern: {
+                  code: 'pattern-21B-2',
+                  headsign: 'Rautatientori',
+                  stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
+                  canceledTrips: [
+                    {
+                      serviceDate: '2026-01-01',
+                      trip: {
+                        gtfsId: 'trip-21B-2',
+                        stoptimes: [{ scheduledDeparture: 29100 }],
                       },
-                    ],
-                  },
+                    },
+                  ],
                 },
-              ],
-            }),
-          ]}
-        />,
-      );
-      const badgeGroup = wrapper.find(RouteBadgeGroup);
-      const [route] = badgeGroup.prop('routes');
-      const renderedSuffix = shallow(
-        <div>{badgeGroup.prop('renderRouteSuffix')(route)}</div>,
-      );
+              },
+            ],
+          }),
+        ],
+      });
+      const departureTimes = Array.from(
+        container.querySelectorAll(
+          '.badges__headsign-group--route .badges__departure-time .routes-s-narrow',
+        ),
+      ).map(node => node.textContent.trim());
 
-      expect(
-        renderedSuffix
-          .find(CanceledDepartures)
-          .dive()
-          .find('.routes-m-narrow')
-          .map(node => node.text()),
-      ).to.deep.equal([' 08:00 ', ' 08:05 ']);
+      expect(departureTimes).to.deep.equal(['08:00', '08:05']);
     });
 
     it('limits inline departures per pattern', () => {
-      const wrapper = shallowWithIntl(
-        <CanceledTripCard
-          {...baseProps}
-          routes={[
-            makeRouteSummary({
-              patterns: [
-                {
-                  cancellationCount: 6,
-                  pattern: {
-                    code: 'pattern-21B-1',
-                    headsign: 'Kamppi',
-                    stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
-                    canceledTrips: makeCanceledTrips({
-                      amount: 6,
-                      gtfsIdPrefix: 'trip-21B-1',
-                    }),
-                  },
+      const container = renderCanceledTripCard({
+        routes: [
+          makeRouteSummary({
+            patterns: [
+              {
+                cancellationCount: 6,
+                pattern: {
+                  code: 'pattern-21B-1',
+                  headsign: 'Kamppi',
+                  stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
+                  canceledTrips: makeCanceledTrips({
+                    amount: 6,
+                    gtfsIdPrefix: 'trip-21B-1',
+                  }),
                 },
-                {
-                  cancellationCount: 6,
-                  pattern: {
-                    code: 'pattern-21B-2',
-                    headsign: 'Rautatientori',
-                    stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
-                    canceledTrips: makeCanceledTrips({
-                      amount: 6,
-                      startTime: 9 * 60 * 60,
-                      gtfsIdPrefix: 'trip-21B-2',
-                    }),
-                  },
+              },
+              {
+                cancellationCount: 6,
+                pattern: {
+                  code: 'pattern-21B-2',
+                  headsign: 'Rautatientori',
+                  stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
+                  canceledTrips: makeCanceledTrips({
+                    amount: 6,
+                    startTime: 9 * 60 * 60,
+                    gtfsIdPrefix: 'trip-21B-2',
+                  }),
                 },
-              ],
-            }),
-          ]}
-        />,
-      );
-      const badgeGroup = wrapper.find(RouteBadgeGroup);
-      const [route] = badgeGroup.prop('routes');
-      const renderedSuffix = shallow(
-        <div>{badgeGroup.prop('renderRouteSuffix')(route)}</div>,
-      );
+              },
+            ],
+          }),
+        ],
+      });
 
       expect(
-        renderedSuffix
-          .find(CanceledDepartures)
-          .dive()
-          .find('.badges__departure-time')
-          .not('.badges__departure-time--show-more'),
+        container.querySelectorAll(
+          '.badges__departure-time:not(.badges__departure-time--show-more)',
+        ),
       ).to.have.lengthOf(10);
     });
 
     it('renders inline hidden departure count per pattern', () => {
-      const wrapper = shallowWithIntl(
-        <CanceledTripCard
-          {...baseProps}
-          routes={[
-            makeRouteSummary({
-              patterns: [
-                {
-                  cancellationCount: 7,
-                  pattern: {
-                    code: 'pattern-21B-1',
-                    headsign: 'Kamppi',
-                    stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
-                    canceledTrips: makeCanceledTrips({
-                      amount: 7,
-                      gtfsIdPrefix: 'trip-21B-1',
-                    }),
-                  },
+      const container = renderCanceledTripCard({
+        routes: [
+          makeRouteSummary({
+            patterns: [
+              {
+                cancellationCount: 7,
+                pattern: {
+                  code: 'pattern-21B-1',
+                  headsign: 'Kamppi',
+                  stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
+                  canceledTrips: makeCanceledTrips({
+                    amount: 7,
+                    gtfsIdPrefix: 'trip-21B-1',
+                  }),
                 },
-                {
-                  cancellationCount: 8,
-                  pattern: {
-                    code: 'pattern-21B-2',
-                    headsign: 'Rautatientori',
-                    stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
-                    canceledTrips: makeCanceledTrips({
-                      amount: 8,
-                      startTime: 9 * 60 * 60,
-                      gtfsIdPrefix: 'trip-21B-2',
-                    }),
-                  },
+              },
+              {
+                cancellationCount: 8,
+                pattern: {
+                  code: 'pattern-21B-2',
+                  headsign: 'Rautatientori',
+                  stops: [{ name: 'Eira' }, { name: 'Kamppi' }],
+                  canceledTrips: makeCanceledTrips({
+                    amount: 8,
+                    startTime: 9 * 60 * 60,
+                    gtfsIdPrefix: 'trip-21B-2',
+                  }),
                 },
-              ],
-            }),
-          ]}
-        />,
-      );
-      const badgeGroup = wrapper.find(RouteBadgeGroup);
-      const [route] = badgeGroup.prop('routes');
-      const renderedSuffix = shallow(
-        <div>{badgeGroup.prop('renderRouteSuffix')(route)}</div>,
-      );
+              },
+            ],
+          }),
+        ],
+      });
+      const hiddenCounts = Array.from(
+        container.querySelectorAll('.badges__departure-time--show-more'),
+      ).map(node => node.textContent.trim());
 
-      expect(
-        renderedSuffix
-          .find(CanceledDepartures)
-          .dive()
-          .find('.badges__departure-time--show-more')
-          .map(node => node.text()),
-      ).to.deep.equal(['+2', '+3']);
+      expect(hiddenCounts).to.deep.equal(['+2', '+3']);
     });
   });
 
   describe('isMobile layout', () => {
     it('renders separator and DisruptionStatus in the header when isMobile=false', () => {
-      const wrapper = shallowWithIntl(
-        <CanceledTripCard {...baseProps} isMobile={false} />,
-      );
+      const container = renderCanceledTripCard({ isMobile: false });
 
-      expect(wrapper.find('.separator.vertical')).to.have.lengthOf(1);
-      expect(wrapper.find('header').find(DisruptionStatus)).to.have.lengthOf(1);
+      expect(
+        container.querySelectorAll('.separator.vertical'),
+      ).to.have.lengthOf(1);
+      expect(container.querySelector('header .disruption-status')).to.not.equal(
+        null,
+      );
     });
 
     it('hides the header separator and moves DisruptionStatus below badges when isMobile=true', () => {
-      const wrapper = shallowWithIntl(
-        <CanceledTripCard {...baseProps} isMobile />,
-      );
+      const container = renderCanceledTripCard({ isMobile: true });
 
-      expect(wrapper.find('.separator.vertical')).to.have.lengthOf(0);
-      expect(wrapper.find('header').find(DisruptionStatus)).to.have.lengthOf(0);
-      expect(wrapper.find(DisruptionStatus)).to.have.lengthOf(1);
+      expect(
+        container.querySelectorAll('.separator.vertical'),
+      ).to.have.lengthOf(0);
+      expect(container.querySelector('header .disruption-status')).to.equal(
+        null,
+      );
+      expect(container.querySelector('.disruption-status')).to.not.equal(null);
     });
   });
 
   describe('Navigation', () => {
     it('navigates to the canceled trips detail view for the mode when the card is clicked', () => {
-      const router = { push: sinon.spy() };
-      const wrapper = shallowWithIntl(<CanceledTripCard {...baseProps} />, {
-        router,
-      });
-      const event = {
-        preventDefault: () => {},
-        stopPropagation: () => {},
-      };
+      const container = renderCanceledTripCard();
 
-      wrapper.find(Card).prop('onClick')(event);
+      fireEvent.click(container.querySelector('.card'));
 
       expect(router.push.calledWith('/liikenne/peruutukset/bus')).to.equal(
         true,

--- a/test/unit/component/trafficnow/DisruptionStatus.test.js
+++ b/test/unit/component/trafficnow/DisruptionStatus.test.js
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import React from 'react';
-import { shallow } from 'enzyme';
-import { createShallowHookSandbox } from '../../helpers/mock-intl-enzyme';
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import translations from '../../../../app/translations/en';
+import { ConfigProvider } from '../../../../app/configurations/ConfigContext';
 import DisruptionStatus from '../../../../app/component/trafficnow/components/DisruptionStatus';
-import Icon from '../../../../app/component/Icon';
 import * as timeUtils from '../../../../app/util/timeUtils';
 
 const baseConfig = {
@@ -21,93 +23,102 @@ describe('<DisruptionStatus />', () => {
   let sandbox;
 
   beforeEach(() => {
-    ({ sandbox } = createShallowHookSandbox({ config: baseConfig }));
+    sandbox = sinon.createSandbox();
     sandbox.stub(Date, 'now').returns(NOW_MS);
   });
 
   afterEach(() => sandbox.restore());
 
+  const renderDisruptionStatus = props => {
+    const { container } = render(
+      <IntlProvider locale="en" messages={translations.en}>
+        <ConfigProvider value={baseConfig}>
+          <DisruptionStatus {...props} />
+        </ConfigProvider>
+      </IntlProvider>,
+    );
+    return container;
+  };
+
+  const iconName = container =>
+    container.querySelector('use')?.getAttribute('xlink:href')?.slice(1);
+
+  const dateSpan = container => container.querySelector('.routes-s');
+
   describe('isValid — timestamp-based', () => {
     it('shows icon_status (active) when now is between start and end', () => {
-      const wrapper = shallow(
-        <DisruptionStatus effectiveStartDate={500} effectiveEndDate={2000} />,
-      );
-      expect(wrapper.find(Icon).prop('img')).to.equal('icon_status');
+      const container = renderDisruptionStatus({
+        effectiveStartDate: 500,
+        effectiveEndDate: 2000,
+      });
+      expect(iconName(container)).to.equal('icon_status');
     });
 
     it('shows icon_calendar (upcoming) when start is in the future', () => {
-      const wrapper = shallow(
-        <DisruptionStatus effectiveStartDate={2000} effectiveEndDate={5000} />,
-      );
-      expect(wrapper.find(Icon).prop('img')).to.equal('icon_calendar');
+      const container = renderDisruptionStatus({
+        effectiveStartDate: 2000,
+        effectiveEndDate: 5000,
+      });
+      expect(iconName(container)).to.equal('icon_calendar');
     });
 
     it('shows icon_calendar (ended) when end is in the past', () => {
-      const wrapper = shallow(
-        <DisruptionStatus effectiveStartDate={100} effectiveEndDate={500} />,
-      );
-      expect(wrapper.find(Icon).prop('img')).to.equal('icon_calendar');
+      const container = renderDisruptionStatus({
+        effectiveStartDate: 100,
+        effectiveEndDate: 500,
+      });
+      expect(iconName(container)).to.equal('icon_calendar');
     });
   });
 
   describe('active prop override', () => {
     it('shows icon_status when active=true regardless of timestamps', () => {
       // Timestamps say upcoming but active overrides
-      const wrapper = shallow(
-        <DisruptionStatus
-          active
-          effectiveStartDate={2000}
-          effectiveEndDate={5000}
-        />,
-      );
-      expect(wrapper.find(Icon).prop('img')).to.equal('icon_status');
+      const container = renderDisruptionStatus({
+        active: true,
+        effectiveStartDate: 2000,
+        effectiveEndDate: 5000,
+      });
+      expect(iconName(container)).to.equal('icon_status');
     });
 
     it('shows icon_calendar when active=false regardless of timestamps', () => {
       // Timestamps say valid but active=false overrides
-      const wrapper = shallow(
-        <DisruptionStatus
-          active={false}
-          effectiveStartDate={500}
-          effectiveEndDate={2000}
-        />,
-      );
-      expect(wrapper.find(Icon).prop('img')).to.equal('icon_calendar');
+      const container = renderDisruptionStatus({
+        active: false,
+        effectiveStartDate: 500,
+        effectiveEndDate: 2000,
+      });
+      expect(iconName(container)).to.equal('icon_calendar');
     });
   });
 
   describe('showDates', () => {
     it('hides the date span when showDates=false', () => {
-      const wrapper = shallow(
-        <DisruptionStatus
-          effectiveStartDate={500}
-          effectiveEndDate={2000}
-          showDates={false}
-        />,
-      );
-      expect(wrapper.find('.routes-s')).to.have.lengthOf(0);
+      const container = renderDisruptionStatus({
+        effectiveStartDate: 500,
+        effectiveEndDate: 2000,
+        showDates: false,
+      });
+      expect(dateSpan(container)).to.equal(null);
     });
 
     it('renders the date span when showDates=true and effectiveStartDate is non-zero', () => {
-      const wrapper = shallow(
-        <DisruptionStatus
-          effectiveStartDate={500}
-          effectiveEndDate={2000}
-          showDates
-        />,
-      );
-      expect(wrapper.find('.routes-s')).to.have.lengthOf(1);
+      const container = renderDisruptionStatus({
+        effectiveStartDate: 500,
+        effectiveEndDate: 2000,
+        showDates: true,
+      });
+      expect(dateSpan(container)).to.not.equal(null);
     });
 
     it('hides the date span when showDates=true but effectiveStartDate is falsy (0)', () => {
-      const wrapper = shallow(
-        <DisruptionStatus
-          effectiveStartDate={0}
-          effectiveEndDate={2000}
-          showDates
-        />,
-      );
-      expect(wrapper.find('.routes-s')).to.have.lengthOf(0);
+      const container = renderDisruptionStatus({
+        effectiveStartDate: 0,
+        effectiveEndDate: 2000,
+        showDates: true,
+      });
+      expect(dateSpan(container)).to.equal(null);
     });
   });
 
@@ -126,32 +137,29 @@ describe('<DisruptionStatus />', () => {
     });
 
     it('shows "startDate - endDate" when start and end are on different dates', () => {
-      const wrapper = shallow(
-        <DisruptionStatus
-          effectiveStartDate={1000}
-          effectiveEndDate={2000}
-          showDates
-        />,
-      );
-      expect(wrapper.find('.routes-s').text()).to.include(' - ');
+      const container = renderDisruptionStatus({
+        effectiveStartDate: 1000,
+        effectiveEndDate: 2000,
+        showDates: true,
+      });
+      expect(dateSpan(container).textContent).to.include(' - ');
     });
 
     it('shows only startDate when start and end fall on the same date', () => {
-      const wrapper = shallow(
-        <DisruptionStatus
-          effectiveStartDate={1000}
-          effectiveEndDate={1000}
-          showDates
-        />,
-      );
-      expect(wrapper.find('.routes-s').text()).to.not.include(' - ');
+      const container = renderDisruptionStatus({
+        effectiveStartDate: 1000,
+        effectiveEndDate: 1000,
+        showDates: true,
+      });
+      expect(dateSpan(container).textContent).to.not.include(' - ');
     });
 
     it('shows only startDate when effectiveEndDate is not provided', () => {
-      const wrapper = shallow(
-        <DisruptionStatus effectiveStartDate={1000} showDates />,
-      );
-      expect(wrapper.find('.routes-s').text()).to.not.include(' - ');
+      const container = renderDisruptionStatus({
+        effectiveStartDate: 1000,
+        showDates: true,
+      });
+      expect(dateSpan(container).textContent).to.not.include(' - ');
     });
   });
 });

--- a/test/unit/component/trafficnow/TrafficNowHeader.test.js
+++ b/test/unit/component/trafficnow/TrafficNowHeader.test.js
@@ -61,6 +61,54 @@ describe('<TrafficNowHeader />', () => {
     });
   });
 
+  describe('Breadcrumb link', () => {
+    it('links to "/" when trafficNowRootPath is not defined', () => {
+      const wrapper = shallow(<TrafficNowHeader />);
+      const breadcrumb = wrapper.find('.traffic-now__header-breadcrumb Link');
+      expect(breadcrumb).to.have.lengthOf(1);
+      expect(breadcrumb.prop('to')).to.equal('/');
+    });
+
+    it('links to ROOTLINK + trafficNowRootPath when defined', () => {
+      stubs.useConfigContext.returns({
+        ...baseConfig,
+        CONFIG: 'hsl',
+        trafficNowRootPath: {
+          fi: '/matkustaminen',
+          sv: '/sv/att-resa',
+          en: '/en/travelling',
+        },
+        URL: { ROOTLINK: 'https://www.hsl.fi' },
+      });
+      const wrapper = shallow(<TrafficNowHeader />);
+      const breadcrumb = wrapper.find('.traffic-now__header-breadcrumb a');
+      expect(breadcrumb).to.have.lengthOf(1);
+      expect(breadcrumb.prop('href')).to.equal(
+        'https://www.hsl.fi/matkustaminen',
+      );
+    });
+
+    it('links using the localized path for the current language', () => {
+      stubs.useConfigContext.returns({
+        ...baseConfig,
+        CONFIG: 'hsl',
+        language: 'sv',
+        trafficNowRootPath: {
+          fi: '/matkustaminen',
+          sv: '/sv/att-resa',
+          en: '/en/travelling',
+        },
+        URL: { ROOTLINK: 'https://www.hsl.fi' },
+      });
+      const wrapper = shallow(<TrafficNowHeader />);
+      const breadcrumb = wrapper.find('.traffic-now__header-breadcrumb a');
+      expect(breadcrumb).to.have.lengthOf(1);
+      expect(breadcrumb.prop('href')).to.equal(
+        'https://www.hsl.fi/sv/att-resa',
+      );
+    });
+  });
+
   describe('HSL-specific AdditionalDescription', () => {
     it('renders AdditionalDescription when CONFIG is hsl', () => {
       stubs.useConfigContext.returns({ ...baseConfig, CONFIG: 'hsl' });

--- a/test/unit/helpers/babel-register.js
+++ b/test/unit/helpers/babel-register.js
@@ -20,6 +20,86 @@ require.extensions['.scss'] = () => {};
 const Module = require('module');
 const React = require('react');
 const PropTypes = require('prop-types');
+// eslint-disable-next-line import/no-commonjs
+const { createElement } = require('react');
+
+// Module._load is invoked on every require() call (it bypasses Node's own
+// require cache for these intercepted requests), so without caching, two
+// files requiring the same @hsl-fi/* package would each get a distinct stub
+// module/component instance. That breaks referential-equality-based Enzyme
+// lookups (e.g. `wrapper.find(Text)`) whenever a test imports the same named
+// export that a component under test also imports. Caching per request
+// ensures every require() of a given package returns the same stub module,
+// and every access to a given named export returns the same stub component.
+const stubModuleCache = new Map();
+
+function createNamedStubModule() {
+  const namedStubs = {};
+  const target = function StubComponent() {
+    return null;
+  };
+  return new Proxy(target, {
+    get(_, prop) {
+      if (prop === '__esModule') {
+        return true;
+      }
+      if (prop === 'default') {
+        return target;
+      }
+      if (typeof prop !== 'string') {
+        return undefined;
+      }
+      if (!namedStubs[prop]) {
+        // Named so Enzyme can match it by displayName / function.name
+        namedStubs[prop] = { [prop]: () => null }[prop];
+      }
+      return namedStubs[prop];
+    },
+  });
+}
+
+// @hsl-fi/layout-primitives' `Text` (and its sibling text-ish exports) is
+// used purely for typography - real usages are asserted on by their actual
+// rendered text content. Rather than stubbing it away to `null`, render it as
+// a plain `div`/`as` tag with its `variant` prop exposed as the className, so
+// tests can use @testing-library/react to find the element by its variant
+// (e.g. `container.querySelector('.routes-s-narrow')`) and read its real
+// text content, instead of introspecting React internals.
+const TEXT_LIKE_EXPORTS = new Set(['Text', 'TextButton', 'TextLink']);
+
+function createLayoutPrimitivesStubModule() {
+  const namedStubs = {};
+  const target = function StubComponent() {
+    return null;
+  };
+  return new Proxy(target, {
+    get(_, prop) {
+      if (prop === '__esModule') {
+        return true;
+      }
+      if (prop === 'default') {
+        return target;
+      }
+      if (typeof prop !== 'string') {
+        return undefined;
+      }
+      if (!namedStubs[prop]) {
+        namedStubs[prop] = TEXT_LIKE_EXPORTS.has(prop)
+          ? {
+              [prop]({ children, as: Tag = 'div', variant, className } = {}) {
+                return createElement(
+                  Tag,
+                  { className: [variant, className].filter(Boolean).join(' ') },
+                  children,
+                );
+              },
+            }[prop]
+          : { [prop]: () => null }[prop];
+      }
+      return namedStubs[prop];
+    },
+  });
+}
 
 const originalLoad = Module._load;
 Module._load = function interceptEsmPackages(request, ...args) {
@@ -71,16 +151,16 @@ Module._load = function interceptEsmPackages(request, ...args) {
   if (request === '@hsl-fi/icons') {
     // Return a Proxy so any named icon export resolves to a stub component.
     // This avoids maintaining an explicit list of every icon exported by the lib.
-    return new Proxy(
-      {},
-      {
-        get(_, name) {
-          // Return a named stub function so Enzyme can match it by .name
-          const stub = { [name]: () => null }[name];
-          return stub;
-        },
-      },
-    );
+    if (!stubModuleCache.has(request)) {
+      stubModuleCache.set(request, createNamedStubModule());
+    }
+    return stubModuleCache.get(request);
+  }
+  if (request === '@hsl-fi/layout-primitives') {
+    if (!stubModuleCache.has(request)) {
+      stubModuleCache.set(request, createLayoutPrimitivesStubModule());
+    }
+    return stubModuleCache.get(request);
   }
   // Fallback: stub any other @hsl-fi/* package generically.
   // Exceptions: CJS packages that can be loaded normally.
@@ -89,24 +169,10 @@ Module._load = function interceptEsmPackages(request, ...args) {
     request !== '@hsl-fi/utilities' &&
     request !== '@hsl-fi/content-delivery-api-types'
   ) {
-    return new Proxy(
-      function StubComponent() {
-        return null;
-      },
-      {
-        get(target, prop) {
-          if (prop === '__esModule') {
-            return true;
-          }
-          if (prop === 'default') {
-            return target;
-          }
-          return function StubComponent() {
-            return null;
-          };
-        },
-      },
-    );
+    if (!stubModuleCache.has(request)) {
+      stubModuleCache.set(request, createNamedStubModule());
+    }
+    return stubModuleCache.get(request);
   }
   return originalLoad.apply(this, [request, ...args]);
 };

--- a/test/unit/helpers/babel-register.js
+++ b/test/unit/helpers/babel-register.js
@@ -149,8 +149,9 @@ Module._load = function interceptEsmPackages(request, ...args) {
     };
   }
   if (request === '@hsl-fi/icons') {
-    // Return a Proxy so any named icon export resolves to a stub component.
-    // This avoids maintaining an explicit list of every icon exported by the lib.
+    // Return a cached Proxy so any named icon export resolves to the same
+    // stub component on every require(). This avoids maintaining an explicit
+    // list of every icon exported by the lib.
     if (!stubModuleCache.has(request)) {
       stubModuleCache.set(request, createNamedStubModule());
     }


### PR DESCRIPTION
## Proposed Changes

  - Adds a configurable link to the breadcrumb on trafficnow page, configured for hsl to link to /matkustaminen, otherwise go to front page
  - Always highlights the traveling section on the header while in reittiopas, this requirement was clarified from hsl
  - Changes margins slightly to make the header spacing identical with hslfi
  - Replaces html with imported `<Text>` and `<Icon>` components from @hsl-fi

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in an issue in Azure Boards
  - Merge the pull request
